### PR TITLE
fix: Remove duplicate fields in SiteData struct

### DIFF
--- a/cmd/g2/overlay_license.go
+++ b/cmd/g2/overlay_license.go
@@ -101,13 +101,13 @@ func (cfg *MainArgConfig) cmdOverlayLicenseAdd(args []string) error {
 	if err != nil {
 		return fmt.Errorf("opening source file %s: %w", file, err)
 	}
-	defer srcFile.Close()
+	defer func() { _ = srcFile.Close() }()
 
 	destFile, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("creating license file %s: %w", path, err)
 	}
-	defer destFile.Close()
+	defer func() { _ = destFile.Close() }()
 
 	if _, err := io.Copy(destFile, srcFile); err != nil {
 		return fmt.Errorf("copying license content: %w", err)
@@ -173,7 +173,7 @@ func (cfg *MainArgConfig) cmdOverlayLicenseAliasList(args []string) error {
 		}
 		return fmt.Errorf("opening license groups file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	groups, err := g2.ParseLicenseGroups(f)
 	if err != nil {

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1678,22 +1678,6 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 	})
 
 	// Generate Feeds for Repo
-	var repoFeedItems []g2.FeedItem
-	for _, pkg := range allPackages {
-		for _, ver := range pkg.Versions {
-			desc := ""
-			if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
-				desc = ver.Ebuild.Vars["DESCRIPTION"]
-			}
-			repoFeedItems = append(repoFeedItems, g2.FeedItem{
-				Title:       fmt.Sprintf("%s/%s-%s", pkg.Category, pkg.Name, ver.Version),
-				Link:        fmt.Sprintf("packages/%s/", pkg.Name),
-				Description: desc,
-				PubDate:     time.Now().Format(time.RFC1123Z),
-				Updated:     time.Now().Format(time.RFC3339),
-			})
-		}
-	}
 	var recentNews []AggNewsItem
 	cutoffDate := time.Now().AddDate(0, -3, 0)
 	for _, n := range globalNews {

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -119,9 +119,7 @@ type SiteData struct {
 	PackageCount      int
 	AggUseFlags       []*AggUseFlag
 	ThirdPartyMirrors map[string][]string
-	InfoVars       []string
-	PackageCount   int
-	AggUseFlags    []*AggUseFlag
+	InfoVars          []string
 }
 
 type LicenseData struct {

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1501,7 +1501,6 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 	aggMoves := make(map[string]*AggPackageMove)
 	var globalNews []AggNewsItem
 
-	var allPackages []PackageData
 	for _, site := range sites {
 		if site.Projects != nil {
 			for i := range site.Projects.Projects {
@@ -1510,9 +1509,6 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 					aggProjects[proj.Email] = &AggProject{Project: proj}
 				}
 			}
-		}
-		for _, cat := range site.Categories {
-			allPackages = append(allPackages, cat.Packages...)
 		}
 	}
 	totalPackages := 0


### PR DESCRIPTION
Fixed duplicate field redeclaration in `SiteData` struct that caused compilation and lint errors.

---
*PR created automatically by Jules for task [15095325115713239983](https://jules.google.com/task/15095325115713239983) started by @arran4*