### PR TITLE
feat(site): Add concurrency limit flag to site commands

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -341,6 +341,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	recentDurOpt := fs.String("recent-duration", "3mo", "Duration to consider an update 'recent' (e.g. 3mo, 14d, 72h)")
 	fastGit := fs.Bool("fast-git-modtime", false, "Use fast (O(1)) but potentially less reliable go-git file log lookup")
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
+	concurrency := fs.Int("concurrency", runtime.GOMAXPROCS(0), "Maximum number of concurrent repository fetches/parses")
 
 	if err := fs.Parse(args[2:]); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
@@ -362,7 +363,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	}
 
 	log.Printf("Generating site from remote repositories: %s into %s", location, *outDir)
-	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip)
+	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency)
 }
 
 func parseLayoutConfFromFS(sysFS fs.FS, path string) (*g2.LayoutConf, error) {
@@ -3043,7 +3044,7 @@ func renderPage(path string, tmpl *template.Template, name string, data interfac
 	return nil
 }
 
-func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool) error {
+func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int) error {
 	var data []byte
 	var err error
 
@@ -3090,7 +3091,9 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	var allSitesMu sync.Mutex
 
 	g, _ := errgroup.WithContext(context.Background())
-	g.SetLimit(runtime.GOMAXPROCS(0))
+	if concurrency > 0 {
+		g.SetLimit(concurrency)
+	}
 
 	for _, repo := range repos.Repositories {
 		repo := repo // loop variable capture

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -341,7 +340,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	recentDurOpt := fs.String("recent-duration", "3mo", "Duration to consider an update 'recent' (e.g. 3mo, 14d, 72h)")
 	fastGit := fs.Bool("fast-git-modtime", false, "Use fast (O(1)) but potentially less reliable go-git file log lookup")
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
-	concurrency := fs.Int("concurrency", runtime.GOMAXPROCS(0), "Maximum number of concurrent repository fetches/parses")
+	concurrency := fs.Int("concurrency", 4, "Maximum number of concurrent repository fetches/parses")
 
 	if err := fs.Parse(args[2:]); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -35,7 +34,7 @@ func (cfg *MainArgConfig) cmdSite(args []string) error {
 func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 	fs := flag.NewFlagSet("site serve", flag.ExitOnError)
 	port := fs.Int("port", 8080, "Port to run the site server on")
-	concurrency := fs.Int("concurrency", runtime.GOMAXPROCS(0), "Maximum number of concurrent repository fetches/parses")
+	concurrency := fs.Int("concurrency", 4, "Maximum number of concurrent repository fetches/parses")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -344,7 +343,6 @@ func newSiteServer(sites []*SiteData, genInfo GenerationInfo) (*SiteServer, erro
 
 	return server, nil
 }
-
 
 func (s *SiteServer) renderPageHTTP(w http.ResponseWriter, name string, data map[string]interface{}) {
 	log.Printf("Serving page using template %s", name)

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -35,6 +35,7 @@ func (cfg *MainArgConfig) cmdSite(args []string) error {
 func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 	fs := flag.NewFlagSet("site serve", flag.ExitOnError)
 	port := fs.Int("port", 8080, "Port to run the site server on")
+	concurrency := fs.Int("concurrency", runtime.GOMAXPROCS(0), "Maximum number of concurrent repository fetches/parses")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -66,7 +67,9 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 
 		var sitesMu sync.Mutex
 		g, _ := errgroup.WithContext(context.Background())
-		g.SetLimit(runtime.GOMAXPROCS(0))
+		if *concurrency > 0 {
+			g.SetLimit(*concurrency)
+		}
 
 		for _, entry := range entries {
 			if !entry.IsDir() {


### PR DESCRIPTION
Added a concurrency limit flag to the site commands, preventing resource exhaustion during parallel checkout of large amounts of repositories.

---
*PR created automatically by Jules for task [6341797134661988865](https://jules.google.com/task/6341797134661988865) started by @arran4*