### PR TITLE
fix: aggregate USE flags defined only in metadata.xml

### DIFF
--- a/cmd/g2/parse_pkg_uses.go
+++ b/cmd/g2/parse_pkg_uses.go
@@ -31,9 +31,25 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 										MetadataDescs: make(map[string]string),
 									}
 								}
+								// Global logic
+								foundPkgGlobal := false
+								for _, pkgObj := range globalAggUseFlags[flag.Name].Packages {
+									if pkgObj.Name == p.Name && pkgObj.Category == p.Category {
+										foundPkgGlobal = true
+										break
+									}
+								}
+								if !foundPkgGlobal && aggPackages != nil {
+									if ap, ok := aggPackages[pkgKey]; ok {
+										globalAggUseFlags[flag.Name].Packages = append(globalAggUseFlags[flag.Name].Packages, ap)
+										globalAggUseFlags[flag.Name].Count++
+									}
+								}
+
 								if flag.Text != "" {
 									globalAggUseFlags[flag.Name].MetadataDescs[pkgKey] = flag.Text
 								}
+
 								// Repo
 								if _, ok := repoAggUseFlags[flag.Name]; !ok {
 									repoAggUseFlags[flag.Name] = &AggUseFlag{
@@ -42,6 +58,22 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 										MetadataDescs: make(map[string]string),
 									}
 								}
+
+								// Repo logic
+								foundPkgRepo := false
+								for _, pkgObj := range repoAggUseFlags[flag.Name].Packages {
+									if pkgObj.Name == p.Name && pkgObj.Category == p.Category {
+										foundPkgRepo = true
+										break
+									}
+								}
+								if !foundPkgRepo && aggPackages != nil {
+									if ap, ok := aggPackages[pkgKey]; ok {
+										repoAggUseFlags[flag.Name].Packages = append(repoAggUseFlags[flag.Name].Packages, ap)
+										repoAggUseFlags[flag.Name].Count++
+									}
+								}
+
 								if flag.Text != "" {
 									repoAggUseFlags[flag.Name].MetadataDescs[pkgKey] = flag.Text
 								}

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1360,10 +1360,28 @@ func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggU
 			if pkg.Metadata != nil {
 				for _, useBlock := range pkg.Metadata.Use {
 					for _, flag := range useBlock.Flags {
-						if aggFlag, ok := aggUseFlags[flag.Name]; ok {
-							if flag.Text != "" {
-								aggFlag.MetadataDescs[pkgKey] = flag.Text
+						if _, ok := aggUseFlags[flag.Name]; !ok {
+							aggUseFlags[flag.Name] = &AggUseFlag{
+								Name:          flag.Name,
+								LocalDescs:    make(map[string]string),
+								MetadataDescs: make(map[string]string),
 							}
+						}
+
+						foundPkg := false
+						for _, p := range aggUseFlags[flag.Name].Packages {
+							if p.Name == pkg.Name && p.Category == pkg.Category {
+								foundPkg = true
+								break
+							}
+						}
+						if !foundPkg {
+							aggUseFlags[flag.Name].Packages = append(aggUseFlags[flag.Name].Packages, aggPackages[pkgKey])
+							aggUseFlags[flag.Name].Count++
+						}
+
+						if flag.Text != "" {
+							aggUseFlags[flag.Name].MetadataDescs[pkgKey] = flag.Text
 						}
 					}
 				}


### PR DESCRIPTION
Fixes an issue where USE flags with descriptions defined only in a package's `metadata.xml` were not correctly propagated or displayed on the generated `/uses/` and `/repos/<repo>/uses/` pages. The aggregation logic in both `cmd/g2/site.go` and `cmd/g2/parse_pkg_uses.go` has been updated to explicitly instantiate missing flags and correctly link the associated package.

---
*PR created automatically by Jules for task [13506355789739883585](https://jules.google.com/task/13506355789739883585) started by @arran4*