### PR TITLE
feat(site): parse and link virtual package dependencies

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -3,9 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"flag"
-	"encoding/json"
 	"fmt"
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints"
@@ -89,26 +89,26 @@ type ProfileData struct {
 }
 
 type SiteData struct {
-	Title          string
-	RepoName       string
-	RemoteURL      string
-	Repository     *g2.Repository
-	EAPI           string
-	Projects       *g2.Projects
-	Categories     []CategoryData
-	Profiles       []ProfileData
-	Authors        []g2.Author
-	AuthorsURL     string
-	Moves          []g2.PackageMove
-	SlotMoves      []g2.PackageSlotMove
-	News           []g2.NewsItem
-	LayoutConf     *g2.LayoutConf
-	LicenseMapping map[string][]string
-	QAPolicy       *g2.QAPolicy
-	UseDesc        *g2.UseDesc
-	UseLocalDesc   *g2.UseLocalDesc
-	InfoPkgs       []g2.InfoPkg
-	Deprecated     []g2.PackageDeprecated
+	Title             string
+	RepoName          string
+	RemoteURL         string
+	Repository        *g2.Repository
+	EAPI              string
+	Projects          *g2.Projects
+	Categories        []CategoryData
+	Profiles          []ProfileData
+	Authors           []g2.Author
+	AuthorsURL        string
+	Moves             []g2.PackageMove
+	SlotMoves         []g2.PackageSlotMove
+	News              []g2.NewsItem
+	LayoutConf        *g2.LayoutConf
+	LicenseMapping    map[string][]string
+	QAPolicy          *g2.QAPolicy
+	UseDesc           *g2.UseDesc
+	UseLocalDesc      *g2.UseLocalDesc
+	InfoPkgs          []g2.InfoPkg
+	Deprecated        []g2.PackageDeprecated
 	PackageCount      int
 	AggUseFlags       []*AggUseFlag
 	ThirdPartyMirrors map[string][]string
@@ -145,14 +145,14 @@ type ManifestEntryData struct {
 }
 
 type PackageData struct {
-	Name          string
-	Category      string
-	Versions      []VersionData
-	Metadata      *g2.PkgMetadata
-	MetadataError error
-	Manifest      *g2.Manifest
-	ManifestData  []ManifestEntryData
-	Files         []FileData
+	Name                  string
+	Category              string
+	Versions              []VersionData
+	Metadata              *g2.PkgMetadata
+	MetadataError         error
+	Manifest              *g2.Manifest
+	ManifestData          []ManifestEntryData
+	Files                 []FileData
 	HighestStableVersion  template.HTML
 	HighestTestingVersion template.HTML
 	EbuildCount           int
@@ -175,6 +175,9 @@ type PackageData struct {
 
 	// InfoPkg matching
 	IsInfoPkg bool
+
+	ReverseVirtuals []string
+	VirtualDeps     []string
 }
 
 type PkgUseFlag struct {
@@ -215,10 +218,10 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	}
 	if subcmd == "license" {
 		return cfg.cmdOverlayLicense(args[1:])
-  }
+	}
 	if subcmd == "info-vars" {
 		return cfg.cmdOverlayInfoVars(args[1:])
-  }
+	}
 	if subcmd == "info-pkgs" {
 		return cfg.cmdOverlayInfoPkgs(args[1:])
 	}
@@ -376,8 +379,6 @@ func parseManifestFromFS(sysFS fs.FS, path string) (*g2.Manifest, error) {
 	return g2.ParseManifestFromReader(file)
 }
 
