### PR TITLE
feat(site): display all local and metadata descriptions on USE flag pages

### DIFF
--- a/cmd/g2/sitegen_templates/repo_use.html
+++ b/cmd/g2/sitegen_templates/repo_use.html
@@ -7,6 +7,29 @@
 </div>
 {{end}}
 
+{{if or .UseFlag.LocalDescs .UseFlag.MetadataDescs}}
+<div class="metadata-section">
+    <h3>Local and Metadata Descriptions</h3>
+    {{if .UseFlag.MetadataDescs}}
+    <h4>Metadata Descriptions (metadata.xml)</h4>
+    <ul>
+        {{range $pkgKey, $desc := .UseFlag.MetadataDescs}}
+        <li><strong>{{$pkgKey}}:</strong> {{$desc}}</li>
+        {{end}}
+    </ul>
+    {{end}}
+
+    {{if .UseFlag.LocalDescs}}
+    <h4>Local Descriptions (use.local.desc)</h4>
+    <ul>
+        {{range $pkgKey, $desc := .UseFlag.LocalDescs}}
+        <li><strong>{{$pkgKey}}:</strong> {{$desc}}</li>
+        {{end}}
+    </ul>
+    {{end}}
+</div>
+{{end}}
+
 {{if .UseFlag.Warnings}}
 <div class="metadata-section" style="border: 1px solid #cc0000; padding: 10px; margin-bottom: 20px;">
     <h3 style="color: #cc0000;">Warnings</h3>

--- a/cmd/g2/sitegen_templates/use.html
+++ b/cmd/g2/sitegen_templates/use.html
@@ -7,6 +7,29 @@
 </div>
 {{end}}
 
+{{if or .UseFlag.LocalDescs .UseFlag.MetadataDescs}}
+<div class="metadata-section">
+    <h3>Local and Metadata Descriptions</h3>
+    {{if .UseFlag.MetadataDescs}}
+    <h4>Metadata Descriptions (metadata.xml)</h4>
+    <ul>
+        {{range $pkgKey, $desc := .UseFlag.MetadataDescs}}
+        <li><strong>{{$pkgKey}}:</strong> {{$desc}}</li>
+        {{end}}
+    </ul>
+    {{end}}
+
+    {{if .UseFlag.LocalDescs}}
+    <h4>Local Descriptions (use.local.desc)</h4>
+    <ul>
+        {{range $pkgKey, $desc := .UseFlag.LocalDescs}}
+        <li><strong>{{$pkgKey}}:</strong> {{$desc}}</li>
+        {{end}}
+    </ul>
+    {{end}}
+</div>
+{{end}}
+
 {{if .UseFlag.Warnings}}
 <div class="metadata-section" style="border: 1px solid #cc0000; padding: 10px; margin-bottom: 20px;">
     <h3 style="color: #cc0000;">Warnings</h3>


### PR DESCRIPTION
Addresses the issue where USE flags that had local descriptions or metadescriptions but were not explicitly defined in an ebuild did not have their descriptions displayed clearly. We now aggregate and render these descriptions at the top of the `use.html` and `repo_use.html` pages, just below the global description and above the warnings.

---
*PR created automatically by Jules for task [668599611947299808](https://jules.google.com/task/668599611947299808) started by @arran4*