### PR TITLE
feat: parse and display virtual dependencies

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -148,6 +148,9 @@ type PackageData struct {
 
 	// InfoPkg matching
 	IsInfoPkg bool
+
+	ReverseVirtuals []string
+	VirtualDeps     []string
 }
 
 type PkgUseFlag struct {
@@ -810,7 +813,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 			continue
 		}
 
-		if len(supportedCategories) > 0 && !supportedCategories[name] {
+		if len(supportedCategories) > 0 && !supportedCategories[name] && name != "virtual" {
 			continue
 		}
 
@@ -1171,7 +1174,79 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		}
 	}
 
+	extractVirtualDeps(site)
 	return site, nil
+}
+
+func extractVirtualDeps(site *SiteData) {
+	for i := range site.Categories {
+		if site.Categories[i].Name != "virtual" {
+			continue
+		}
+		for j := range site.Categories[i].Packages {
+			pkg := &site.Categories[i].Packages[j]
+			depsMap := make(map[string]bool)
+			for _, ver := range pkg.Versions {
+				if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+					types := []string{"DEPEND", "RDEPEND", "PDEPEND"}
+					for _, depType := range types {
+						depStr := ver.Ebuild.Vars[depType]
+						if depStr != "" {
+							tree := g2.ParseDepTree(depStr)
+							extractDepNodes(tree.Nodes, depsMap)
+						}
+					}
+				}
+			}
+			for dep := range depsMap {
+				pkg.VirtualDeps = append(pkg.VirtualDeps, dep)
+				depParts := strings.Split(dep, "/")
+				if len(depParts) == 2 {
+					depCat := depParts[0]
+					depName := depParts[1]
+					for k := range site.Categories {
+						if site.Categories[k].Name == depCat {
+							for l := range site.Categories[k].Packages {
+								if site.Categories[k].Packages[l].Name == depName {
+									targetPkg := &site.Categories[k].Packages[l]
+									virtualName := pkg.Category + "/" + pkg.Name
+									found := false
+									for _, v := range targetPkg.ReverseVirtuals {
+										if v == virtualName {
+											found = true
+											break
+										}
+									}
+									if !found {
+										targetPkg.ReverseVirtuals = append(targetPkg.ReverseVirtuals, virtualName)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			sort.Strings(pkg.VirtualDeps)
+		}
+	}
+}
+
+func extractDepNodes(nodes []g2.DepNode, depsMap map[string]bool) {
+	for _, node := range nodes {
+		switch n := node.(type) {
+		case g2.DepString:
+			pkgName := g2.ExtractPackageNameFromDep(string(n))
+			if pkgName != "" {
+				depsMap[pkgName] = true
+			}
+		case g2.DepAnyOf:
+			extractDepNodes(n.Children, depsMap)
+		case g2.DepAllOf:
+			extractDepNodes(n.Children, depsMap)
+		case g2.DepUseConditional:
+			extractDepNodes(n.Children, depsMap)
+		}
+	}
 }
 
 func buildManifestData(manifest *g2.Manifest, versions []VersionData, thirdPartyMirrors map[string][]string) []ManifestEntryData {
@@ -1371,6 +1446,8 @@ type AggPackage struct {
 	DominantDescription string
 	DominantHomepage    string
 	DominantLicense     string
+	ReverseVirtuals     []string
+	VirtualDeps         []string
 }
 type AggProject struct {
 	Project  *g2.Project
@@ -1684,6 +1761,33 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 					aggPackages[pkgKey].DominantLicense = pkg.DominantLicense
 				}
 				aggCategories[cat.Name].Packages[pkg.Name] = aggPackages[pkgKey]
+				for _, rev := range pkg.ReverseVirtuals {
+					found := false
+					for _, existingRev := range aggPackages[pkgKey].ReverseVirtuals {
+						if existingRev == rev {
+							found = true
+							break
+						}
+					}
+					if !found {
+						aggPackages[pkgKey].ReverseVirtuals = append(aggPackages[pkgKey].ReverseVirtuals, rev)
+					}
+				}
+				sort.Strings(aggPackages[pkgKey].ReverseVirtuals)
+
+				for _, dep := range pkg.VirtualDeps {
+					found := false
+					for _, existingDep := range aggPackages[pkgKey].VirtualDeps {
+						if existingDep == dep {
+							found = true
+							break
+						}
+					}
+					if !found {
+						aggPackages[pkgKey].VirtualDeps = append(aggPackages[pkgKey].VirtualDeps, dep)
+					}
+				}
+				sort.Strings(aggPackages[pkgKey].VirtualDeps)
 
 				if pkg.Metadata != nil {
 					for _, maint := range pkg.Metadata.Maintainers {
@@ -2108,6 +2212,7 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 			DominantDescription   string
 			DominantHomepage      string
 			DominantLicense       string
+			ReverseVirtuals       []string
 		}
 		var tmplPkgs []TmplPkg
 		for _, p := range catPkgs {
@@ -2124,7 +2229,7 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 				}
 			}
 			hs, ht, count := getHighestVersionsAndCount(allVersions)
-			tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: mapToList(p.Repos), EbuildCount: count, HighestStableVersion: hs, HighestTestingVersion: ht, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense})
+			tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: mapToList(p.Repos), EbuildCount: count, HighestStableVersion: hs, HighestTestingVersion: ht, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
 		}
 
 		if err := renderPage(filepath.Join(catDir, "index.html"), tmpl, "category.html", map[string]interface{}{
@@ -2615,10 +2720,11 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 				DominantDescription   string
 				DominantHomepage      string
 				DominantLicense       string
+				ReverseVirtuals       []string
 			}
 			var tmplPkgs []TmplPkg
 			for _, p := range cat.Packages {
-				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense})
+				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
 			}
 
 			if err := renderPage(filepath.Join(catDir, "index.html"), tmpl, "category.html", map[string]interface{}{

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -426,6 +426,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				DominantDescription   string
 				DominantHomepage      string
 				DominantLicense       string
+				ReverseVirtuals       []string
 			}
 			var tmplPkgs []TmplPkg
 			for _, p := range catPkgs {
@@ -442,7 +443,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 				hs, ht, count := getHighestVersionsAndCount(allVersions)
-				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: mapToList(p.Repos), EbuildCount: count, HighestStableVersion: hs, HighestTestingVersion: ht, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense})
+				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: mapToList(p.Repos), EbuildCount: count, HighestStableVersion: hs, HighestTestingVersion: ht, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
 			}
 
 			s.renderPageHTTP(w, "category.html", map[string]interface{}{
@@ -740,10 +741,11 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							DominantDescription   string
 							DominantHomepage      string
 							DominantLicense       string
+							ReverseVirtuals       []string
 						}
 						var tmplPkgs []TmplPkg
 						for _, p := range catData.Packages {
-							tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense})
+							tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
 						}
 
 						s.renderPageHTTP(w, "category.html", map[string]interface{}{

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -14,6 +14,7 @@ func getTemplateFuncMap() template.FuncMap {
 		"buildOwnerEmailLink": buildOwnerEmailLinkFunc,
 		"now":                 time.Now,
 		"slugify":             sanitizeFilename,
+		"split":               strings.Split,
 	}
 }
 

--- a/templates/site/category.html
+++ b/templates/site/category.html
@@ -42,6 +42,9 @@
                 <a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{.Name}}/">{{.Name}}</a> (ambiguous, available in {{len .ReposList}} overlays)
             {{end}}
             - Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{.HighestStableVersion}}{{end}}{{if .HighestTestingVersion}}, Testing: {{.HighestTestingVersion}}{{end}}
