### PR TITLE
Hide email in repository details by linking to source

### DIFF
--- a/cmd/g2/search_index.go
+++ b/cmd/g2/search_index.go
@@ -332,10 +332,7 @@ func generateSearchIndex(outDir string, sites []*SiteData) error {
 		}
 	}
 
-	tmpl, err := template.New("").Funcs(template.FuncMap{
-		"join": strings.Join,
-		"parseIUSEFlags": parseIUSEFlagsFunc,
-	}).ParseFS(templates.SiteFS, "site/*.html")
+	tmpl, err := template.New("").Funcs(getTemplateFuncMap()).ParseFS(templates.SiteFS, "site/*.html")
 	if err != nil {
 		return fmt.Errorf("parsing search templates: %w", err)
 	}

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -2,12 +2,24 @@ package main
 
 import (
 	"html/template"
+	"net/url"
 	"strings"
 )
 
 func getTemplateFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"join":           strings.Join,
-		"parseIUSEFlags": parseIUSEFlagsFunc,
+		"join":                strings.Join,
+		"parseIUSEFlags":      parseIUSEFlagsFunc,
+		"buildOwnerEmailLink": buildOwnerEmailLinkFunc,
 	}
+}
+
+func buildOwnerEmailLinkFunc(remoteURL, email string) string {
+	if strings.Contains(remoteURL, "github.com") || strings.Contains(remoteURL, "gitlab.com") {
+		return remoteURL + "/search?q=" + url.QueryEscape(email)
+	}
+	if remoteURL != "" {
+		return remoteURL
+	}
+	return ""
 }

--- a/templates/site/repo_index.html
+++ b/templates/site/repo_index.html
@@ -36,7 +36,14 @@
                 <td>
                     <ul>
                         {{range .Repo.Repository.Owners}}
-                        <li>{{if .Name}}{{.Name}}{{else}}Unknown{{end}} {{if .Email}}({{.Email}}){{end}} {{if .Type}}[{{.Type}}]{{end}}</li>
+                        <li>{{if .Name}}{{.Name}}{{else}}Unknown{{end}} {{if .Email}}
+                            {{$link := buildOwnerEmailLink $.Repo.RemoteURL .Email}}
+                            {{if $link}}
+                                (<a href="{{$link}}">Email hidden</a>)
+                            {{else}}
+                                (Email hidden)
+                            {{end}}
+                        {{end}} {{if .Type}}[{{.Type}}]{{end}}</li>
                         {{end}}
                     </ul>
                 </td>


### PR DESCRIPTION
Hide email in repository details by linking to source

Addresses the issue of displaying raw email addresses in the repository
details page. This commit introduces a new template function,
`buildOwnerEmailLink`, which attempts to construct a search URL to find
the email within the repository's source code if it's hosted on GitHub
or GitLab. If the remote URL is not from a known host, it gracefully
falls back to linking to the root remote URL. The `repo_index.html`
template has been updated to use this function, obscuring the email
address behind a hyperlink.

Additionally, `search_index.go` was updated to properly use the centralized
`getTemplateFuncMap()` to prevent template parsing panics when the newly
added `buildOwnerEmailLink` function is referenced.

---
*PR created automatically by Jules for task [11671804921756946246](https://jules.google.com/task/11671804921756946246) started by @arran4*