### PR TITLE
Integrate layout.conf constraints into g2 tools and site

### DIFF
--- a/cmd/g2/cache.go
+++ b/cmd/g2/cache.go
@@ -143,6 +143,11 @@ func doCacheVerify(cfs CacheFS, repoDir string) error {
 	hasErrors := false
 
 	for _, format := range cacheFormats {
+		if format != "md5-dict" {
+			log.Printf("Warning: Cache format '%s' is not supported. Only md5-dict is supported.", format)
+			hasErrors = true
+			continue
+		}
 		log.Printf("Verifying cache for format: %s", format)
 
 		for _, cat := range siteData.Categories {
@@ -204,12 +209,12 @@ func doCacheGenerate(cfs CacheFS, repoDir string) error {
 	}
 
 	for _, format := range cacheFormats {
-		log.Printf("Generating cache for format: %s", format)
-
-		// For now, we only fully support md5-dict as a known format for generation.
 		if format != "md5-dict" {
-			log.Printf("Warning: Generation for cache format '%s' might not be fully supported, but we'll generate basic variables.", format)
+			log.Printf("Warning: Cache format '%s' is not supported. Skipping. Only md5-dict is supported.", format)
+			continue
 		}
+
+		log.Printf("Generating cache for format: %s", format)
 
 		for _, cat := range siteData.Categories {
 			for _, pkg := range cat.Packages {

--- a/cmd/g2/layout_conf.go
+++ b/cmd/g2/layout_conf.go
@@ -35,24 +35,37 @@ func (cfg *MainArgConfig) cmdLayoutConf(args []string) error {
 		}
 	}
 
-	subcmd := remainingArgs[0]
+	element := remainingArgs[0]
+
+	if element == "list" {
+		for _, entry := range lc.Entries {
+			for _, comment := range entry.Comments {
+				if comment != "" {
+					fmt.Println(comment)
+				}
+			}
+			fmt.Printf("%s = %s\n", entry.Key, entry.Value)
+		}
+		return nil
+	}
+
+	if len(remainingArgs) < 2 {
+		return fmt.Errorf("missing subcommand for element %s (e.g., get, set, unset)", element)
+	}
+
+	subcmd := remainingArgs[1]
 	switch subcmd {
 	case "get":
-		if len(remainingArgs) < 2 {
-			return fmt.Errorf("missing key to get")
-		}
-		key := remainingArgs[1]
-		val := lc.GetValue(key)
+		val := lc.GetValue(element)
 		if val != "" {
 			fmt.Println(val)
 		}
 	case "set":
 		if len(remainingArgs) < 3 {
-			return fmt.Errorf("missing key or value to set")
+			return fmt.Errorf("missing value to set for %s", element)
 		}
-		key := remainingArgs[1]
 		value := strings.Join(remainingArgs[2:], " ")
-		lc.SetValue(key, value)
+		lc.SetValue(element, value)
 		if err := os.MkdirAll(filepath.Dir(layoutConfPath), 0755); err != nil {
 			return fmt.Errorf("creating metadata dir: %w", err)
 		}
@@ -60,16 +73,12 @@ func (cfg *MainArgConfig) cmdLayoutConf(args []string) error {
 			return fmt.Errorf("writing layout.conf: %w", err)
 		}
 	case "unset":
-		if len(remainingArgs) < 2 {
-			return fmt.Errorf("missing key to unset")
-		}
-		key := remainingArgs[1]
-		lc.UnsetValue(key)
+		lc.UnsetValue(element)
 		if err := g2.WriteLayoutConf(lc, layoutConfPath); err != nil {
 			return fmt.Errorf("writing layout.conf: %w", err)
 		}
 	default:
-		return fmt.Errorf("unknown layout-conf subcommand: %s", subcmd)
+		return fmt.Errorf("unknown action for %s: %s", element, subcmd)
 	}
 
 	return nil

--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -201,12 +201,64 @@ func (cfg *MainArgConfig) cmdManifest(args []string) error {
 	switch cmd {
 	case "upsert-from-url":
 		urlArgs := fs.Args()[1:]
-		if err := config.cmdUpsertFromUrl(urlArgs, getHashes()); err != nil {
+		hashes := getHashes()
+		if len(urlArgs) >= 3 {
+			ebuildDirOrFile := urlArgs[2]
+			dir := filepath.Dir(ebuildDirOrFile)
+			if filepath.Base(ebuildDirOrFile) == "Manifest" {
+				dir = filepath.Dir(ebuildDirOrFile)
+			}
+			repoDir := filepath.Dir(filepath.Dir(dir)) // Assuming category/package
+			layoutConfPath := filepath.Join(repoDir, "metadata", "layout.conf")
+			if lc, err := g2.ParseLayoutConf(layoutConfPath); err == nil {
+				if manifestHashes := lc.GetValuesAsSlice("manifest-hashes"); len(manifestHashes) > 0 {
+					hashes = manifestHashes
+				}
+			}
+		}
+		if err := config.cmdUpsertFromUrl(urlArgs, hashes); err != nil {
 			return fmt.Errorf("upsert file from url: %w", err)
 		}
 	case "verify":
 		verifyArgs := fs.Args()[1:]
-		if err := config.cmdVerify(verifyArgs, getHashes()); err != nil {
+		hashes := getHashes()
+		if len(verifyArgs) > 0 {
+			target := verifyArgs[len(verifyArgs)-1] // Last arg should be target
+			if !strings.HasPrefix(target, "-") {
+				dir := target
+				if !strings.HasSuffix(dir, "/") {
+					// We might be passing a directory or file. Let's make sure we find the repo root properly.
+					if filepath.Base(target) == "Manifest" {
+						dir = filepath.Dir(target)
+					}
+				}
+
+				// Keep going up until we find metadata/layout.conf or hit root
+				currentDir, _ := filepath.Abs(dir)
+				var layoutConfPath string
+				for {
+					candidate := filepath.Join(currentDir, "metadata", "layout.conf")
+					if _, err := os.Stat(candidate); err == nil {
+						layoutConfPath = candidate
+						break
+					}
+					parent := filepath.Dir(currentDir)
+					if parent == currentDir {
+						break // Root reached
+					}
+					currentDir = parent
+				}
+
+				if layoutConfPath != "" {
+					if lc, err := g2.ParseLayoutConf(layoutConfPath); err == nil {
+						if manifestHashes := lc.GetValuesAsSlice("manifest-hashes"); len(manifestHashes) > 0 {
+							hashes = manifestHashes
+						}
+					}
+				}
+			}
+		}
+		if err := config.cmdVerify(verifyArgs, hashes); err != nil {
 			return fmt.Errorf("verify manifest: %w", err)
 		}
 	case "clean":

--- a/cmd/g2/sitegen_templates/repo_index.html
+++ b/cmd/g2/sitegen_templates/repo_index.html
@@ -20,6 +20,24 @@
         {{if .Repo.LayoutConf.GetValue "eapis-deprecated"}}
             <li>EAPIs Deprecated: {{.Repo.LayoutConf.GetValue "eapis-deprecated"}}</li>
         {{end}}
+        {{if .Repo.LayoutConf.GetValue "profile-eapis-banned"}}
+            <li>Profile EAPIs Banned: {{.Repo.LayoutConf.GetValue "profile-eapis-banned"}}</li>
+        {{end}}
+        {{if .Repo.LayoutConf.GetValue "profile-eapis-deprecated"}}
+            <li>Profile EAPIs Deprecated: {{.Repo.LayoutConf.GetValue "profile-eapis-deprecated"}}</li>
+        {{end}}
+        {{if .Repo.LayoutConf.GetValue "restrict-allowed"}}
+            <li>Restrict Allowed: {{.Repo.LayoutConf.GetValue "restrict-allowed"}}</li>
+        {{end}}
+        {{if .Repo.LayoutConf.GetValue "properties-allowed"}}
+            <li>Properties Allowed: {{.Repo.LayoutConf.GetValue "properties-allowed"}}</li>
+        {{end}}
+        {{if .Repo.LayoutConf.GetValue "manifest-hashes"}}
+            <li>Manifest Hashes: {{.Repo.LayoutConf.GetValue "manifest-hashes"}}</li>
+        {{end}}
+        {{if .Repo.LayoutConf.GetValue "manifest-required-hashes"}}
+            <li>Manifest Required Hashes: {{.Repo.LayoutConf.GetValue "manifest-required-hashes"}}</li>
+        {{end}}
     {{end}}
     {{if gt (len .Repo.Categories) 0}}
     <li><a href="categories/">Categories ({{len .Repo.Categories}})</a></li>

--- a/lints/ebuild/layout_conf_rules.go
+++ b/lints/ebuild/layout_conf_rules.go
@@ -1,0 +1,103 @@
+package ebuild
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+func init() {
+	lints.RegisterLintRule(&LayoutConfLintRule{})
+}
+
+type LayoutConfLintRule struct{}
+
+func (r *LayoutConfLintRule) Lint(repoDir string, pkg *g2.PackageData) []string {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *LayoutConfLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []string {
+	var warnings []string
+
+	layoutConfPath := filepath.Join(repoDir, "metadata", "layout.conf")
+	lc, err := g2.ParseLayoutConf(layoutConfPath)
+	if err != nil {
+		// Cannot lint without layout.conf or if it doesn't exist. Assuming valid or not our place to report here.
+		return warnings
+	}
+
+	eapisBanned := append(lc.GetValuesAsSlice("eapis-banned"), lc.GetValuesAsSlice("profile-eapis-banned")...)
+	eapisDeprecated := append(lc.GetValuesAsSlice("eapis-deprecated"), lc.GetValuesAsSlice("profile-eapis-deprecated")...)
+	restrictAllowed := lc.GetValuesAsSlice("restrict-allowed")
+	propertiesAllowed := lc.GetValuesAsSlice("properties-allowed")
+
+	isBanned := func(eapi string, banned []string) bool {
+		for _, b := range banned {
+			if b == eapi {
+				return true
+			}
+		}
+		return false
+	}
+
+	isAllowed := func(val string, allowed []string) bool {
+		if len(allowed) == 0 {
+			return true // If not specified, anything is allowed
+		}
+		for _, a := range allowed {
+			if a == val || val == "" {
+				return true
+			}
+		}
+		return false
+	}
+
+	checkTokens := func(field string, rawValue string, allowed []string) []string {
+		var errs []string
+		tree := g2.ParseDepTree(rawValue)
+		tokens, _ := tree.Evaluate(g2.IgnoreUseFlags(true))
+		for _, token := range tokens {
+			if !isAllowed(token, allowed) {
+				errs = append(errs, fmt.Sprintf("unallowed %s token '%s'", field, token))
+			}
+		}
+		return errs
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			eapi := ver.Ebuild.Vars["EAPI"]
+			if eapi == "" {
+				eapi = "0"
+			}
+
+			if isBanned(eapi, eapisBanned) {
+				warnings = append(warnings, fmt.Sprintf("[Error] Ebuild %s uses banned EAPI '%s'", ver.Version, eapi))
+			} else if isBanned(eapi, eapisDeprecated) {
+				warnings = append(warnings, fmt.Sprintf("[Warning] Ebuild %s uses deprecated EAPI '%s'", ver.Version, eapi))
+			}
+
+			if len(restrictAllowed) > 0 {
+				restrict := ver.Ebuild.Vars["RESTRICT"]
+				if errs := checkTokens("RESTRICT", restrict, restrictAllowed); len(errs) > 0 {
+					for _, e := range errs {
+						warnings = append(warnings, fmt.Sprintf("[Error] Ebuild %s: %s", ver.Version, e))
+					}
+				}
+			}
+
+			if len(propertiesAllowed) > 0 {
+				properties := ver.Ebuild.Vars["PROPERTIES"]
+				if errs := checkTokens("PROPERTIES", properties, propertiesAllowed); len(errs) > 0 {
+					for _, e := range errs {
+						warnings = append(warnings, fmt.Sprintf("[Error] Ebuild %s: %s", ver.Version, e))
+					}
+				}
+			}
+		}
+	}
+
+	return warnings
+}

--- a/lints/metadata/manifest.go
+++ b/lints/metadata/manifest.go
@@ -1,0 +1,74 @@
+package metadata
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+func init() {
+	lints.RegisterLintRule(&ManifestLintRule{})
+}
+
+type ManifestLintRule struct{}
+
+func (r *ManifestLintRule) Lint(repoDir string, pkg *g2.PackageData) []string {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []string {
+	var warnings []string
+
+	layoutConfPath := filepath.Join(repoDir, "metadata", "layout.conf")
+	lc, err := g2.ParseLayoutConf(layoutConfPath)
+	if err != nil {
+		return warnings
+	}
+
+	manifestHashes := lc.GetValuesAsSlice("manifest-hashes")
+	manifestRequiredHashes := lc.GetValuesAsSlice("manifest-required-hashes")
+
+	if len(manifestRequiredHashes) == 0 {
+		return warnings
+	}
+
+	manifestPath := filepath.Join(repoDir, pkg.Category, pkg.Name, "Manifest")
+	manifest, err := g2.ParseManifest(manifestPath)
+	if err != nil {
+		return warnings
+	}
+
+	for _, entry := range manifest.Entries {
+		for _, requiredHash := range manifestRequiredHashes {
+			found := false
+			for _, hash := range entry.Hashes {
+				if hash.Type == requiredHash {
+					found = true
+					break
+				}
+			}
+			if !found {
+				warnings = append(warnings, fmt.Sprintf("[Error] Manifest entry %s is missing required hash '%s'", entry.Filename, requiredHash))
+			}
+		}
+
+		if len(manifestHashes) > 0 {
+			for _, hash := range entry.Hashes {
+				allowed := false
+				for _, allowedHash := range manifestHashes {
+					if hash.Type == allowedHash {
+						allowed = true
+						break
+					}
+				}
+				if !allowed {
+					warnings = append(warnings, fmt.Sprintf("[Warning] Manifest entry %s has unallowed hash '%s'", entry.Filename, hash.Type))
+				}
+			}
+		}
+	}
+
+	return warnings
+}


### PR DESCRIPTION
Integrates Gentoo repository `metadata/layout.conf` configurations deeply into the `g2` toolset. It displays these configurations correctly on the web dashboard template, overhauls the `layout-conf` CLI to use nested element commands, restricts cache mechanisms solely to `md5-dict`, and introduces rigorous linters that evaluate `EAPI`, `RESTRICT`, `PROPERTIES` and `Manifest` hashes against the definitions found in `layout.conf`.

---
*PR created automatically by Jules for task [3721867823936993910](https://jules.google.com/task/3721867823936993910) started by @arran4*