+            {{if .ReverseVirtuals}}
+            <span class="badge" style="background-color: #17a2b8; color: white; padding: 2px 5px; border-radius: 3px; font-size: 0.8em;">Virtual</span>
+            {{end}}
             <span class="package-details">
             {{if .DominantDescription}}<br/><small><b>Description:</b> {{.DominantDescription}}</small>{{end}}
             {{if .DominantHomepage}}<br/><small><b>Homepage:</b> <a href="{{.DominantHomepage}}">{{.DominantHomepage}}</a></small>{{end}}

--- a/templates/site/ebuild_details.html
+++ b/templates/site/ebuild_details.html
@@ -22,6 +22,28 @@
 </div>
 {{end}}
 
+{{if .Package.ReverseVirtuals}}
+<div class="alert alert-info">
+    <strong>Notice:</strong> This package is in a virtual group:
+    {{range $index, $virtual := .Package.ReverseVirtuals}}{{if $index}}, {{end}}
+    <a href="{{$.BaseURL}}packages/virtual/{{index (split $virtual "/") 1}}/">{{$virtual}}</a>{{end}}
+</div>
+{{end}}
+
+{{if and (eq $.Package.Category "virtual") .Package.VirtualDeps}}
+<div class="metadata-section">
+    <h3>Virtual Group Dependencies</h3>
+    <p>This virtual package provides the following dependencies:</p>
+    <ul>
+        {{range .Package.VirtualDeps}}
+        <li>
+            <a href="{{$.BaseURL}}packages/{{.}}/">{{.}}</a>
+        </li>
+        {{end}}
+    </ul>
+</div>
+{{end}}
+
 <div class="metadata-section">
     <h3>Package Information</h3>
     <dl>

