### PR TITLE
feat: add expandable section for raw ebuild as fallback

### DIFF
--- a/ebuild.go
+++ b/ebuild.go
@@ -41,10 +41,11 @@ func (m ParsingMode) String() string {
 }
 
 type Ebuild struct {
-	Path   string
-	Vars   map[string]string
-	SrcUri []URIEntry
-	Mode   ParsingMode
+	Path    string
+	Vars    map[string]string
+	SrcUri  []URIEntry
+	Mode    ParsingMode
+	RawText string
 }
 
 const ebuildTemplate = `{{- range .Vars -}}
@@ -180,6 +181,7 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 		return nil, fmt.Errorf("reading file %s: %w", path, err)
 	}
 	content := string(contentBytes)
+	e.RawText = content
 
 	if mode >= ParseVariables {
 		// Use the recursive descent parser

--- a/ebuild.go
+++ b/ebuild.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/arran4/g2/templates"
 )
 
 type URIEntry struct {
@@ -47,18 +49,6 @@ type Ebuild struct {
 	Mode    ParsingMode
 	RawText string
 }
-
-const ebuildTemplate = `{{- range .Vars -}}
-{{ .Key }}="{{ .Value }}"
-{{ end -}}
-{{- if .SrcUri -}}
-SRC_URI="
-{{- range .SrcUri }}
-	{{ .URL }}{{ if .Filename }} -> {{ .Filename }}{{ end }}
-{{- end }}
-"
-{{ end -}}
-`
 
 type varEntry struct {
 	Key   string
@@ -149,7 +139,7 @@ func (e *Ebuild) String() string {
 		}
 	}
 
-	tmpl := template.Must(template.New("ebuild").Parse(ebuildTemplate))
+	tmpl := template.Must(template.ParseFS(templates.EbuildFS, "ebuild/generate.tmpl"))
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
 		// Should not happen with valid data

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,7 @@
+1. Add `templates/ebuild/generate.tmpl`. Wait, maybe name it `generate.tmpl` but `templates/embed.go` only embeds `*.ebuild`. Oh, wait! I can just embed `ebuild/*.tmpl` or `ebuild/*` if I want to embed `generate.tmpl`. Alternatively, since the other files are `*.ebuild` skeletons, maybe `generate.tmpl` is fine and I just need to modify `templates/embed.go`.
+Let's see: `//go:embed ebuild/*.ebuild ebuild/*.tmpl`.
+Or maybe just rename the template `string_output.tmpl` or `generate.tmpl`.
+Let's call it `generate.tmpl`.
+2. Update `templates/embed.go` to include `//go:embed ebuild/*.tmpl`.
+3. Update `ebuild.go` to parse `templates.EbuildFS` and the `generate.tmpl` file.
+Let's do this to resolve the PR comment.

--- a/plan.md
+++ b/plan.md
@@ -1,7 +1,0 @@
-1. Add `templates/ebuild/generate.tmpl`. Wait, maybe name it `generate.tmpl` but `templates/embed.go` only embeds `*.ebuild`. Oh, wait! I can just embed `ebuild/*.tmpl` or `ebuild/*` if I want to embed `generate.tmpl`. Alternatively, since the other files are `*.ebuild` skeletons, maybe `generate.tmpl` is fine and I just need to modify `templates/embed.go`.
-Let's see: `//go:embed ebuild/*.ebuild ebuild/*.tmpl`.
-Or maybe just rename the template `string_output.tmpl` or `generate.tmpl`.
-Let's call it `generate.tmpl`.
-2. Update `templates/embed.go` to include `//go:embed ebuild/*.tmpl`.
-3. Update `ebuild.go` to parse `templates.EbuildFS` and the `generate.tmpl` file.
-Let's do this to resolve the PR comment.

--- a/templates/ebuild/generate.tmpl
+++ b/templates/ebuild/generate.tmpl
@@ -1,0 +1,10 @@
+{{- range .Vars -}}
+{{ .Key }}="{{ .Value }}"
+{{ end -}}
+{{- if .SrcUri -}}
+SRC_URI="
+{{- range .SrcUri }}
+	{{ .URL }}{{ if .Filename }} -> {{ .Filename }}{{ end }}
+{{- end }}
+"
+{{ end -}}

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed ebuild/*.ebuild
+//go:embed ebuild/*.ebuild ebuild/*.tmpl
 var EbuildFS embed.FS
 
 //go:embed site/*.html site/*.xml site/*.js

--- a/templates/site/ebuild_details.html
+++ b/templates/site/ebuild_details.html
@@ -50,6 +50,15 @@
     </table>
 </div>
 
+{{if not .VersionData.EbuildRawURL}}
+<div class="metadata-section">
+    <details>
+        <summary style="cursor: pointer;"><strong>View Raw Ebuild</strong></summary>
+        <pre style="background: #f4f4f4; padding: 10px; overflow-x: auto;">{{.VersionData.Ebuild.RawText}}</pre>
+    </details>
+</div>
+{{end}}
+
 <style>
     .iuse-flag { display: inline-block; margin-right: 15px; font-family: monospace; }
     .iuse-tooltip { position: relative; display: inline-block; cursor: help; }


### PR DESCRIPTION
Adds an expandable "View Raw Ebuild" section to the package ebuild details page as a fallback for when an external Git raw link is not available.

---
*PR created automatically by Jules for task [12752291482168696510](https://jules.google.com/task/12752291482168696510) started by @arran4*