### PR TITLE
Fix command parsing ineffassign warning

### DIFF
--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -29,14 +29,13 @@ func main() {
 		os.Exit(-1)
 		return
 	}
-	cmd := "help"
 	if fs.NArg() <= 1 {
 		log.Printf("Please specify an argument, try -help for help")
 		os.Exit(-1)
 		return
-	} else {
-		cmd = fs.Arg(1)
 	}
+
+	cmd := fs.Arg(1)
 	cfg.Args = append(cfg.Args, cmd)
 	switch cmd {
 	case "manifest":


### PR DESCRIPTION
## Summary
- remove unused default command assignment in main command parsing
- keep argument tracking and command dispatch unchanged

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fe790b4a8832fbdd9d5b3ca2b8bd3)