### PR TITLE
Fix invalid license characters breaking URLs and add linting rules

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -521,6 +521,16 @@ func resolveDependencies(node g2.DepNode, site *SiteData) ResolvedDepNode {
 	return ResolvedDepNode{}
 }
 
+// isValidLicense checks if a license string contains at least one alphanumeric character
+func isValidLicense(s string) bool {
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			return true
+		}
+	}
+	return false
+}
+
 // sanitizeFilename restricts a string to characters safe for file and directory names
 // and limits its length to prevent "file name too long" errors.
 func sanitizeFilename(s string) string {
@@ -534,7 +544,12 @@ func sanitizeFilename(s string) string {
 			log.Printf("Warning: name %q contains null bytes, stripping them", s)
 			continue
 		}
-		sb.WriteRune(r)
+		// Replace characters that are invalid or problematic in file names and URLs
+		if r == '/' || r == '\\' || r == ':' || r == '*' || r == '?' || r == '"' || r == '<' || r == '>' || r == '|' || r == ' ' {
+			sb.WriteRune('_')
+		} else {
+			sb.WriteRune(r)
+		}
 	}
 	res := sb.String()
 	if res != s {
@@ -1669,6 +1684,10 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 
 						for _, lic := range licenses {
 							if lic != "" {
+								if !isValidLicense(lic) {
+									log.Printf("Warning: Invalid license skipped: %q in package %s", lic, pkgKey)
+									continue
+								}
 								if _, ok := aggLicenses[lic]; !ok {
 									aggLicenses[lic] = &AggLicense{Name: lic}
 								}

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -229,6 +229,10 @@ func newSiteServer(sites []*SiteData) (*SiteServer, error) {
 					if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
 						lic := ver.Ebuild.Vars["LICENSE"]
 						if lic != "" {
+							if !isValidLicense(lic) {
+								log.Printf("Warning: Invalid license skipped: %q in package %s", lic, pkgKey)
+								continue
+							}
 							if _, ok := aggLicenses[lic]; !ok {
 								aggLicenses[lic] = &AggLicense{Name: lic}
 							}
@@ -522,9 +526,15 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		} else if len(parts) == 2 {
-			licName := parts[1]
-			lic, ok := s.LicMap[licName]
-			if !ok {
+			licNameSlug := parts[1]
+			var lic *AggLicense
+			for _, l := range s.AggLicenses {
+				if sanitizeFilename(l.Name) == licNameSlug {
+					lic = l
+					break
+				}
+			}
+			if lic == nil {
 				http.NotFound(w, r)
 				return
 			}

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -11,6 +11,7 @@ func getTemplateFuncMap() template.FuncMap {
 		"join":                strings.Join,
 		"parseIUSEFlags":      parseIUSEFlagsFunc,
 		"buildOwnerEmailLink": buildOwnerEmailLinkFunc,
+		"slugify":             sanitizeFilename,
 	}
 }
 

--- a/lints/ebuild/license_sanity.go
+++ b/lints/ebuild/license_sanity.go
@@ -70,6 +70,22 @@ func (r *LicenseSanityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, 
 					}
 				}
 
+				for _, lic := range parsedLicenses {
+					hasAlphanumeric := false
+					for _, r := range lic {
+						if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+							hasAlphanumeric = true
+							break
+						}
+					}
+
+					if !hasAlphanumeric {
+						warnings = append(warnings, fmt.Sprintf("[%s] Ebuild %s has a LICENSE '%s' without valid characters.", severity, ver.Version, lic))
+					} else if strings.Contains(lic, "/") {
+						warnings = append(warnings, fmt.Sprintf("[%s] Ebuild %s has a LICENSE '%s' containing a slash, which may break URLs.", severity, ver.Version, lic))
+					}
+				}
+
 				if isFullText {
 					warnings = append(warnings, fmt.Sprintf("[%s] Ebuild %s has a LICENSE variable that looks like a full-text license rather than a license identifier.", severity, ver.Version))
 				}

--- a/lints/ebuild/license_sanity_test.go
+++ b/lints/ebuild/license_sanity_test.go
@@ -44,6 +44,16 @@ func TestLicenseSanityLintRule(t *testing.T) {
 			licenseStr: "Some, license, with, lots, of, commas",
 			expectWarn: true,
 		},
+		{
+			name:       "Invalid characters only",
+			licenseStr: "//",
+			expectWarn: true,
+		},
+		{
+			name:       "Contains slash",
+			licenseStr: "GPL/2",
+			expectWarn: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/templates/site/ebuild_details.html
+++ b/templates/site/ebuild_details.html
@@ -27,7 +27,7 @@
         {{end}}
         {{if .VersionData.Ebuild.Vars.LICENSE}}
         <dt><strong>License:</strong></dt>
-        <dd>{{if and .VersionData.Ebuild.Vars.LICENSE (index $.ValidLicenses .VersionData.Ebuild.Vars.LICENSE)}}<a href="../../../../../../licenses/{{.VersionData.Ebuild.Vars.LICENSE}}/">{{.VersionData.Ebuild.Vars.LICENSE}}</a>{{else}}{{.VersionData.Ebuild.Vars.LICENSE}}{{end}}</dd>
+        <dd>{{if and .VersionData.Ebuild.Vars.LICENSE (index $.ValidLicenses .VersionData.Ebuild.Vars.LICENSE)}}<a href="../../../../../../licenses/{{slugify .VersionData.Ebuild.Vars.LICENSE}}/">{{.VersionData.Ebuild.Vars.LICENSE}}</a>{{else}}{{.VersionData.Ebuild.Vars.LICENSE}}{{end}}</dd>
         {{end}}
     </dl>
 </div>

--- a/templates/site/index.html
+++ b/templates/site/index.html
@@ -28,6 +28,6 @@
 <h2>Licenses</h2>
 <ul>
     {{range .Licenses}}
-    <li><a href="licenses/{{.Name}}/packages/">{{.Name}} ({{.Count}})</a></li>
+    <li><a href="licenses/{{slugify .Name}}/packages/">{{.Name}} ({{.Count}})</a></li>
     {{end}}
 </ul>

--- a/templates/site/licenses.html
+++ b/templates/site/licenses.html
@@ -3,7 +3,7 @@
 <ul>
     {{range .Licenses}}
     <li>
-        <a href="{{.Name}}/">{{.Name}}</a> ({{.Count}} packages)
+        <a href="{{slugify .Name}}/">{{.Name}}</a> ({{.Count}} packages)
         {{if .Aliases}}
         <br><small>Aliases: {{join .Aliases ", "}}</small>
         {{end}}

--- a/templates/site/repo_package.html
+++ b/templates/site/repo_package.html
@@ -34,7 +34,7 @@
         {{end}}
         {{if .Package.DominantLicense}}
         <dt><strong>License:</strong></dt>
-        <dd>{{if and .Package.DominantLicense (index $.ValidLicenses .Package.DominantLicense)}}<a href="../../../../../../licenses/{{.Package.DominantLicense}}/">{{.Package.DominantLicense}}</a>{{else}}{{.Package.DominantLicense}}{{end}}</dd>
+        <dd>{{if and .Package.DominantLicense (index $.ValidLicenses .Package.DominantLicense)}}<a href="../../../../../../licenses/{{slugify .Package.DominantLicense}}/">{{.Package.DominantLicense}}</a>{{else}}{{.Package.DominantLicense}}{{end}}</dd>
         {{end}}
     </dl>
 </div>


### PR DESCRIPTION
Fixes an issue where invalid characters in licenses (e.g., `//`) break generated directory structures and URLs. Invalid licenses without alphanumeric characters are now completely ignored during site generation. Valid licenses with problematic characters like `/` are slugified in URLs and correctly resolved by the `site_serve` server routing. Lint rules were also added to detect invalid licenses and licenses containing slashes.

---
*PR created automatically by Jules for task [17836314225158078852](https://jules.google.com/task/17836314225158078852) started by @arran4*