### PR TITLE
feat: unlimit errgroup concurrency for remote fetching

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -3090,7 +3089,6 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	var allSitesMu sync.Mutex
 
 	g, _ := errgroup.WithContext(context.Background())
-	g.SetLimit(runtime.GOMAXPROCS(0))
 
 	for _, repo := range repos.Repositories {
 		repo := repo // loop variable capture

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -3089,6 +3089,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	var allSitesMu sync.Mutex
 
 	g, _ := errgroup.WithContext(context.Background())
+	g.SetLimit(10)
 
 	for _, repo := range repos.Repositories {
 		repo := repo // loop variable capture

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -65,6 +65,7 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 
 		var sitesMu sync.Mutex
 		g, _ := errgroup.WithContext(context.Background())
+		g.SetLimit(10)
 
 		for _, entry := range entries {
 			if !entry.IsDir() {

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -66,7 +65,6 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 
 		var sitesMu sync.Mutex
 		g, _ := errgroup.WithContext(context.Background())
-		g.SetLimit(runtime.GOMAXPROCS(0))
 
 		for _, entry := range entries {
 			if !entry.IsDir() {
@@ -341,7 +339,6 @@ func newSiteServer(sites []*SiteData, genInfo GenerationInfo) (*SiteServer, erro
 
 	return server, nil
 }
-
 
 func (s *SiteServer) renderPageHTTP(w http.ResponseWriter, name string, data map[string]interface{}) {
 	log.Printf("Serving page using template %s", name)


### PR DESCRIPTION
Removes the GOMAXPROCS concurrency limit from the errgroup instances handling repository checkouts in `cmdSiteRemote` and `cmdSiteServe`. Since checkouts are network and I/O bound, restricting them to CPU core count artificially degrades parallel processing performance, forcing sequential behavior on low-core machines.

---
*PR created automatically by Jules for task [987076464177461171](https://jules.google.com/task/987076464177461171) started by @arran4*