### PR TITLE
Add support for profiles/info_pkgs

### DIFF
--- a/cmd/g2/overlay_info_pkgs.go
+++ b/cmd/g2/overlay_info_pkgs.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/g2"
+)
+
+func (cfg *MainArgConfig) cmdOverlayInfoPkgs(args []string) error {
+	fs := flag.NewFlagSet("overlay info-pkgs", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Printf("Usage: g2 overlay info-pkgs <subcommand>\n")
+		fmt.Printf("\tlist\t\t\tList all info packages in the overlay\n")
+		fmt.Printf("\tadd <atom>\t\tAdd an info package atom to the overlay\n")
+		fmt.Printf("\tremove <atom>\t\tRemove an info package atom from the overlay\n")
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() < 1 {
+		fs.Usage()
+		return fmt.Errorf("missing subcommand")
+	}
+
+	subcmd := fs.Arg(0)
+	switch subcmd {
+	case "list":
+		return cfg.cmdOverlayInfoPkgsList(fs.Args()[1:])
+	case "add":
+		return cfg.cmdOverlayInfoPkgsAdd(fs.Args()[1:])
+	case "remove":
+		return cfg.cmdOverlayInfoPkgsRemove(fs.Args()[1:])
+	default:
+		fs.Usage()
+		return fmt.Errorf("unknown subcommand: %s", subcmd)
+	}
+}
+
+func getInfoPkgsPath() string {
+	return filepath.Join("profiles", "info_pkgs")
+}
+
+func (cfg *MainArgConfig) cmdOverlayInfoPkgsList(args []string) error {
+	pkgs, err := g2.ParseInfoPkgs(getInfoPkgsPath())
+	if err != nil {
+		return fmt.Errorf("parsing info_pkgs: %w", err)
+	}
+
+	for _, p := range pkgs {
+		fmt.Println(p.PackageAtom)
+	}
+	return nil
+}
+
+func (cfg *MainArgConfig) cmdOverlayInfoPkgsAdd(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("missing package atom to add")
+	}
+	atom := args[0]
+
+	path := getInfoPkgsPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating profiles directory: %w", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading info_pkgs: %w", err)
+	}
+
+	if err == nil {
+		// check if it's already there
+		pkgs, err := g2.ParseInfoPkgs(path)
+		if err != nil {
+			return fmt.Errorf("parsing info_pkgs: %w", err)
+		}
+		for _, p := range pkgs {
+			if p.PackageAtom == atom {
+				fmt.Printf("Package %s is already in info_pkgs.\n", atom)
+				return nil
+			}
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("opening info_pkgs file: %w", err)
+	}
+	defer f.Close()
+
+	// Write standard header if it's new/empty
+	if len(content) == 0 {
+		f.WriteString("# Copyright 2004-2025 Gentoo Authors\n")
+		f.WriteString("# Distributed under the terms of the GNU General Public License v2\n")
+		f.WriteString("##\n")
+		f.WriteString("## These ATOMS are printed with a standard 'emerge info' in\n")
+		f.WriteString("## portage as of 2.0.51-r5. Do not overcrowd the output please.\n")
+		f.WriteString("##\n")
+	} else if len(content) > 0 && content[len(content)-1] != '\n' {
+		f.WriteString("\n")
+	}
+
+	f.WriteString(atom + "\n")
+	fmt.Printf("Added %s to info_pkgs.\n", atom)
+	return nil
+}
+
+func (cfg *MainArgConfig) cmdOverlayInfoPkgsRemove(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("missing package atom to remove")
+	}
+	atom := args[0]
+
+	path := getInfoPkgsPath()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("Package %s not found in info_pkgs.\n", atom)
+			return nil
+		}
+		return fmt.Errorf("reading info_pkgs: %w", err)
+	}
+
+	var newContent bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	found := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == atom {
+			found = true
+			continue
+		}
+		newContent.WriteString(line + "\n")
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanning info_pkgs: %w", err)
+	}
+
+	if !found {
+		fmt.Printf("Package %s not found in info_pkgs.\n", atom)
+		return nil
+	}
+
+	if err := os.WriteFile(path, newContent.Bytes(), 0644); err != nil {
+		return fmt.Errorf("writing info_pkgs: %w", err)
+	}
+
+	fmt.Printf("Removed %s from info_pkgs.\n", atom)
+	return nil
+}

