### PR TITLE
feat(search): split search result into independent links

### DIFF
--- a/cmd/g2/sitegen_templates/search_ui.js
+++ b/cmd/g2/sitegen_templates/search_ui.js
@@ -56,10 +56,26 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             const title = document.createElement('h3');
             title.style.marginTop = '0';
-            const link = document.createElement('a');
-            link.href = doc.page_url;
-            link.textContent = `${doc.full_name}-${doc.version}`;
-            title.appendChild(link);
+
+            const catLink = document.createElement('a');
+            catLink.href = `../repos/${doc.overlay}/categories/${doc.category}/`;
+            catLink.textContent = doc.category;
+            title.appendChild(catLink);
+
+            title.appendChild(document.createTextNode('/'));
+
+            const pkgLink = document.createElement('a');
+            pkgLink.href = `../repos/${doc.overlay}/categories/${doc.category}/packages/${doc.package}/`;
+            pkgLink.textContent = doc.package;
+            title.appendChild(pkgLink);
+
+            title.appendChild(document.createTextNode('-'));
+
+            const verLink = document.createElement('a');
+            verLink.href = doc.page_url;
+            verLink.textContent = doc.version;
+            title.appendChild(verLink);
+
             resultDiv.appendChild(title);
 
             const meta = document.createElement('p');
@@ -93,7 +109,22 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const uses = document.createElement('p');
                 uses.style.fontSize = '0.8em';
                 uses.style.color = '#888';
-                uses.innerHTML = `<strong>USE:</strong> ${doc.uses.join(' ')}`;
+
+                const usesLabel = document.createElement('strong');
+                usesLabel.textContent = 'USE: ';
+                uses.appendChild(usesLabel);
+
+                doc.uses.forEach((use, index) => {
+                    const useLink = document.createElement('a');
+                    useLink.href = `../uses/${use}/`;
+                    useLink.textContent = use;
+                    uses.appendChild(useLink);
+
+                    if (index < doc.uses.length - 1) {
+                        uses.appendChild(document.createTextNode(' '));
+                    }
+                });
+
                 resultDiv.appendChild(uses);
             }
 


### PR DESCRIPTION
This change addresses user feedback requesting independently clickable links in the search results UI. 

Previously, the entire search result title (e.g., `app-admin/chezmoi-bin-2.70.0`) was a single link to the ebuild version page. The category, package, and version components are now split into three separate links:
- The category links to the category index: `../repos/{overlay}/categories/{category}/`
- The package name links to the package index: `../repos/{overlay}/categories/{category}/packages/{package}/`
- The version string links to the specific ebuild version page as before.

Additionally, the USE flags string has been updated from plain text into individually clickable links pointing to `../uses/{use}/`. 

The changes are contained within the client-side rendering logic in `search_ui.js` using safe DOM manipulation elements rather than raw innerHTML. `search_js_test.js` was used to ensure the logic modifications did not interfere with the search engine parsing or operation.

---
*PR created automatically by Jules for task [162019952471522309](https://jules.google.com/task/162019952471522309) started by @arran4*