### PR TITLE
Implement scoring to rank exact search matches higher

### DIFF
--- a/cmd/g2/testdata/search_js_test.js
+++ b/cmd/g2/testdata/search_js_test.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const assert = require('assert');
 const vm = require('vm');
 
-const parserCode = fs.readFileSync('cmd/g2/sitegen_templates/search_parser.js', 'utf8');
-const engineCode = fs.readFileSync('cmd/g2/sitegen_templates/search.js', 'utf8');
+const parserCode = fs.readFileSync('templates/site/search_parser.js', 'utf8');
+const engineCode = fs.readFileSync('templates/site/search.js', 'utf8');
 
 vm.runInThisContext(parserCode);
 vm.runInThisContext(engineCode);

--- a/templates/site/search.js
+++ b/templates/site/search.js
@@ -30,9 +30,17 @@ class SearchEngine {
         // Match against all documents
         const results = this.documents.filter(doc => this.matchDoc(doc, ast));
 
-        // Rank results: simpler version, sort by length of full name to favor exact matches,
-        // then by version string descending. (Or use VersionSortKey if we implement it client-side)
+        const terms = this.getTerms(ast);
+        results.forEach(doc => {
+            doc._score = this.scoreDoc(doc, terms);
+        });
+
+        // Rank results: score descending, then by full name alphabetical,
+        // then by version string descending.
         results.sort((a, b) => {
+            if (a._score !== b._score) {
+                return b._score - a._score;
+            }
             if (a.full_name !== b.full_name) {
                 return a.full_name.localeCompare(b.full_name);
             }
@@ -40,6 +48,53 @@ class SearchEngine {
         });
 
         return results;
+    }
+
+    getTerms(ast) {
+        if (!ast) return [];
+        switch(ast.type) {
+            case 'OR':
+            case 'AND':
+                return this.getTerms(ast.left).concat(this.getTerms(ast.right));
+            case 'NOT':
+                return [];
+            case 'GROUP':
+                return this.getTerms(ast.expr);
+            case 'TERM':
+                return [ast.value.toLowerCase()];
+            case 'FIELD':
+                if (ast.field === 'category' || ast.field === 'overlay' || ast.field === 'arch' || ast.field === 'license' || ast.field === 'keyword') {
+                    return [];
+                }
+                return [ast.value.toLowerCase()];
+            case 'SEQUENCE':
+                return [ast.value.toLowerCase()];
+            default:
+                return [];
+        }
+    }
+
+    escapeRegExp(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    scoreDoc(doc, terms) {
+        let score = 0;
+        const search_text = doc.search_text || "";
+        const full_name = (doc.full_name || "").toLowerCase();
+        for (const term of terms) {
+            if (!term) continue;
+            if (full_name === term || full_name.endsWith("/" + term)) {
+                score += 100;
+            } else if (full_name.includes(term)) {
+                score += 50;
+            } else if (new RegExp(`\\b${this.escapeRegExp(term)}\\b`, 'i').test(search_text)) {
+                score += 10;
+            } else if (search_text.includes(term)) {
+                score += 1;
+            }
+        }
+        return score;
     }
 
     matchDoc(doc, ast) {


### PR DESCRIPTION
This commit solves the issue where prefix, infix, and suffix substring matches (such as "fastest") were being ranked equivalently to exact keyword matches (such as "test") in the client-side search UI.

It introduces a query scoring logic `scoreDoc` that assigns weights:
- +100 for exact package name match
- +50 for partial package name match
- +10 for exact word boundary match in search text
- +1 for partial substring match in search text

This ensures optimal ranking without completely filtering out substrings, while using version descending as a tie breaker.

---
*PR created automatically by Jules for task [973860145610778093](https://jules.google.com/task/973860145610778093) started by @arran4*