### PR TITLE
Fix overlay source title falling back to local paths like `.`

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -584,12 +584,41 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		}
 	}
 
-	// Get Git Info if not injected
-	if remoteURL == "" {
-		var err error
-		remoteURL, err = getGitOriginURL(repoDir)
-		if err != nil {
-			log.Printf("Warning: failed to get git origin url: %v", err)
+	isUselessURL := func(u string) bool {
+		u = strings.TrimSpace(u)
+		return u == "" || u == "." || u == ".." || u == "./" || u == "../"
+	}
+
+	originalRemoteURL := remoteURL
+
+	// Implement fallback layers for remoteURL
+	if isUselessURL(remoteURL) {
+		remoteURL = ""
+
+		// 1. Git origin URL
+		gitURL, err := getGitOriginURL(repoDir)
+		if err == nil && !isUselessURL(gitURL) {
+			remoteURL = gitURL
+		}
+
+		// 2. RepoInfo Sources
+		if remoteURL == "" && repoInfo != nil && len(repoInfo.Sources) > 0 {
+			for _, src := range repoInfo.Sources {
+				if !isUselessURL(src.Text) {
+					remoteURL = src.Text
+					break
+				}
+			}
+		}
+
+		// 3. RepoInfo Homepage
+		if remoteURL == "" && repoInfo != nil && !isUselessURL(repoInfo.Homepage) {
+			remoteURL = repoInfo.Homepage
+		}
+
+		// 4. Fallback to original
+		if remoteURL == "" {
+			remoteURL = originalRemoteURL
 		}
 	}
 


### PR DESCRIPTION
This addresses an issue where the "Source" title generated for an overlay could be displayed merely as `.` on the front end.

The changes expand how `parseRepo` identifies the most suitable source URL for a repository by ignoring generic paths and scanning via a multi-layered priority scheme:
1. Injected `SourceURL` string.
2. Git `remote.origin.url` configuration.
3. Registered `Sources` text inside the `repositories.xml` representation (`repoInfo.Sources`).
4. Registered `Homepage` URL within the `repositories.xml` (`repoInfo.Homepage`).
5. Falling back to the originally passed location value if none apply.

---
*PR created automatically by Jules for task [12517543348626823235](https://jules.google.com/task/12517543348626823235) started by @arran4*