### PR TITLE
feat: add fetch retries and continue-on-error mode

### DIFF
--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -75,7 +75,7 @@ func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool, 
 	for i := 0; i <= retries; i++ {
 		if i > 0 {
 			log.Printf("Retrying fetch for %s (attempt %d/%d)...", gitUrl, i, retries)
-			os.RemoveAll(destDir)
+			_ = os.RemoveAll(destDir)
 			time.Sleep(1 * time.Second)
 		}
 		err = fetchRepoAttempt(ctx, gitUrl, destDir, useZip)

--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type ZipUrlConverter func(gitUrl string) (string, error)
@@ -68,7 +70,24 @@ func giteaUrlConverter(gitUrl string) (string, error) {
 	return fmt.Sprintf("https://%s%s/archive/HEAD.zip", u.Host, path), nil
 }
 
-func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool) error {
+func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool, retries int) error {
+	var err error
+	for i := 0; i <= retries; i++ {
+		if i > 0 {
+			log.Printf("Retrying fetch for %s (attempt %d/%d)...", gitUrl, i, retries)
+			os.RemoveAll(destDir)
+			time.Sleep(1 * time.Second)
+		}
+		err = fetchRepoAttempt(ctx, gitUrl, destDir, useZip)
+		if err == nil {
+			return nil
+		}
+		log.Printf("Fetch attempt %d failed for %s: %v", i+1, gitUrl, err)
+	}
+	return err
+}
+
+func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip bool) error {
 	if useZip {
 		u, err := url.Parse(gitUrl)
 		if err == nil {

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -260,7 +260,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 		defer cancel()
 
 		t0 := time.Now()
-		if err := FetchRepo(ctx, location, tmpDir, *useZip); err != nil {
+		if err := FetchRepo(ctx, location, tmpDir, *useZip, 0); err != nil {
 			cleanup()
 			return fmt.Errorf("cloning repository: %w", err)
 		}
@@ -341,6 +341,8 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	fastGit := fs.Bool("fast-git-modtime", false, "Use fast (O(1)) but potentially less reliable go-git file log lookup")
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
 	concurrency := fs.Int("concurrency", 4, "Maximum number of concurrent repository fetches/parses")
+	retries := fs.Int("retries", 3, "Number of times to retry fetching a repository")
+	continueOnError := fs.Bool("continue-on-error", true, "Continue parsing other repositories even if fetching one fails")
 
 	if err := fs.Parse(args[2:]); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
@@ -362,7 +364,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	}
 
 	log.Printf("Generating site from remote repositories: %s into %s", location, *outDir)
-	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency)
+	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError)
 }
 
 func parseLayoutConfFromFS(sysFS fs.FS, path string) (*g2.LayoutConf, error) {
@@ -3043,7 +3045,7 @@ func renderPage(path string, tmpl *template.Template, name string, data interfac
 	return nil
 }
 
-func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int) error {
+func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool) error {
 	var data []byte
 	var err error
 
@@ -3120,8 +3122,11 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			defer cancel()
 
 			t0 := time.Now()
-			if err := FetchRepo(ctx, gitUrl, repoPath, useZip); err != nil {
+			if err := FetchRepo(ctx, gitUrl, repoPath, useZip, retries); err != nil {
 				log.Printf("Failed to fetch %s: %v", repo.Name, err)
+				if !continueOnError {
+					return fmt.Errorf("fetching %s: %w", repo.Name, err)
+				}
 				return nil
 			}
 			checkoutTime := time.Since(t0)
@@ -3151,14 +3156,15 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			allSitesMu.Lock()
 			allSites = append(allSites, siteData)
 			allSitesMu.Unlock()
-
 			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {
+		if !continueOnError {
+			return fmt.Errorf("parallel repository fetching: %w", err)
+		}
 		log.Printf("Warning: error during parallel repository fetching: %v", err)
 	}
-
 	// Sort the resulting sites alphabetically by RepoName for deterministic ordering
 	sort.Slice(allSites, func(i, j int) bool {
 		return allSites[i].RepoName < allSites[j].RepoName


### PR DESCRIPTION
Implemented retries for `git clone` / zip downloads to handle transient network errors, particularly useful when fetching many overlays. Also added a configurable `continue-on-error` mode to allow failing the entire command if any repository fails to download, as requested.

---
*PR created automatically by Jules for task [14995332811172791560](https://jules.google.com/task/14995332811172791560) started by @arran4*