### PR TITLE
fix: display USE flags link on global dashboard

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1847,6 +1847,7 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 		"Categories":           sortedCategories,
 		"Packages":             sortedPackages,
 		"Licenses":             sortedLicenses,
+		"UseFlags":             sortedUseFlags,
 		"Projects":             sortedProjects,
 		"Profiles":             sortedProfiles,
 		"Version":              version,


### PR DESCRIPTION
The `dashboard.html` template contains logic to display a link to the global `USE Flags` section alongside Categories, Packages, Licenses, etc.:

```html
{{if and .UseFlags (gt (len .UseFlags) 0)}}
<li><a href="uses/">USE Flags ({{len .UseFlags}})</a></li>
{{end}}
```

While the local web server (`site_serve.go`) passed this variable, the static site generator (`cmd/g2/site.go`) did not, so the link was never appearing on the static Gentoo Packages main page (`index.html`).

This patch ensures `UseFlags` is passed to the root `dashboard.html` template.

---
*PR created automatically by Jules for task [9560172177683638050](https://jules.google.com/task/9560172177683638050) started by @arran4*