--- a/cmd/g2/overlay_info_pkgs.go
+++ b/cmd/g2/overlay_info_pkgs.go
@@ -94,21 +94,21 @@ func (cfg *MainArgConfig) cmdOverlayInfoPkgsAdd(args []string) error {
 	if err != nil {
 		return fmt.Errorf("opening info_pkgs file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Write standard header if it's new/empty
 	if len(content) == 0 {
-		f.WriteString("# Copyright 2004-2025 Gentoo Authors\n")
-		f.WriteString("# Distributed under the terms of the GNU General Public License v2\n")
-		f.WriteString("##\n")
-		f.WriteString("## These ATOMS are printed with a standard 'emerge info' in\n")
-		f.WriteString("## portage as of 2.0.51-r5. Do not overcrowd the output please.\n")
-		f.WriteString("##\n")
+		_, _ = f.WriteString("# Copyright 2004-2025 Gentoo Authors\n")
+		_, _ = f.WriteString("# Distributed under the terms of the GNU General Public License v2\n")
+		_, _ = f.WriteString("##\n")
+		_, _ = f.WriteString("## These ATOMS are printed with a standard 'emerge info' in\n")
+		_, _ = f.WriteString("## portage as of 2.0.51-r5. Do not overcrowd the output please.\n")
+		_, _ = f.WriteString("##\n")
 	} else if len(content) > 0 && content[len(content)-1] != '\n' {
-		f.WriteString("\n")
+		_, _ = f.WriteString("\n")
 	}
 
-	f.WriteString(atom + "\n")
+	_, _ = f.WriteString(atom + "\n")
 	fmt.Printf("Added %s to info_pkgs.\n", atom)
 	return nil
 }

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -113,6 +113,7 @@ type SiteData struct {
 	QAPolicy       *g2.QAPolicy
 	UseDesc        *g2.UseDesc
 	UseLocalDesc   *g2.UseLocalDesc
+	InfoPkgs       []g2.InfoPkg
 	Deprecated     []g2.PackageDeprecated
 	PackageCount   int
 	AggUseFlags    []*AggUseFlag
@@ -174,6 +175,9 @@ type PackageData struct {
 
 	// Deprecation
 	Deprecated *g2.PackageDeprecated
+
+	// InfoPkg matching
+	IsInfoPkg bool
 }
 
 type PkgUseFlag struct {
@@ -206,6 +210,9 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	subcmd := args[0]
 	if subcmd == "ebuild" {
 		return cfg.cmdOverlayEbuild(args[1:])
+	}
+	if subcmd == "info-pkgs" {
+		return cfg.cmdOverlayInfoPkgs(args[1:])
 	}
 	if subcmd != "site" {
 		return fmt.Errorf("unknown overlay subcommand: %s", subcmd)
@@ -524,6 +531,14 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool) (
 		log.Printf("Warning: failed to parse package.deprecated: %v", err)
 	}
 
+	infoPkgsPath := filepath.Join(repoDir, "profiles", "info_pkgs")
+	var infoPkgs []g2.InfoPkg
+	if parsedInfoPkgs, err := g2.ParseInfoPkgsFS(sysFS, filepath.ToSlash(infoPkgsPath)); err == nil {
+		infoPkgs = parsedInfoPkgs
+	} else if !os.IsNotExist(err) {
+		log.Printf("Warning: failed to parse info_pkgs: %v", err)
+	}
+
 	site := &SiteData{
 		Title:          title,
 		RepoName:       repoName,
@@ -535,6 +550,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool) (
 		UseDesc:        useDesc,
 		UseLocalDesc:   useLocalDesc,
 		Deprecated:     deprecated,
+		InfoPkgs:       infoPkgs,
 		PackageCount:   0,
 	}
 
@@ -946,6 +962,22 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool) (
 					Deprecated:   pkgData.Versions[i].Deprecated,
 				})
 			}
+
+			// Add InfoPkg status at the package level
+			for j := range site.InfoPkgs {
+				// We want to exact match the package string (e.g. "app-shells/bash")
+				// with either the full atom or the atom without its slot part (":0").
+				atom := site.InfoPkgs[j].PackageAtom
+				baseAtom := atom
+				if idx := strings.Index(atom, ":"); idx != -1 {
+					baseAtom = atom[:idx]
+				}
+				if baseAtom == pkgStr {
+					pkgData.IsInfoPkg = true
+					break
+				}
+			}
+
 			pkgData.LintWarnings = lints.PerformLinting(repoDir, &g2PkgData)
 
 			catData.Packages = append(catData.Packages, pkgData)
@@ -1858,6 +1890,20 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 				"Title":       site.RepoName + " - Deprecated",
 				"BaseURL":     "../../../",
 				"Breadcrumbs": []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Deprecated Packages"}},
+				"Repo":        site,
+			}); err != nil {
+				return fmt.Errorf("rendering page: %w", err)
+			}
+		}
+
+		if len(site.InfoPkgs) > 0 {
+			if err := os.MkdirAll(filepath.Join(repoDir, "info_pkgs"), 0755); err != nil {
+				return fmt.Errorf("creating directory: %w", err)
+			}
+			if err := renderPage(filepath.Join(repoDir, "info_pkgs", "index.html"), tmpl, "repo_info_pkgs.html", map[string]interface{}{
+				"Title":       site.RepoName + " - Info Packages",
+				"BaseURL":     "../../../",
+				"Breadcrumbs": []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Info Packages"}},
 				"Repo":        site,
 			}); err != nil {
 				return fmt.Errorf("rendering page: %w", err)

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -688,6 +688,28 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			if len(parts) >= 3 {
 				switch parts[2] {
+				case "deprecated":
+					if len(parts) == 3 {
+						s.renderPageHTTP(w, "repo_deprecated.html", map[string]interface{}{
+							"Title":       site.RepoName + " - Deprecated",
+							"BaseURL":     baseURL,
+							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Deprecated Packages"}},
+							"Repo":        site,
+							"Version":     version,
+						})
+						return
+					}
+				case "info_pkgs":
+					if len(parts) == 3 {
+						s.renderPageHTTP(w, "repo_info_pkgs.html", map[string]interface{}{
+							"Title":       site.RepoName + " - Info Packages",
+							"BaseURL":     baseURL,
+							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Info Packages"}},
+							"Repo":        site,
+							"Version":     version,
+						})
+						return
+					}
 				case "categories":
 					if len(parts) == 3 {
 						s.renderPageHTTP(w, "categories.html", map[string]interface{}{

--- a/cmd/g2/sitegen_templates/repo_index.html
+++ b/cmd/g2/sitegen_templates/repo_index.html
@@ -45,6 +45,9 @@
     {{if gt (len .Repo.AggUseFlags) 0}}
     <li><a href="uses/">USE Flags ({{len .Repo.AggUseFlags}})</a></li>
     {{end}}
+    {{if gt (len .Repo.InfoPkgs) 0}}
+    <li><a href="info_pkgs/">Info Packages ({{len .Repo.InfoPkgs}})</a></li>
+    {{end}}
     {{if gt (len .Repo.Deprecated) 0}}
     <li><a href="deprecated/">Deprecated Packages ({{len .Repo.Deprecated}})</a></li>
     {{end}}

--- a/cmd/g2/sitegen_templates/repo_info_pkgs.html
+++ b/cmd/g2/sitegen_templates/repo_info_pkgs.html
@@ -1,0 +1,17 @@
+<h2>Info Packages in {{.Repo.RepoName}}</h2>
+<p>The following packages are marked as informative (printed with standard `emerge info`).</p>
+
+{{if .Repo.InfoPkgs}}
+<table>
+    <tr>
+        <th>Package Atom</th>
+    </tr>
+    {{range .Repo.InfoPkgs}}
+    <tr>
+        <td><code>{{.PackageAtom}}</code></td>
+    </tr>
+    {{end}}
+</table>
+{{else}}
+<p><em>No packages are listed as info packages in this repository.</em></p>
+{{end}}

--- a/cmd/g2/sitegen_templates/repo_package.html
+++ b/cmd/g2/sitegen_templates/repo_package.html
@@ -8,6 +8,13 @@
 </div>
 {{end}}
 
+{{if .Package.IsInfoPkg}}
+<div class="alert alert-info" style="border-color: #17a2b8; background-color: #d1ecf1;">
+    <strong>Notice:</strong> This package has been listed as an informative package.
+    <a href="{{.BaseURL}}repos/{{.Repo.RepoName}}/info_pkgs/">View the full list here</a>.
+</div>
+{{end}}
+
 {{if .MovedToName}}
 <div class="alert alert-warning">
     <strong>Notice:</strong> Older versions of this package were moved to <a href="{{.MovedToURL}}">{{.MovedToName}}</a>.

--- a/info_pkgs.go
+++ b/info_pkgs.go
@@ -1,0 +1,74 @@
+package g2
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+type InfoPkg struct {
+	PackageAtom string
+}
+
+func parseInfoPkgsReader(r io.Reader) ([]InfoPkg, error) {
+	var results []InfoPkg
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		results = append(results, InfoPkg{
+			PackageAtom: line,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading info_pkgs: %w", err)
+	}
+
+	return results, nil
+}
+
+func ParseInfoPkgsFS(sysFS fs.FS, path string) ([]InfoPkg, error) {
+	f, err := sysFS.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return parseInfoPkgsReader(f)
+}
+
+func ParseInfoPkgs(path string) ([]InfoPkg, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return parseInfoPkgsReader(f)
+}
+
+func SerializeInfoPkgs(w io.Writer, pkgs []InfoPkg) error {
+	for i, pkg := range pkgs {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "%s", pkg.PackageAtom); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/info_pkgs_test.go
+++ b/info_pkgs_test.go
@@ -1,0 +1,61 @@
+package g2
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseInfoPkgsReader(t *testing.T) {
+	input := `
+# Copyright 2004-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+##
+## These ATOMS are printed with a standard 'emerge info' in
+## portage as of 2.0.51-r5. Do not overcrowd the output please.
+##
+app-shells/bash:0
+dev-build/autoconf
+
+dev-build/automake
+`
+
+	expected := []InfoPkg{
+		{PackageAtom: "app-shells/bash:0"},
+		{PackageAtom: "dev-build/autoconf"},
+		{PackageAtom: "dev-build/automake"},
+	}
+
+	results, err := parseInfoPkgsReader(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != len(expected) {
+		t.Fatalf("expected %d results, got %d", len(expected), len(results))
+	}
+
+	for i, r := range results {
+		if r.PackageAtom != expected[i].PackageAtom {
+			t.Errorf("result %d: expected %q, got %q", i, expected[i].PackageAtom, r.PackageAtom)
+		}
+	}
+}
+
+func TestSerializeInfoPkgs(t *testing.T) {
+	pkgs := []InfoPkg{
+		{PackageAtom: "app-shells/bash:0"},
+		{PackageAtom: "dev-build/autoconf"},
+		{PackageAtom: "dev-build/automake"},
+	}
+
+	var buf bytes.Buffer
+	if err := SerializeInfoPkgs(&buf, pkgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "app-shells/bash:0\ndev-build/autoconf\ndev-build/automake"
+	if buf.String() != expected {
+		t.Errorf("expected %q, got %q", expected, buf.String())
+	}
+}


### PR DESCRIPTION
Adds functionality for parsing `profiles/info_pkgs`, managing it via a CLI `g2 overlay info-pkgs`, and rendering info notices on generated site pages.

---
*PR created automatically by Jules for task [9118178455568845522](https://jules.google.com/task/9118178455568845522) started by @arran4*