### PR TITLE
Fix missing USE Flags and News links on root dashboard

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1847,11 +1847,13 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 		"Categories":           sortedCategories,
 		"Packages":             sortedPackages,
 		"Licenses":             sortedLicenses,
+		"UseFlags":             sortedUseFlags,
 		"Projects":             sortedProjects,
 		"Profiles":             sortedProfiles,
 		"Version":              version,
 		"RecentDurationString": recentDurationStr,
 		"RecentNews":           recentNews,
+		"GlobalNews":           globalNews,
 	}); err != nil {
 		return fmt.Errorf("rendering page: %w", err)
 	}

--- a/templates/site/dashboard.html
+++ b/templates/site/dashboard.html
@@ -32,6 +32,9 @@
         {{if and .Profiles (gt (len .Profiles) 0)}}
         <li><a href="profiles/">Profiles</a></li>
         {{end}}
+        {{if and .GlobalNews (gt (len .GlobalNews) 0)}}
+        <li><a href="news/">News</a></li>
+        {{end}}
     </ul>
 </div>
 {{if .RecentNews}}

--- a/testdata/test-overlay/metadata/news/2026-03-27-test-news/2026-03-27-test-news.en.txt
+++ b/testdata/test-overlay/metadata/news/2026-03-27-test-news/2026-03-27-test-news.en.txt
@@ -1,0 +1,8 @@
+Title: Test News Item
+Author: Test Author <test@example.com>
+Posted: 2026-03-27
+Revision: 1
+News-Item-Format: 2.0
+Display-If-Installed: sys-apps/testpkg
+
+This is a test news item for verification.

--- a/testdata/test-overlay/profiles/use.desc
+++ b/testdata/test-overlay/profiles/use.desc
@@ -1,0 +1,1 @@
+testflag - A test use flag for verifying functionality

--- a/testdata/test-overlay/sys-apps/testpkg/testpkg-1.0.ebuild
+++ b/testdata/test-overlay/sys-apps/testpkg/testpkg-1.0.ebuild
@@ -1,1 +1,7 @@
-KEYWORDS="~amd64 x86"
+EAPI=8
+DESCRIPTION="A test package"
+HOMEPAGE="https://example.com"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="testflag"


### PR DESCRIPTION
Fixes a bug where generated USE Flags and News pages didn't have corresponding links dynamically added to the site's main root dashboard.

---
*PR created automatically by Jules for task [11577562224481917327](https://jules.google.com/task/11577562224481917327) started by @arran4*