### PR TITLE
Fallback USE flag descriptions to most common local and metadata descs

### DIFF
--- a/cmd/g2/parse_pkg_uses.go
+++ b/cmd/g2/parse_pkg_uses.go
@@ -307,6 +307,70 @@ func populatePkgUseFlags(site *SiteData) {
 		localDescs = site.UseLocalDesc.Flags
 	}
 
+	// Pre-compute the most common local and metadata descriptions globally per flag.
+	mostCommonLocal := make(map[string]string)
+	mostCommonMetadata := make(map[string]string)
+
+	localCounts := make(map[string]map[string]int)
+	metadataCounts := make(map[string]map[string]int)
+
+	if site.UseLocalDesc != nil {
+		for _, flags := range site.UseLocalDesc.Flags {
+			for flag, desc := range flags {
+				if localCounts[flag] == nil {
+					localCounts[flag] = make(map[string]int)
+				}
+				localCounts[flag][desc]++
+			}
+		}
+	}
+
+	for i := range site.Categories {
+		for j := range site.Categories[i].Packages {
+			pkg := &site.Categories[i].Packages[j]
+			if pkg.Metadata != nil {
+				for _, block := range pkg.Metadata.Use {
+					for _, f := range block.Flags {
+						if f.Text != "" {
+							if metadataCounts[f.Name] == nil {
+								metadataCounts[f.Name] = make(map[string]int)
+							}
+							metadataCounts[f.Name][f.Text]++
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for flag, descCounts := range localCounts {
+		maxCount := 0
+		maxDesc := ""
+		for desc, count := range descCounts {
+			if count > maxCount {
+				maxCount = count
+				maxDesc = desc
+			} else if count == maxCount && desc < maxDesc { // break ties
+				maxDesc = desc
+			}
+		}
+		mostCommonLocal[flag] = maxDesc
+	}
+
+	for flag, descCounts := range metadataCounts {
+		maxCount := 0
+		maxDesc := ""
+		for desc, count := range descCounts {
+			if count > maxCount {
+				maxCount = count
+				maxDesc = desc
+			} else if count == maxCount && desc < maxDesc { // break ties
+				maxDesc = desc
+			}
+		}
+		mostCommonMetadata[flag] = maxDesc
+	}
+
 	for i := range site.Categories {
 		for j := range site.Categories[i].Packages {
 			pkg := &site.Categories[i].Packages[j]
@@ -349,11 +413,14 @@ func populatePkgUseFlags(site *SiteData) {
 			var pkgFlags []PkgUseFlag
 			for name, flag := range flagsMap {
 				desc := ""
+				source := ""
+
 				if pkg.Metadata != nil {
 					for _, block := range pkg.Metadata.Use {
 						for _, f := range block.Flags {
 							if f.Name == name {
 								desc = f.Text
+								source = "metadata.xml"
 								break
 							}
 						}
@@ -364,6 +431,7 @@ func populatePkgUseFlags(site *SiteData) {
 					if localFlags, ok := localDescs[pkgKey]; ok {
 						if ld, ok := localFlags[name]; ok {
 							desc = ld
+							source = "use.local.desc"
 						}
 					}
 				}
@@ -371,10 +439,26 @@ func populatePkgUseFlags(site *SiteData) {
 				if desc == "" {
 					if gd, ok := globalDescs[name]; ok {
 						desc = gd
+						source = "use.desc"
+					}
+				}
+
+				if desc == "" {
+					if mcl, ok := mostCommonLocal[name]; ok && mcl != "" {
+						desc = mcl
+						source = "most common use.local.desc"
+					}
+				}
+
+				if desc == "" {
+					if mcm, ok := mostCommonMetadata[name]; ok && mcm != "" {
+						desc = mcm
+						source = "most common metadata.xml"
 					}
 				}
 
 				flag.Desc = desc
+				flag.Source = source
 
 				for _, ver := range pkg.Versions {
 					vName := ver.Version

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -177,8 +177,9 @@ type PackageData struct {
 }
 
 type PkgUseFlag struct {
-	Name string
-	Desc string
+	Name     string
+	Desc     string
+	Source   string
 	Versions map[string]string // Version -> Unicode symbol representing state
 }
 

--- a/cmd/g2/sitegen_templates/repo_package.html
+++ b/cmd/g2/sitegen_templates/repo_package.html
@@ -140,7 +140,12 @@
         {{range $flag := .Package.PkgUseFlags}}
         <tr>
             <td><a href="../../../../uses/{{$flag.Name}}/">{{$flag.Name}}</a></td>
-            <td>{{$flag.Desc}}</td>
+            <td>
+                {{$flag.Desc}}
+                {{if or (eq $flag.Source "most common use.local.desc") (eq $flag.Source "most common metadata.xml") (eq $flag.Source "")}}
+                <span title="Description not explicitly defined in this package's metadata.xml, use.local.desc, or global use.desc. Source: {{if $flag.Source}}{{$flag.Source}}{{else}}Unknown{{end}}" style="cursor: help;">⚠️</span>
+                {{end}}
+            </td>
             {{range $.Package.Versions}}
             {{$verName := .Version}}{{if .Ebuild.Vars.PV}}{{$verName = .Ebuild.Vars.PV}}{{end}}
             <td style="text-align: center;" title="Status of USE flag '{{$flag.Name}}' for version {{$verName}}">{{index $flag.Versions $verName}}</td>

--- a/testdata/test_overlay/app-misc/foo2/foo2-1.0.ebuild
+++ b/testdata/test_overlay/app-misc/foo2/foo2-1.0.ebuild
@@ -1,0 +1,2 @@
+EAPI=8
+IUSE="bar +baz test-flag"

--- a/testdata/test_overlay/app-misc/foo3/foo3-1.0.ebuild
+++ b/testdata/test_overlay/app-misc/foo3/foo3-1.0.ebuild
@@ -1,0 +1,2 @@
+EAPI=8
+IUSE="bar +baz test-flag2"

--- a/testdata/test_overlay/profiles/use.local.desc
+++ b/testdata/test_overlay/profiles/use.local.desc
@@ -1,0 +1,4 @@
+app-misc/foo test-flag bar
+app-misc/foo test-flag bar2
+app-misc/foo baz bazdesc
+app-misc/foo1 baz bazdesc


### PR DESCRIPTION
This branch updates the site generator to intelligently fallback to the most common USE flag descriptions when local or global descriptions are missing for a given package. It tracks the source of the description and adds a warning indicator in the UI to notify users when a fallback is being shown.

---
*PR created automatically by Jules for task [15995139910819581103](https://jules.google.com/task/15995139910819581103) started by @arran4*