### PR TITLE
fix: Generate integrated site structure for remote repositories

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -2511,9 +2511,8 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	overallSiteData := &g2.SiteData{
-		Title: "Remote Gentoo Repositories",
-	}
+	var allSites []*SiteData
+
 	for _, repo := range repos.Repositories {
 		if len(repo.Sources) == 0 {
 			continue
@@ -2550,41 +2549,12 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			continue
 		}
 
-		// Since user requested a "list of overlays" we should put each repo in a subfolder
-		// generateSite will write into outDir/repo.Name
-		repoOutDir := filepath.Join(outDir, repo.Name)
-		log.Printf("Generating site for repo: %s", repo.Name)
-		if err := generateSite(repoOutDir, []*SiteData{siteData}, recentDuration, recentDurationStr); err != nil {
-			log.Printf("Failed to generate site for repo %s: %v", repo.Name, err)
-		}
-		// Add as a root category simply so we can create an index.html listing the repos
-		overallSiteData.Categories = append(overallSiteData.Categories, g2.CategoryData{
-			Name: repo.Name,
-		})
+		allSites = append(allSites, siteData)
 	}
 
-	// Sort categories (which are now repos in this context)
-	sort.Slice(overallSiteData.Categories, func(i, j int) bool {
-		return overallSiteData.Categories[i].Name < overallSiteData.Categories[j].Name
-	})
-
-	// Generate the root index.html listing the overlays
-	if err := os.MkdirAll(outDir, 0755); err != nil {
-		return err
-	}
-
-	tmpl, err := template.New("").Funcs(getTemplateFuncMap()).ParseFS(siteTemplates, "sitegen_templates/*.html")
-	if err != nil {
-		return fmt.Errorf("parsing templates: %w", err)
-	}
-
-	if err := renderPage(filepath.Join(outDir, "index.html"), tmpl, "index.html", map[string]interface{}{
-		"Title":       overallSiteData.Title,
-		"BaseURL":     "",
-		"Categories":  overallSiteData.Categories,
-		"Breadcrumbs": []g2.Breadcrumb{},
-	}); err != nil {
-		return fmt.Errorf("rendering overall index page: %w", err)
+	log.Printf("Generating integrated site for %d repos", len(allSites))
+	if err := generateSite(outDir, allSites, recentDuration, recentDurationStr); err != nil {
+		return fmt.Errorf("generating integrated site: %w", err)
 	}
 
 	log.Println("Remote site generation complete.")

--- a/ebuild.go
+++ b/ebuild.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"io/fs"
 	"path/filepath"
 	"regexp"

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8J
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
+github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
Fixes `g2 overlays site generate` pathing and multi-repository generation.
Previously it would generate isolated sites inside `<outDir>/<repoName>` rather than building a unified global repository correctly.
This passes the entire array of parsed sites sequentially into `generateSite` after completing clones, creating the unified site successfully.
Removed unused `go-version` import in `ebuild.go` triggering `go build` lints.

---
*PR created automatically by Jules for task [7710741296752036658](https://jules.google.com/task/7710741296752036658) started by @arran4*