### PR TITLE
Fix file name too long error during site license generation

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1468,37 +1468,41 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 
 				for _, ver := range pkg.Versions {
 					if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
-						lic := ver.Ebuild.Vars["LICENSE"]
-						if lic != "" {
-							if _, ok := aggLicenses[lic]; !ok {
-								aggLicenses[lic] = &AggLicense{Name: lic}
-							}
+						licenseStr := ver.Ebuild.Vars["LICENSE"]
+						licenses := g2.ParseLicense(licenseStr)
 
-							found := false
-							for _, p := range aggLicenses[lic].Packages {
-								if p.Name == pkg.Name && p.Category == pkg.Category {
-									found = true
-									break
+						for _, lic := range licenses {
+							if lic != "" {
+								if _, ok := aggLicenses[lic]; !ok {
+									aggLicenses[lic] = &AggLicense{Name: lic}
 								}
-							}
-							if !found {
-								aggLicenses[lic].Packages = append(aggLicenses[lic].Packages, aggPackages[pkgKey])
-								aggLicenses[lic].Count++
-							}
 
-							// Add aliases from this site's license mapping
-							if site.LicenseMapping != nil {
-								if aliases, ok := site.LicenseMapping[lic]; ok {
-									for _, alias := range aliases {
-										hasAlias := false
-										for _, existing := range aggLicenses[lic].Aliases {
-											if existing == alias {
-												hasAlias = true
-												break
+								found := false
+								for _, p := range aggLicenses[lic].Packages {
+									if p.Name == pkg.Name && p.Category == pkg.Category {
+										found = true
+										break
+									}
+								}
+								if !found {
+									aggLicenses[lic].Packages = append(aggLicenses[lic].Packages, aggPackages[pkgKey])
+									aggLicenses[lic].Count++
+								}
+
+								// Add aliases from this site's license mapping
+								if site.LicenseMapping != nil {
+									if aliases, ok := site.LicenseMapping[lic]; ok {
+										for _, alias := range aliases {
+											hasAlias := false
+											for _, existing := range aggLicenses[lic].Aliases {
+												if existing == alias {
+													hasAlias = true
+													break
+												}
 											}
-										}
-										if !hasAlias {
-											aggLicenses[lic].Aliases = append(aggLicenses[lic].Aliases, alias)
+											if !hasAlias {
+												aggLicenses[lic].Aliases = append(aggLicenses[lic].Aliases, alias)
+											}
 										}
 									}
 								}

--- a/ebuild.go
+++ b/ebuild.go
@@ -222,30 +222,195 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 	return e, nil
 }
 
-// ParseLicense extracts individual license names from a LICENSE string,
-// stripping USE-conditional flags, || operators, and parenthesis.
-func ParseLicense(licenseStr string) []string {
-	flags := strings.Fields(licenseStr)
-	var parsed []string
-	for _, flagName := range flags {
-		if flagName == "||" || flagName == "(" || flagName == ")" {
+type DepNode interface {
+	Evaluate(opts ...any) ([]string, error)
+}
+
+type DepString string
+
+func (d DepString) Evaluate(opts ...any) ([]string, error) {
+	return []string{string(d)}, nil
+}
+
+type DepAnyOf struct {
+	Children []DepNode
+}
+
+func (d DepAnyOf) Evaluate(opts ...any) ([]string, error) {
+	var res []string
+	for _, c := range d.Children {
+		vals, err := c.Evaluate(opts...)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, vals...)
+	}
+	return res, nil
+}
+
+type DepAllOf struct {
+	Children []DepNode
+}
+
+func (d DepAllOf) Evaluate(opts ...any) ([]string, error) {
+	var res []string
+	for _, c := range d.Children {
+		vals, err := c.Evaluate(opts...)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, vals...)
+	}
+	return res, nil
+}
+
+type UseFlags []string
+type UseFlag string
+type IgnoreUseFlags bool
+
+type EvaluateConfig struct {
+	UseFlags       map[string]bool
+	IgnoreUseFlags bool
+}
+
+func parseOpts(opts ...any) EvaluateConfig {
+	cfg := EvaluateConfig{
+		UseFlags: make(map[string]bool),
+	}
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case UseFlags:
+			for _, flag := range o {
+				cfg.UseFlags[flag] = true
+			}
+		case UseFlag:
+			cfg.UseFlags[string(o)] = true
+		case IgnoreUseFlags:
+			cfg.IgnoreUseFlags = bool(o)
+		}
+	}
+	return cfg
+}
+
+type DepUseConditional struct {
+	Flag      string
+	IsNegated bool
+	Children  []DepNode
+}
+
+func (d DepUseConditional) Evaluate(opts ...any) ([]string, error) {
+	cfg := parseOpts(opts...)
+
+	include := cfg.IgnoreUseFlags
+	if !cfg.IgnoreUseFlags {
+		hasFlag := cfg.UseFlags[d.Flag]
+		if d.IsNegated {
+			include = !hasFlag
+		} else {
+			include = hasFlag
+		}
+	}
+
+	if !include {
+		return nil, nil
+	}
+
+	var res []string
+	for _, c := range d.Children {
+		vals, err := c.Evaluate(opts...)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, vals...)
+	}
+	return res, nil
+}
+
+func parseDepTokens(tokens []string) ([]DepNode, int) {
+	var nodes []DepNode
+	for i := 0; i < len(tokens); i++ {
+		t := tokens[i]
+		if t == "" {
 			continue
 		}
-		if strings.HasSuffix(flagName, "?") {
-			continue
+		if t == "||" {
+			if i+1 < len(tokens) && tokens[i+1] == "(" {
+				children, advance := parseDepTokens(tokens[i+2:])
+				nodes = append(nodes, DepAnyOf{Children: children})
+				i += advance + 1 // +1 for '('
+			} else {
+				nodes = append(nodes, DepString(t))
+			}
+		} else if strings.HasSuffix(t, "?") {
+			flag := strings.TrimSuffix(t, "?")
+			isNegated := false
+			if strings.HasPrefix(flag, "!") {
+				isNegated = true
+				flag = flag[1:]
+			}
+			if i+1 < len(tokens) && tokens[i+1] == "(" {
+				children, advance := parseDepTokens(tokens[i+2:])
+				nodes = append(nodes, DepUseConditional{
+					Flag:      flag,
+					IsNegated: isNegated,
+					Children:  children,
+				})
+				i += advance + 1
+			} else {
+				nodes = append(nodes, DepString(t))
+			}
+		} else if t == "(" {
+			children, advance := parseDepTokens(tokens[i+1:])
+			nodes = append(nodes, DepAllOf{Children: children})
+			i += advance
+		} else if t == ")" {
+			return nodes, i + 1
+		} else {
+			nodes = append(nodes, DepString(t))
 		}
-		parsed = append(parsed, flagName)
+	}
+	return nodes, len(tokens)
+}
+
+type DepTree struct {
+	Nodes []DepNode
+}
+
+func (d DepTree) Evaluate(opts ...any) ([]string, error) {
+	var res []string
+	for _, n := range d.Nodes {
+		vals, err := n.Evaluate(opts...)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, vals...)
 	}
 
 	unique := make(map[string]bool)
-	var result []string
-	for _, p := range parsed {
-		if !unique[p] {
-			unique[p] = true
-			result = append(result, p)
+	var final []string
+	for _, r := range res {
+		if !unique[r] {
+			unique[r] = true
+			final = append(final, r)
 		}
 	}
-	return result
+	return final, nil
+}
+
+// ParseDepTree parses a dependency string (like DEPEND, RDEPEND, LICENSE)
+// into an AST that can be evaluated with Evaluate().
+func ParseDepTree(s string) DepTree {
+	tokens := strings.Fields(s)
+	nodes, _ := parseDepTokens(tokens)
+	return DepTree{Nodes: nodes}
+}
+
+// ParseLicense extracts individual license names from a LICENSE string,
+// evaluating all conditionals to true to gather all possible licenses.
+func ParseLicense(licenseStr string) []string {
+	tree := ParseDepTree(licenseStr)
+	res, _ := tree.Evaluate(IgnoreUseFlags(true))
+	return res
 }
 
 // ParseIUSE extracts the actual USE flag names from an IUSE string,

--- a/ebuild.go
+++ b/ebuild.go
@@ -222,6 +222,32 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 	return e, nil
 }
 
+// ParseLicense extracts individual license names from a LICENSE string,
+// stripping USE-conditional flags, || operators, and parenthesis.
+func ParseLicense(licenseStr string) []string {
+	flags := strings.Fields(licenseStr)
+	var parsed []string
+	for _, flagName := range flags {
+		if flagName == "||" || flagName == "(" || flagName == ")" {
+			continue
+		}
+		if strings.HasSuffix(flagName, "?") {
+			continue
+		}
+		parsed = append(parsed, flagName)
+	}
+
+	unique := make(map[string]bool)
+	var result []string
+	for _, p := range parsed {
+		if !unique[p] {
+			unique[p] = true
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
 // ParseIUSE extracts the actual USE flag names from an IUSE string,
 // stripping prefixes like + and -.
 func ParseIUSE(iuseStr string) []string {

--- a/ebuild_test.go
+++ b/ebuild_test.go
@@ -287,6 +287,58 @@ func TestParseLicense(t *testing.T) {
 	}
 }
 
+func TestParseDepTree(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		opts     []any
+		expected []string
+	}{
+		{
+			name:     "Evaluate with use flags",
+			input:    "3270? ( BSD ) anonymouspro? ( OFL-1.1 )",
+			opts:     []any{UseFlags([]string{"3270"})},
+			expected: []string{"BSD"},
+		},
+		{
+			name:     "Evaluate multiple with ignore",
+			input:    "|| ( A B ) use? ( C ) !use? ( D )",
+			opts:     []any{IgnoreUseFlags(true)},
+			expected: []string{"A", "B", "C", "D"},
+		},
+		{
+			name:     "Evaluate with negated use flag matched",
+			input:    "|| ( A B ) use? ( C ) !use? ( D )",
+			opts:     []any{UseFlags([]string{"use"})},
+			expected: []string{"A", "B", "C"},
+		},
+		{
+			name:     "Evaluate with negated use flag not matched",
+			input:    "|| ( A B ) use? ( C ) !use? ( D )",
+			opts:     []any{UseFlags([]string{})},
+			expected: []string{"A", "B", "D"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := ParseDepTree(tt.input)
+			result, err := tree.Evaluate(tt.opts...)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if len(result) != len(tt.expected) {
+				t.Fatalf("Evaluate() len = %v, want %v. Got %v", len(result), len(tt.expected), result)
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("Evaluate()[%d] = %v, want %v", i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
 func TestParseIUSE(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/ebuild_test.go
+++ b/ebuild_test.go
@@ -234,6 +234,59 @@ func TestBlackbox(t *testing.T) {
 	}
 }
 
+func TestParseLicense(t *testing.T) {
+	tests := []struct {
+		name     string
+		license  string
+		expected []string
+	}{
+		{
+			name:     "Empty",
+			license:  "",
+			expected: nil,
+		},
+		{
+			name:     "Single license",
+			license:  "GPL-2",
+			expected: []string{"GPL-2"},
+		},
+		{
+			name:     "Multiple licenses",
+			license:  "GPL-2 MIT",
+			expected: []string{"GPL-2", "MIT"},
+		},
+		{
+			name:     "Conditional license",
+			license:  "USE? ( GPL-2 )",
+			expected: []string{"GPL-2"},
+		},
+		{
+			name:     "Conditional and or license",
+			license:  "3270? ( || ( BSD CC-BY-SA-3.0 ) ) anonymouspro? ( OFL-1.1 ) arimo? ( Apache-2.0 )",
+			expected: []string{"BSD", "CC-BY-SA-3.0", "OFL-1.1", "Apache-2.0"},
+		},
+		{
+			name:     "complex",
+			license:  "0BSD Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD-2 BSD CC0-1.0 CDLA-Permissive-2.0 ISC MIT MPL-2.0 Unicode-3.0 Unicode-DFS-2016 ZLIB BZIP2 openssl",
+			expected: []string{"0BSD", "Apache-2.0", "Apache-2.0-with-LLVM-exceptions", "BSD-2", "BSD", "CC0-1.0", "CDLA-Permissive-2.0", "ISC", "MIT", "MPL-2.0", "Unicode-3.0", "Unicode-DFS-2016", "ZLIB", "BZIP2", "openssl"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseLicense(tt.license)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("ParseLicense() len = %v, want %v. Got %v", len(result), len(tt.expected), result)
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("ParseLicense()[%d] = %v, want %v", i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
 func TestParseIUSE(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fixes a bug where complex, conditional `LICENSE` strings in ebuilds caused "file name too long" errors during static site generation. Introduced `ParseLicense` to properly extract individual license names and updated `cmd/g2/site.go` to use the parsed results.

---
*PR created automatically by Jules for task [11816525653875715279](https://jules.google.com/task/11816525653875715279) started by @arran4*