--- a/templates/site/repo_package.html
+++ b/templates/site/repo_package.html
@@ -23,6 +23,15 @@
 </div>
 {{end}}
 
+{{if .Package.ReverseVirtuals}}
+<div class="alert alert-info">
+    <strong>Notice:</strong> This package is in a virtual group:
+    {{range $index, $virtual := .Package.ReverseVirtuals}}{{if $index}}, {{end}}
+    <a href="{{$.BaseURL}}packages/virtual/{{index (split $virtual "/") 1}}/">{{$virtual}}</a>
+    {{end}}
+</div>
+{{end}}
+
 {{if .MovedToName}}
 <div class="alert alert-warning">
     <strong>Notice:</strong> Older versions of this package were moved to <a href="{{.MovedToURL}}">{{.MovedToName}}</a>.
@@ -46,6 +55,20 @@
         {{end}}
     </dl>
 </div>
+
+{{if and (eq .Package.Category "virtual") .Package.VirtualDeps}}
+<div class="metadata-section">
+    <h3>Virtual Group Dependencies</h3>
+    <p>This virtual package provides the following dependencies:</p>
+    <ul>
+        {{range .Package.VirtualDeps}}
+        <li>
+            <a href="{{$.BaseURL}}packages/{{.}}/">{{.}}</a>
+        </li>
+        {{end}}
+    </ul>
+</div>
+{{end}}
 
 <div class="metadata-section">
     <h3>Versions</h3>

--- a/testdata/test-overlay/dev-util/pkgconf/pkgconf-1.ebuild
+++ b/testdata/test-overlay/dev-util/pkgconf/pkgconf-1.ebuild
@@ -1,0 +1,4 @@
+EAPI=8
+DESCRIPTION="pkgconf"
+SLOT="0"
+KEYWORDS="amd64"

--- a/testdata/test-overlay/virtual/pkgconfig/pkgconfig-2.ebuild
+++ b/testdata/test-overlay/virtual/pkgconfig/pkgconfig-2.ebuild
@@ -1,0 +1,5 @@
+EAPI=8
+DESCRIPTION="Virtual for pkgconfig"
+SLOT="0"
+KEYWORDS="amd64"
+RDEPEND="dev-util/pkgconf"


### PR DESCRIPTION
Adds support for Gentoo virtual packages.

- The `virtual` category is now always scanned.
- Dependencies of virtuals are tracked globally and at a repository level via `VirtualDeps` and `ReverseVirtuals`.
- Both `ebuild_details.html` and `repo_package.html` highlight virtual group dependencies and reverse dependencies properly.

---
*PR created automatically by Jules for task [15809587435436062907](https://jules.google.com/task/15809587435436062907) started by @arran4*