### PR TITLE
Improve logging for concurrent repository processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Build g2
-        run: go build -o g2 cmd/g2/*.go
+        run: go build -o g2 ./cmd/g2
       - name: Test site generation
         run: go run ./cmd/g2 overlay site generate https://github.com/arran4/arrans_overlay
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test_site/
 testrepo/
 playwright-script.js
 doc/g2.1
+/*.exe

--- a/cmd/g2/dir_size_unix.go
+++ b/cmd/g2/dir_size_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func getFreeSpace(path string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
+}

--- a/cmd/g2/dir_size_windows.go
+++ b/cmd/g2/dir_size_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func getFreeSpace(path string) (uint64, error) {
+	var freeBytesAvailable uint64
+	var totalNumberOfBytes uint64
+	var totalNumberOfFreeBytes uint64
+
+	ptr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+
+	err = windows.GetDiskFreeSpaceEx(ptr, &freeBytesAvailable, &totalNumberOfBytes, &totalNumberOfFreeBytes)
+	if err != nil {
+		return 0, err
+	}
+
+	return freeBytesAvailable, nil
+}

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -3094,6 +3094,9 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	g, _ := errgroup.WithContext(context.Background())
 	if concurrency > 0 {
 		g.SetLimit(concurrency)
+		log.Printf("Starting concurrent remote repository processing with %d concurrency limit", concurrency)
+	} else {
+		log.Printf("Starting concurrent remote repository processing with unbounded concurrency")
 	}
 
 	for _, repo := range repos.Repositories {
@@ -3115,7 +3118,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 		}
 
 		g.Go(func() error {
-			log.Printf("Fetching remote repository: %s (%s)", repo.Name, gitUrl)
+			log.Printf("[START] Fetching remote repository: %s (%s)", repo.Name, gitUrl)
 
 			repoPath := filepath.Join(tmpDir, repo.Name)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -3130,8 +3133,14 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				return nil
 			}
 			checkoutTime := time.Since(t0)
+			freeSpace, err := getFreeSpace(repoPath)
+			if err == nil {
+				log.Printf("[DONE] Finished fetching repository %s in %s. Free space: %.2f MB", repo.Name, checkoutTime, float64(freeSpace)/(1024*1024))
+			} else {
+				log.Printf("[DONE] Finished fetching repository %s in %s", repo.Name, checkoutTime)
+			}
 
-			log.Printf("Parsing repository: %s", repo.Name)
+			log.Printf("[START] Parsing repository: %s", repo.Name)
 
 			size, err := getDirSize(repoPath)
 			var gitSize string
@@ -3148,6 +3157,12 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				return nil
 			}
 			processTime := time.Since(t1)
+			freeSpaceAfter, err := getFreeSpace(repoPath)
+			if err == nil {
+				log.Printf("[DONE] Finished parsing repository %s in %s. Free space: %.2f MB", repo.Name, processTime, float64(freeSpaceAfter)/(1024*1024))
+			} else {
+				log.Printf("[DONE] Finished parsing repository %s in %s", repo.Name, processTime)
+			}
 
 			siteData.CheckoutTime = checkoutTime.String()
 			siteData.ProcessTime = processTime.String()

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -68,6 +68,9 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 		g, _ := errgroup.WithContext(context.Background())
 		if *concurrency > 0 {
 			g.SetLimit(*concurrency)
+			log.Printf("Starting concurrent repository processing with %d concurrency limit", *concurrency)
+		} else {
+			log.Printf("Starting concurrent repository processing with unbounded concurrency")
 		}
 
 		for _, entry := range entries {
@@ -79,11 +82,18 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 
 			if isOverlayDir(repoPath) {
 				g.Go(func() error {
-					log.Printf("Parsing repository %s", entry.Name())
+					log.Printf("[START] Parsing repository %s", entry.Name())
 					siteData, err := parseRepo(os.DirFS(repoPath), ".", entry.Name(), false, nil)
 					if err != nil {
 						log.Printf("Warning: failed to parse repo %s: %v", entry.Name(), err)
 						return nil // Don't fail entire group
+					}
+
+					freeSpace, err := getFreeSpace(repoPath)
+					if err == nil {
+						log.Printf("[DONE] Finished parsing repository %s. Free space: %.2f MB", entry.Name(), float64(freeSpace)/(1024*1024))
+					} else {
+						log.Printf("[DONE] Finished parsing repository %s", entry.Name())
 					}
 
 					sitesMu.Lock()

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,10 @@ require (
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-require golang.org/x/sync v0.19.0
+require (
+	golang.org/x/sync v0.19.0
+	golang.org/x/sys v0.39.0
+)


### PR DESCRIPTION
Improve logging for concurrent repository processing

This commit modifies `cmd/g2/site.go` and `cmd/g2/site_serve.go` to explicitly log the concurrency limits and when concurrent repository processing tasks begin and complete. It also implements cross-platform checking using `golang.org/x/sys` to occasionally log the available free disk space after checking out/parsing repositories.

---
*PR created automatically by Jules for task [10189681074787001199](https://jules.google.com/task/10189681074787001199) started by @arran4*