### PR TITLE
Add context-aware search widgets to site pages

### DIFF
--- a/templates/site/category.html
+++ b/templates/site/category.html
@@ -1,6 +1,14 @@
 
 <h2>Category: {{.Category.Name}}</h2>
 
+<div class="metadata-section">
+    <h3>Search</h3>
+    <form action="{{.BaseURL}}search/" method="get">
+        <input type="text" name="q" value="category:{{.Category.Name}} " placeholder="Search packages, descriptions, use flags..." style="width: 80%; padding: 0.5rem;" />
+        <button type="submit" style="padding: 0.5rem;">Search</button>
+    </form>
+</div>
+
 <button id="toggle-view-btn" style="float: right; margin-bottom: 1em;">Compact View</button>
 <style>
     ul.short-mode .package-details {

--- a/templates/site/ebuild_details.html
+++ b/templates/site/ebuild_details.html
@@ -1,5 +1,13 @@
 <h2><a href="../../../">{{.Package.Category}}</a>/<a href="../../">{{.Package.Name}}</a> - {{.VersionData.Version}} (<a href="../../../../../../">{{.Repo.RepoName}}</a>)</h2>
 
+<div class="metadata-section">
+    <h3>Search</h3>
+    <form action="{{.BaseURL}}search/" method="get">
+        <input type="text" name="q" value="overlay:{{.Repo.RepoName}} category:{{.Package.Category}} {{.Package.Name}} " placeholder="Search packages, descriptions, use flags..." style="width: 80%; padding: 0.5rem;" />
+        <button type="submit" style="padding: 0.5rem;">Search</button>
+    </form>
+</div>
+
 {{if .VersionData.Deprecated}}
 <div class="alert alert-danger" style="border-color: #ff4c4c; background-color: #ffe6e6;">
     <strong>Deprecated:</strong> This version is deprecated.

--- a/templates/site/license.html
+++ b/templates/site/license.html
@@ -1,5 +1,14 @@
 
 <h2>License: {{.License.Name}}</h2>
+
+<div class="metadata-section">
+    <h3>Search</h3>
+    <form action="{{.BaseURL}}search/" method="get">
+        <input type="text" name="q" value="license:{{.License.Name}} " placeholder="Search packages, descriptions, use flags..." style="width: 80%; padding: 0.5rem;" />
+        <button type="submit" style="padding: 0.5rem;">Search</button>
+    </form>
+</div>
+
 {{if .License.Aliases}}
 <p><strong>Aliases:</strong> {{join .License.Aliases ", "}}</p>
 {{end}}

--- a/templates/site/repo_index.html
+++ b/templates/site/repo_index.html
@@ -1,6 +1,13 @@
 
 <h2>Repository: {{.Repo.RepoName}}</h2>
 <div class="metadata-section">
+    <h3>Search</h3>
+    <form action="{{.BaseURL}}search/" method="get">
+        <input type="text" name="q" value="overlay:{{.Repo.RepoName}} " placeholder="Search packages, descriptions, use flags..." style="width: 80%; padding: 0.5rem;" />
+        <button type="submit" style="padding: 0.5rem;">Search</button>
+    </form>
+</div>
+<div class="metadata-section">
     <p>To use this repository, you can enable it via eselect:</p>
     <pre><code>eselect repository enable {{.Repo.RepoName}}</code></pre>
     <p>And sync it:</p>

--- a/templates/site/repo_package.html
+++ b/templates/site/repo_package.html
@@ -1,5 +1,13 @@
 <h2><a href="../../">{{.Package.Category}}</a>/<a href="">{{.Package.Name}}</a> (<a href="../../../../">{{.Repo.RepoName}}</a>)</h2>
 
+<div class="metadata-section">
+    <h3>Search</h3>
+    <form action="{{.BaseURL}}search/" method="get">
+        <input type="text" name="q" value="overlay:{{.Repo.RepoName}} category:{{.Package.Category}} {{.Package.Name}} " placeholder="Search packages, descriptions, use flags..." style="width: 80%; padding: 0.5rem;" />
+        <button type="submit" style="padding: 0.5rem;">Search</button>
+    </form>
+</div>
+
 {{if .Package.Deprecated}}
 <div class="alert alert-danger" style="border-color: #ff4c4c; background-color: #ffe6e6;">
     <strong>Deprecated:</strong> This package is deprecated.

--- a/templates/site/repo_use.html
+++ b/templates/site/repo_use.html
@@ -1,5 +1,13 @@
 <h2>USE Flag: {{.UseFlag.Name}}</h2>
 
+<div class="metadata-section">
+    <h3>Search</h3>
+    <form action="{{.BaseURL}}search/" method="get">
+        <input type="text" name="q" value="overlay:{{.Repo.RepoName}} use:{{.UseFlag.Name}} " placeholder="Search packages, descriptions, use flags..." style="width: 80%; padding: 0.5rem;" />
+        <button type="submit" style="padding: 0.5rem;">Search</button>
+    </form>
+</div>
+
 {{if .UseFlag.GlobalDesc}}
 <div class="metadata-section">
     <h3>Global Description</h3>

--- a/templates/site/use.html
+++ b/templates/site/use.html
@@ -1,5 +1,13 @@
 <h2>USE Flag: {{.UseFlag.Name}}</h2>
 
+<div class="metadata-section">
+    <h3>Search</h3>
+    <form action="{{.BaseURL}}search/" method="get">
+        <input type="text" name="q" value="use:{{.UseFlag.Name}} " placeholder="Search packages, descriptions, use flags..." style="width: 80%; padding: 0.5rem;" />
+        <button type="submit" style="padding: 0.5rem;">Search</button>
+    </form>
+</div>
+
 {{if .UseFlag.GlobalDesc}}
 <div class="metadata-section">
     <h3>Global Description</h3>


### PR DESCRIPTION
Added context-aware search widgets to various pages with prepopulated filters (e.g. `repo:arrans-overlay`). Supported `repo:` filter alongside `overlay:`.

---
*PR created automatically by Jules for task [5443653245707939806](https://jules.google.com/task/5443653245707939806) started by @arran4*