### PR TITLE
Add EAPI deprecated and maintainer missing lint rules

### DIFF
--- a/lints/ebuild/eapi_deprecated.go
+++ b/lints/ebuild/eapi_deprecated.go
@@ -1,0 +1,53 @@
+package ebuild
+
+import (
+	"fmt"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func init() {
+	lints.RegisterLintRule(&EAPIDeprecatedLintRule{})
+}
+
+type EAPIDeprecatedLintRule struct{}
+
+func (r *EAPIDeprecatedLintRule) Lint(repoDir string, pkg *g2.PackageData) []string {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *EAPIDeprecatedLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []string {
+	var warnings []string
+	severity := "Warning"
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0803"]; ok {
+			if val == "notice" || val == "error" || val == "warning" {
+				severity = cases.Title(language.English).String(val)
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			eapi := ver.Ebuild.Vars["EAPI"]
+			if eapi == "" {
+				eapi = "0"
+			}
+
+			// Simple check for EAPI < 6
+			isDeprecated := false
+			if len(eapi) == 1 && eapi[0] >= '0' && eapi[0] <= '5' {
+				isDeprecated = true
+			}
+
+			if isDeprecated {
+				warnings = append(warnings, fmt.Sprintf("[%s] Ebuild %s uses an outdated EAPI '%s'. Consider upgrading to a newer EAPI.", severity, ver.Version, eapi))
+			}
+		}
+	}
+
+	return warnings
+}

--- a/lints/ebuild/eapi_deprecated_test.go
+++ b/lints/ebuild/eapi_deprecated_test.go
@@ -1,0 +1,66 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestEAPIDeprecatedLintRule(t *testing.T) {
+	rule := &EAPIDeprecatedLintRule{}
+
+	t.Run("Modern EAPI", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						Vars: map[string]string{"EAPI": "8"},
+					},
+				},
+			},
+		}
+		warnings := rule.Lint("", pkg)
+		if len(warnings) != 0 {
+			t.Errorf("Expected 0 warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Deprecated EAPI", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						Vars: map[string]string{"EAPI": "5"},
+					},
+				},
+			},
+		}
+		warnings := rule.Lint("", pkg)
+		if len(warnings) != 1 {
+			t.Errorf("Expected 1 warning, got %v", warnings)
+		} else if warnings[0] != "[Warning] Ebuild 1.0 uses an outdated EAPI '5'. Consider upgrading to a newer EAPI." {
+			t.Errorf("Unexpected warning: %s", warnings[0])
+		}
+	})
+
+	t.Run("Missing EAPI", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						Vars: map[string]string{}, // Defaults to 0
+					},
+				},
+			},
+		}
+		warnings := rule.Lint("", pkg)
+		if len(warnings) != 1 {
+			t.Errorf("Expected 1 warning, got %v", warnings)
+		} else if warnings[0] != "[Warning] Ebuild 1.0 uses an outdated EAPI '0'. Consider upgrading to a newer EAPI." {
+			t.Errorf("Unexpected warning: %s", warnings[0])
+		}
+	})
+}

--- a/lints/metadata/maintainer_missing.go
+++ b/lints/metadata/maintainer_missing.go
@@ -1,0 +1,37 @@
+package metadata
+
+import (
+	"fmt"
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func init() {
+	lints.RegisterLintRule(&MaintainerLintRule{})
+}
+
+type MaintainerLintRule struct{}
+
+func (r *MaintainerLintRule) Lint(repoDir string, pkg *g2.PackageData) []string {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *MaintainerLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []string {
+	var warnings []string
+	severity := "Warning"
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0702"]; ok {
+			if val == "notice" || val == "error" || val == "warning" {
+				severity = cases.Title(language.English).String(val)
+			}
+		}
+	}
+
+	if pkg.Metadata != nil && len(pkg.Metadata.Maintainers) == 0 {
+		warnings = append(warnings, fmt.Sprintf("[%s] metadata.xml is missing a maintainer. Add at least one <maintainer> element.", severity))
+	}
+
+	return warnings
+}

--- a/lints/metadata/maintainer_missing_test.go
+++ b/lints/metadata/maintainer_missing_test.go
@@ -1,0 +1,47 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestMaintainerLintRule(t *testing.T) {
+	rule := &MaintainerLintRule{}
+
+	t.Run("Has maintainer", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{{Email: "test@example.com"}},
+			},
+		}
+		warnings := rule.Lint("", pkg)
+		if len(warnings) != 0 {
+			t.Errorf("Expected 0 warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Missing maintainer", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{},
+			},
+		}
+		warnings := rule.Lint("", pkg)
+		if len(warnings) != 1 {
+			t.Errorf("Expected 1 warning, got %v", warnings)
+		} else if warnings[0] != "[Warning] metadata.xml is missing a maintainer. Add at least one <maintainer> element." {
+			t.Errorf("Unexpected warning: %s", warnings[0])
+		}
+	})
+
+	t.Run("Missing metadata entirely", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: nil,
+		}
+		warnings := rule.Lint("", pkg)
+		if len(warnings) != 0 {
+			t.Errorf("Expected 0 warnings, got %v", warnings)
+		}
+	})
+}


### PR DESCRIPTION
Adds two new linting rules for ebuild analysis:
- `EAPIDeprecatedLintRule`: Warns when outdated EAPIs (<= 5) are used in ebuild files.
- `MaintainerLintRule`: Warns when a `metadata.xml` file is missing a `<maintainer>` element.
Also added unit tests for the two new rules to ensure they work correctly.

---
*PR created automatically by Jules for task [15074752367436454470](https://jules.google.com/task/15074752367436454470) started by @arran4*