-
-
 func getHighestVersionsAndCount(versions []VersionData) (template.HTML, template.HTML, int) {
 	// Parse KEYWORDS and group versions
 
@@ -433,11 +434,11 @@ func getHighestVersionsAndCount(versions []VersionData) (template.HTML, template
 
 		// Sort descending
 		for i := 0; i < len(sortedVersions); i++ {
-		    for j := i+1; j < len(sortedVersions); j++ {
-		        if g2.CompareVersions(sortedVersions[i], sortedVersions[j]) < 0 {
-		            sortedVersions[i], sortedVersions[j] = sortedVersions[j], sortedVersions[i]
-		        }
-		    }
+			for j := i + 1; j < len(sortedVersions); j++ {
+				if g2.CompareVersions(sortedVersions[i], sortedVersions[j]) < 0 {
+					sortedVersions[i], sortedVersions[j] = sortedVersions[j], sortedVersions[i]
+				}
+			}
 		}
 
 		var parts []string
@@ -446,13 +447,13 @@ func getHighestVersionsAndCount(versions []VersionData) (template.HTML, template
 
 			// sort archs
 			for i := 0; i < len(archs); i++ {
-			    for j := i+1; j < len(archs); j++ {
-			        if archs[i] > archs[j] {
-			            archs[i], archs[j] = archs[j], archs[i]
-			        }
-			    }
+				for j := i + 1; j < len(archs); j++ {
+					if archs[i] > archs[j] {
+						archs[i], archs[j] = archs[j], archs[i]
+					}
+				}
 			}
-			parts = append(parts, "<span title=\"" + strings.Join(archs, " ") + "\">" + ver + "</span>")
+			parts = append(parts, "<span title=\""+strings.Join(archs, " ")+"\">"+ver+"</span>")
 		}
 
 		return strings.Join(parts, ", ")
@@ -462,12 +463,12 @@ func getHighestVersionsAndCount(versions []VersionData) (template.HTML, template
 }
 
 type ResolvedDepNode struct {
-	Type       string            `json:"type"`
-	Name       string            `json:"name,omitempty"`
-	Link       string            `json:"link,omitempty"`
-	Flag       string            `json:"flag,omitempty"`
-	IsNegated  bool              `json:"is_negated,omitempty"`
-	Children   []ResolvedDepNode `json:"children,omitempty"`
+	Type      string            `json:"type"`
+	Name      string            `json:"name,omitempty"`
+	Link      string            `json:"link,omitempty"`
+	Flag      string            `json:"flag,omitempty"`
+	IsNegated bool              `json:"is_negated,omitempty"`
+	Children  []ResolvedDepNode `json:"children,omitempty"`
 }
 
 func resolveDependencies(node g2.DepNode, site *SiteData) ResolvedDepNode {
@@ -480,7 +481,7 @@ func resolveDependencies(node g2.DepNode, site *SiteData) ResolvedDepNode {
 		if pkgName != "" {
 			for i := range site.Categories {
 				for j := range site.Categories[i].Packages {
-					if site.Categories[i].Packages[j].Category + "/" + site.Categories[i].Packages[j].Name == pkgName {
+					if site.Categories[i].Packages[j].Category+"/"+site.Categories[i].Packages[j].Name == pkgName {
 						link = "../../../../../../categories/" + site.Categories[i].Packages[j].Category + "/packages/" + site.Categories[i].Packages[j].Name + "/"
 					}
 				}
@@ -636,7 +637,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		if uld, err := g2.ParseUseLocalDesc(f); err == nil {
 			useLocalDesc = uld
 		}
-  }
+	}
 	packageDeprecatedPath := filepath.Join(repoDir, "profiles", "package.deprecated")
 	var deprecated []g2.PackageDeprecated
 	if parsedDeprecated, err := g2.ParsePackageDeprecatedFS(sysFS, filepath.ToSlash(packageDeprecatedPath)); err == nil {
@@ -650,14 +651,14 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		thirdPartyMirrors = tm
 	} else if !os.IsNotExist(err) {
 		log.Printf("Warning: failed to parse thirdpartymirrors: %v", err)
-  }
+	}
 	infoVarsPath := filepath.Join(repoDir, "profiles", "info_vars")
 	var infoVars []string
 	if parsedInfoVars, err := g2.ParseInfoVarsFS(sysFS, filepath.ToSlash(infoVarsPath)); err == nil {
 		infoVars = parsedInfoVars
 	} else if !os.IsNotExist(err) {
 		log.Printf("Warning: failed to parse info_vars: %v", err)
-  }
+	}
 	infoPkgsPath := filepath.Join(repoDir, "profiles", "info_pkgs")
 	var infoPkgs []g2.InfoPkg
 	if parsedInfoPkgs, err := g2.ParseInfoPkgsFS(sysFS, filepath.ToSlash(infoPkgsPath)); err == nil {
@@ -667,21 +668,21 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 	}
 
 	site := &SiteData{
-		Title:          title,
-		RepoName:       repoName,
-		RemoteURL:      remoteURL,
-		Repository:     repoInfo,
-		EAPI:           eapi,
-		LayoutConf:     lc,
-		LicenseMapping: licenseGroups,
-		QAPolicy:       qa,
-		UseDesc:        useDesc,
-		UseLocalDesc:   useLocalDesc,
+		Title:             title,
+		RepoName:          repoName,
+		RemoteURL:         remoteURL,
+		Repository:        repoInfo,
+		EAPI:              eapi,
+		LayoutConf:        lc,
+		LicenseMapping:    licenseGroups,
+		QAPolicy:          qa,
+		UseDesc:           useDesc,
+		UseLocalDesc:      useLocalDesc,
 		ThirdPartyMirrors: thirdPartyMirrors,
-		Deprecated:     deprecated,
-		InfoVars:       infoVars,
-		InfoPkgs:       infoPkgs,
-		PackageCount:   0,
+		Deprecated:        deprecated,
+		InfoVars:          infoVars,
+		InfoPkgs:          infoPkgs,
+		PackageCount:      0,
 	}
 
 	// Calculate PackageCount correctly after parsing all categories
@@ -800,7 +801,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 			continue
 		}
 
-		if len(supportedCategories) > 0 && !supportedCategories[name] {
+		if len(supportedCategories) > 0 && !supportedCategories[name] && name != "virtual" {
 			continue
 		}
 
@@ -953,12 +954,12 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 				targetEbuild = highestMasked
 			}
 			if targetEbuild == nil && len(pkgData.Versions) > 0 {
-			    for _, v := range pkgData.Versions {
-			        if v.Ebuild != nil && v.Ebuild.Vars != nil {
-			            targetEbuild = v.Ebuild
-			            break
-			        }
-			    }
+				for _, v := range pkgData.Versions {
+					if v.Ebuild != nil && v.Ebuild.Vars != nil {
+						targetEbuild = v.Ebuild
+						break
+					}
+				}
 			}
 
 			if pkgData.Metadata != nil && len(pkgData.Metadata.LongDescription) > 0 {
@@ -1097,7 +1098,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 
 		if len(catData.Packages) > 0 {
 			// TODO: Make a lint rule
-			if len(supportedCategories) > 0 && !supportedCategories[name] {
+			if len(supportedCategories) > 0 && !supportedCategories[name] && name != "virtual" {
 				log.Printf("Warning: category '%s' is not listed in repo's profiles/categories", name)
 			}
 			mainCats := fetchMainGentooCategories()
@@ -1118,7 +1119,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		return site.Categories[i].Name < site.Categories[j].Name
 	})
 
-		// Finalize ResolvedDepsJSON for each version
+	// Finalize ResolvedDepsJSON for each version
 	for i := range site.Categories {
 		for j := range site.Categories[i].Packages {
 			for k := range site.Categories[i].Packages[j].Versions {
@@ -1146,9 +1147,80 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		}
 	}
 
+	extractVirtualDeps(site)
 	return site, nil
 }
 
+func extractVirtualDeps(site *SiteData) {
+	for i := range site.Categories {
+		if site.Categories[i].Name != "virtual" {
+			continue
+		}
+		for j := range site.Categories[i].Packages {
+			pkg := &site.Categories[i].Packages[j]
+			depsMap := make(map[string]bool)
+			for _, ver := range pkg.Versions {
+				if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+					types := []string{"DEPEND", "RDEPEND", "PDEPEND"}
+					for _, depType := range types {
+						depStr := ver.Ebuild.Vars[depType]
+						if depStr != "" {
+							tree := g2.ParseDepTree(depStr)
+							extractDepNodes(tree.Nodes, depsMap)
+						}
+					}
+				}
+			}
+			for dep := range depsMap {
+				pkg.VirtualDeps = append(pkg.VirtualDeps, dep)
+				depParts := strings.Split(dep, "/")
+				if len(depParts) == 2 {
+					depCat := depParts[0]
+					depName := depParts[1]
+					for k := range site.Categories {
+						if site.Categories[k].Name == depCat {
+							for l := range site.Categories[k].Packages {
+								if site.Categories[k].Packages[l].Name == depName {
+									targetPkg := &site.Categories[k].Packages[l]
+									virtualName := pkg.Category + "/" + pkg.Name
+									found := false
+									for _, v := range targetPkg.ReverseVirtuals {
+										if v == virtualName {
+											found = true
+											break
+										}
+									}
+									if !found {
+										targetPkg.ReverseVirtuals = append(targetPkg.ReverseVirtuals, virtualName)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			sort.Strings(pkg.VirtualDeps)
+		}
+	}
+}
+
+func extractDepNodes(nodes []g2.DepNode, depsMap map[string]bool) {
+	for _, node := range nodes {
+		switch n := node.(type) {
+		case g2.DepString:
+			pkgName := g2.ExtractPackageNameFromDep(string(n))
+			if pkgName != "" {
+				depsMap[pkgName] = true
+			}
+		case g2.DepAnyOf:
+			extractDepNodes(n.Children, depsMap)
+		case g2.DepAllOf:
+			extractDepNodes(n.Children, depsMap)
+		case g2.DepUseConditional:
+			extractDepNodes(n.Children, depsMap)
+		}
+	}
+}
 func buildManifestData(manifest *g2.Manifest, versions []VersionData, thirdPartyMirrors map[string][]string) []ManifestEntryData {
 	var manifestData []ManifestEntryData
 	for _, entry := range manifest.Entries {
@@ -1346,6 +1418,8 @@ type AggPackage struct {
 	DominantDescription string
 	DominantHomepage    string
 	DominantLicense     string
+	ReverseVirtuals     []string
+	VirtualDeps         []string
 }
 type AggProject struct {
 	Project  *g2.Project
@@ -1361,13 +1435,13 @@ type AggLicense struct {
 }
 
 type AggUseFlag struct {
-	Name             string
-	Count            int
-	GlobalDesc       string
-	LocalDescs       map[string]string
-	MetadataDescs    map[string]string
-	Packages         []*AggPackage
-	Warnings         []string
+	Name          string
+	Count         int
+	GlobalDesc    string
+	LocalDescs    map[string]string
+	MetadataDescs map[string]string
+	Packages      []*AggPackage
+	Warnings      []string
 }
 
 func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggUseFlag {
@@ -1498,9 +1572,9 @@ func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggU
 	var sortedUseFlags []*AggUseFlag
 	for _, flag := range aggUseFlags {
 		for _, pkg := range flag.Packages {
-		    if pkg == nil {
-		        continue
-		    }
+			if pkg == nil {
+				continue
+			}
 			pkgKey := pkg.Category + "/" + pkg.Name
 			hasLocal := flag.LocalDescs[pkgKey] != ""
 			hasMetadata := flag.MetadataDescs[pkgKey] != ""
@@ -1659,6 +1733,33 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 					aggPackages[pkgKey].DominantLicense = pkg.DominantLicense
 				}
 				aggCategories[cat.Name].Packages[pkg.Name] = aggPackages[pkgKey]
+				for _, rev := range pkg.ReverseVirtuals {
+					found := false
+					for _, existingRev := range aggPackages[pkgKey].ReverseVirtuals {
+						if existingRev == rev {
+							found = true
+							break
+						}
+					}
+					if !found {
+						aggPackages[pkgKey].ReverseVirtuals = append(aggPackages[pkgKey].ReverseVirtuals, rev)
+					}
+				}
+				sort.Strings(aggPackages[pkgKey].ReverseVirtuals)
+
+				for _, dep := range pkg.VirtualDeps {
+					found := false
+					for _, existingDep := range aggPackages[pkgKey].VirtualDeps {
+						if existingDep == dep {
+							found = true
+							break
+						}
+					}
+					if !found {
+						aggPackages[pkgKey].VirtualDeps = append(aggPackages[pkgKey].VirtualDeps, dep)
+					}
+				}
+				sort.Strings(aggPackages[pkgKey].VirtualDeps)
 
 				if pkg.Metadata != nil {
 					for _, maint := range pkg.Metadata.Maintainers {
@@ -1988,7 +2089,7 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 			}); err != nil {
 				return fmt.Errorf("rendering page: %w", err)
 			}
-    }
+		}
 		if len(site.InfoPkgs) > 0 {
 			if err := os.MkdirAll(filepath.Join(repoDir, "info_pkgs"), 0755); err != nil {
 				return fmt.Errorf("creating directory: %w", err)
@@ -2059,23 +2160,24 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 			DominantDescription   string
 			DominantHomepage      string
 			DominantLicense       string
+			ReverseVirtuals       []string
 		}
 		var tmplPkgs []TmplPkg
 		for _, p := range catPkgs {
 			var allVersions []VersionData
 			for _, r := range p.Repos {
-			    for _, c := range r.Categories {
-			        if c.Name == cat.Name {
-			            for _, pkgData := range c.Packages {
-			                if pkgData.Name == p.Name {
-                                allVersions = append(allVersions, pkgData.Versions...)
-			                }
-			            }
-			        }
-			    }
+				for _, c := range r.Categories {
+					if c.Name == cat.Name {
+						for _, pkgData := range c.Packages {
+							if pkgData.Name == p.Name {
+								allVersions = append(allVersions, pkgData.Versions...)
+							}
+						}
+					}
+				}
 			}
 			hs, ht, count := getHighestVersionsAndCount(allVersions)
-			tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: mapToList(p.Repos), EbuildCount: count, HighestStableVersion: hs, HighestTestingVersion: ht, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense})
+			tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: mapToList(p.Repos), EbuildCount: count, HighestStableVersion: hs, HighestTestingVersion: ht, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
 		}
 
 		if err := renderPage(filepath.Join(catDir, "index.html"), tmpl, "category.html", map[string]interface{}{
@@ -2532,10 +2634,11 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 				DominantDescription   string
 				DominantHomepage      string
 				DominantLicense       string
+				ReverseVirtuals       []string
 			}
 			var tmplPkgs []TmplPkg
 			for _, p := range cat.Packages {
-				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense})
+				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
 			}
 
 			if err := renderPage(filepath.Join(catDir, "index.html"), tmpl, "category.html", map[string]interface{}{
@@ -2660,7 +2763,7 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 						return fmt.Errorf("rendering page: %w", err)
 					}
 				}
-      }
+			}
 			for _, v := range pkg.Versions {
 				versionStr := v.Version
 				if v.Ebuild != nil && v.Ebuild.Vars != nil && v.Ebuild.Vars["PV"] != "" {

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -112,13 +112,13 @@ type SiteServer struct {
 	AggProjects   []*AggProject
 
 	// Mappings for faster lookup
-	CatMap  map[string]*AggCategory
-	PkgMap  map[string]*AggPackage
-	LicMap  map[string]*AggLicense
-	UseMap  map[string]*AggUseFlag
+	CatMap      map[string]*AggCategory
+	PkgMap      map[string]*AggPackage
+	LicMap      map[string]*AggLicense
+	UseMap      map[string]*AggUseFlag
 	AggUseFlags []*AggUseFlag
-	ProjMap map[string]*AggProject
-	RepoMap map[string]*SiteData
+	ProjMap     map[string]*AggProject
+	RepoMap     map[string]*SiteData
 }
 
 type ParsedIUSEFlag struct {
@@ -207,6 +207,33 @@ func newSiteServer(sites []*SiteData) (*SiteServer, error) {
 					aggPackages[pkgKey].DominantLicense = pkg.DominantLicense
 				}
 				aggCategories[cat.Name].Packages[pkg.Name] = aggPackages[pkgKey]
+				for _, rev := range pkg.ReverseVirtuals {
+					found := false
+					for _, existingRev := range aggPackages[pkgKey].ReverseVirtuals {
+						if existingRev == rev {
+							found = true
+							break
+						}
+					}
+					if !found {
+						aggPackages[pkgKey].ReverseVirtuals = append(aggPackages[pkgKey].ReverseVirtuals, rev)
+					}
+				}
+				sort.Strings(aggPackages[pkgKey].ReverseVirtuals)
+
+				for _, dep := range pkg.VirtualDeps {
+					found := false
+					for _, existingDep := range aggPackages[pkgKey].VirtualDeps {
+						if existingDep == dep {
+							found = true
+							break
+						}
+					}
+					if !found {
+						aggPackages[pkgKey].VirtualDeps = append(aggPackages[pkgKey].VirtualDeps, dep)
+					}
+				}
+				sort.Strings(aggPackages[pkgKey].VirtualDeps)
 
 				if pkg.Metadata != nil {
 					for _, maint := range pkg.Metadata.Maintainers {
@@ -429,13 +456,13 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						if c.Name == catName {
 							for _, pkgData := range c.Packages {
 								if pkgData.Name == p.Name {
-                                    allVersions = append(allVersions, pkgData.Versions...)
+									allVersions = append(allVersions, pkgData.Versions...)
 								}
 							}
 						}
 					}
 				}
-                hs, ht, count := getHighestVersionsAndCount(allVersions)
+				hs, ht, count := getHighestVersionsAndCount(allVersions)
 				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: mapToList(p.Repos), EbuildCount: count, HighestStableVersion: hs, HighestTestingVersion: ht, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense})
 			}
 
@@ -625,12 +652,12 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 
 				s.renderPageHTTP(w, "repo_index.html", map[string]interface{}{
-					"Title":        site.RepoName,
-					"BaseURL":      baseURL,
-					"Breadcrumbs":  []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Overlays", URL: baseURL + "overlays/"}, {Name: site.RepoName}},
-					"Repo":         site,
-					"PackageCount": site.PackageCount,
-					"Version":      version,
+					"Title":                 site.RepoName,
+					"BaseURL":               baseURL,
+					"Breadcrumbs":           []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Overlays", URL: baseURL + "overlays/"}, {Name: site.RepoName}},
+					"Repo":                  site,
+					"PackageCount":          site.PackageCount,
+					"Version":               version,
 					"GlobalCategoriesCount": len(s.AggCategories),
 					"GlobalPackagesCount":   len(s.AggPackages),
 					"GlobalLicensesCount":   len(s.AggLicenses),
@@ -730,15 +757,15 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							return
 						}
 
-            validLicenses := make(map[string]bool)
-            for _, lic := range s.AggLicenses {
-              validLicenses[lic.Name] = true
-							}
+						validLicenses := make(map[string]bool)
+						for _, lic := range s.AggLicenses {
+							validLicenses[lic.Name] = true
+						}
 
 						if len(parts) == 6 {
 							s.renderPageHTTP(w, "repo_package.html", map[string]interface{}{
-								"Title":       fmt.Sprintf("%s - %s/%s", site.RepoName, pkgData.Category, pkgData.Name),
-								"BaseURL":     baseURL,
+								"Title":   fmt.Sprintf("%s - %s/%s", site.RepoName, pkgData.Category, pkgData.Name),
+								"BaseURL": baseURL,
 								"Breadcrumbs": []Breadcrumb{
 									{Name: s.Title, URL: baseURL},
 									{Name: site.RepoName, URL: "../../../../"},
@@ -746,10 +773,10 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									{Name: pkgData.Category},
 									{Name: pkgData.Name},
 								},
-								"Repo":    site,
-								"Package": *pkgData,
-								"Version": version,
-									"ValidLicenses": validLicenses,
+								"Repo":          site,
+								"Package":       *pkgData,
+								"Version":       version,
+								"ValidLicenses": validLicenses,
 							})
 							return
 						} else if len(parts) == 8 && parts[6] == "ebuild" {
@@ -778,8 +805,8 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 
 							s.renderPageHTTP(w, "ebuild_details.html", map[string]interface{}{
-								"Title":       fmt.Sprintf("%s - %s/%s-%s", site.RepoName, pkgData.Category, pkgData.Name, versionName),
-								"BaseURL":     baseURL,
+								"Title":   fmt.Sprintf("%s - %s/%s-%s", site.RepoName, pkgData.Category, pkgData.Name, versionName),
+								"BaseURL": baseURL,
 								"Breadcrumbs": []Breadcrumb{
 									{Name: s.Title, URL: baseURL},
 									{Name: site.RepoName, URL: "../../../../../../"},
@@ -795,7 +822,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								"VersionData":      *versionData,
 								"FilteredManifest": filteredManifest,
 								"Version":          version,
-									"ValidLicenses":    validLicenses,
+								"ValidLicenses":    validLicenses,
 							})
 							return
 						} else if len(parts) == 8 && parts[6] == "manifest" {
@@ -814,8 +841,8 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							}
 
 							s.renderPageHTTP(w, "repo_package_manifest.html", map[string]interface{}{
-								"Title":       fmt.Sprintf("%s - %s/%s-Manifest-%s", site.RepoName, pkgData.Category, pkgData.Name, manifestName),
-								"BaseURL":     baseURL,
+								"Title":   fmt.Sprintf("%s - %s/%s-Manifest-%s", site.RepoName, pkgData.Category, pkgData.Name, manifestName),
+								"BaseURL": baseURL,
 								"Breadcrumbs": []Breadcrumb{
 									{Name: s.Title, URL: baseURL},
 									{Name: site.RepoName, URL: "../../../../../../"},
@@ -826,10 +853,10 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									{Name: "Manifest"},
 									{Name: manifestName},
 								},
-								"Repo":        site,
-								"Package":     *pkgData,
-								"Manifest":    *targetMD,
-								"Version":     version,
+								"Repo":     site,
+								"Package":  *pkgData,
+								"Manifest": *targetMD,
+								"Version":  version,
 							})
 							return
 						}

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -12,6 +12,7 @@ func getTemplateFuncMap() template.FuncMap {
 		"parseIUSEFlags":      parseIUSEFlagsFunc,
 		"buildOwnerEmailLink": buildOwnerEmailLinkFunc,
 		"slugify":             sanitizeFilename,
+		"split":               strings.Split,
 	}
 }
 

--- a/templates/site/category.html
+++ b/templates/site/category.html
@@ -34,6 +34,9 @@
                 <a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{.Name}}/">{{.Name}}</a> (ambiguous, available in {{len .ReposList}} overlays)
             {{end}}
             - Ebuilds: {{.EbuildCount}}, Stable: {{.HighestStableVersion}}, Testing: {{.HighestTestingVersion}}
+            {{if .ReverseVirtuals}}
+            <span class="badge" style="background-color: #17a2b8; color: white; padding: 2px 5px; border-radius: 3px; font-size: 0.8em;">Virtual</span>
+            {{end}}
             <span class="package-details">
             {{if .DominantDescription}}<br/><small><b>Description:</b> {{.DominantDescription}}</small>{{end}}
             {{if .DominantHomepage}}<br/><small><b>Homepage:</b> <a href="{{.DominantHomepage}}">{{.DominantHomepage}}</a></small>{{end}}

--- a/templates/site/ebuild_details.html
+++ b/templates/site/ebuild_details.html
@@ -14,6 +14,14 @@
 </div>
 {{end}}
 
+{{if .Package.ReverseVirtuals}}
+<div class="alert alert-info">
+    <strong>Notice:</strong> This package is in a virtual group:
+    {{range $index, $virtual := .Package.ReverseVirtuals}}{{if $index}}, {{end}}
+    <a href="{{$.BaseURL}}packages/virtual/{{index (split $virtual "/") 1}}/">{{$virtual}}</a>{{end}}
+</div>
+{{end}}
+
 <div class="metadata-section">
     <h3>Package Information</h3>
     <dl>

--- a/templates/site/repo_package.html
+++ b/templates/site/repo_package.html
@@ -15,6 +15,15 @@
 </div>
 {{end}}
 
+{{if .Package.ReverseVirtuals}}
+<div class="alert alert-info">
+    <strong>Notice:</strong> This package is in a virtual group:
+    {{range $index, $virtual := .Package.ReverseVirtuals}}{{if $index}}, {{end}}
+    <a href="{{$.BaseURL}}packages/virtual/{{index (split $virtual "/") 1}}/">{{$virtual}}</a>
+    {{end}}
+</div>
+{{end}}
+
 {{if .MovedToName}}
 <div class="alert alert-warning">
     <strong>Notice:</strong> Older versions of this package were moved to <a href="{{.MovedToURL}}">{{.MovedToName}}</a>.
@@ -38,6 +47,20 @@
         {{end}}
     </dl>
 </div>
+
+{{if and (eq .Package.Category "virtual") .Package.VirtualDeps}}
+<div class="metadata-section">
+    <h3>Virtual Group Dependencies</h3>
+    <p>This virtual package provides the following dependencies:</p>
+    <ul>
+        {{range .Package.VirtualDeps}}
+        <li>
+            <a href="{{$.BaseURL}}packages/{{.}}/">{{.}}</a>
+        </li>
+        {{end}}
+    </ul>
+</div>
+{{end}}
 
 <div class="metadata-section">
     <h3>Versions</h3>

--- a/testdata/test-overlay/dev-util/pkgconf/pkgconf-1.ebuild
+++ b/testdata/test-overlay/dev-util/pkgconf/pkgconf-1.ebuild
@@ -1,0 +1,4 @@
+EAPI=8
+DESCRIPTION="pkgconf"
+SLOT="0"
+KEYWORDS="amd64"

--- a/testdata/test-overlay/virtual/pkgconfig/pkgconfig-2.ebuild
+++ b/testdata/test-overlay/virtual/pkgconfig/pkgconfig-2.ebuild
@@ -1,0 +1,5 @@
+EAPI=8
+DESCRIPTION="Virtual for pkgconfig"
+SLOT="0"
+KEYWORDS="amd64"
+RDEPEND="dev-util/pkgconf"


### PR DESCRIPTION
- Ensured `virtual` category is scanned even if not explicitly listed in `profiles/categories`.
- Added logic in `cmd/g2/site.go` to parse dependency trees (`DEPEND`, `RDEPEND`, `PDEPEND`) of `virtual/*` packages.
- Populated `VirtualDeps` on virtual packages and propagated `ReverseVirtuals` onto the packages they depend on.
- Merged these fields during cross-repo aggregation in `generateSite` and `site_serve.go`.
- Added a "Virtual Group Dependencies" section in `repo_package.html` to clearly display a virtual package's dependents.
- Added a dismissible "Notice: This package is in a virtual group" banner in `repo_package.html` and `ebuild_details.html` for reverse-linked dependencies.
- Added a helper `split` string function to `template_funcs.go`.

---
*PR created automatically by Jules for task [17092182895149633733](https://jules.google.com/task/17092182895149633733) started by @arran4*