### PR TITLE
fix: hide empty Stable and Testing labels in templates

### DIFF
--- a/templates/site/category.html
+++ b/templates/site/category.html
@@ -33,7 +33,7 @@
             {{else}}
                 <a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{.Name}}/">{{.Name}}</a> (ambiguous, available in {{len .ReposList}} overlays)
             {{end}}
-            - Ebuilds: {{.EbuildCount}}, Stable: {{.HighestStableVersion}}, Testing: {{.HighestTestingVersion}}
+            - Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{.HighestStableVersion}}{{end}}{{if .HighestTestingVersion}}, Testing: {{.HighestTestingVersion}}{{end}}
             <span class="package-details">
             {{if .DominantDescription}}<br/><small><b>Description:</b> {{.DominantDescription}}</small>{{end}}
             {{if .DominantHomepage}}<br/><small><b>Homepage:</b> <a href="{{.DominantHomepage}}">{{.DominantHomepage}}</a></small>{{end}}

--- a/templates/site/repo_packages.html
+++ b/templates/site/repo_packages.html
@@ -4,7 +4,7 @@
     {{range .Packages}}
     <li>
         <a href="../categories/{{.Category}}/packages/{{.Name}}/">{{.Category}}/{{.Name}}</a>
-        - Ebuilds: {{.EbuildCount}}, Stable: {{.HighestStableVersion}}, Testing: {{.HighestTestingVersion}}
+        - Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{.HighestStableVersion}}{{end}}{{if .HighestTestingVersion}}, Testing: {{.HighestTestingVersion}}{{end}}
     </li>
     {{end}}
 </ul>


### PR DESCRIPTION
Fixes the issue where empty Stable and Testing versions display awkwardly in the package lists.

---
*PR created automatically by Jules for task [8453365156082284675](https://jules.google.com/task/8453365156082284675) started by @arran4*