### PR TITLE
Fix `undefined: allPackages` error in cmd/g2/site.go

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1551,7 +1551,6 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 			}
 		}
 	}
-	_ = allPackages
 	totalPackages := 0
 
 	for _, site := range sites {


### PR DESCRIPTION
This commit resolves an issue where the variable `allPackages` was undeclared but assigned to the blank identifier `_` at `cmd/g2/site.go:1554`. The line `_ = allPackages` has been removed.

---
*PR created automatically by Jules for task [16321634372411157408](https://jules.google.com/task/16321634372411157408) started by @arran4*