### PR TITLE
feat: Display count of news items next to links

### DIFF
--- a/templates/views/dashboard.html
+++ b/templates/views/dashboard.html
@@ -33,7 +33,7 @@
         <li><a href="profiles/">Profiles</a></li>
         {{end}}
         {{if and .GlobalNews (gt (len .GlobalNews) 0)}}
-        <li><a href="news/">News</a></li>
+        <li><a href="news/">News ({{len .GlobalNews}})</a></li>
         {{end}}
     </ul>
 </div>

--- a/templates/views/repo_index.html
+++ b/templates/views/repo_index.html
@@ -162,7 +162,7 @@
     <li><a href="deprecated/">Deprecated Packages ({{len .Repo.Deprecated}})</a></li>
     {{end}}
     {{if .RecentNews}}
-    <li><a href="news/">News</a></li>
+    <li><a href="news/">News ({{len .Repo.News}})</a></li>
     {{end}}
 </ul>
 


### PR DESCRIPTION
Adds a count showing the total number of news items next to the "News" link in both the global dashboard navigation and the repository-specific index navigation. This aligns the News links with other navigational elements (like Packages, Categories) that already display counts.

---
*PR created automatically by Jules for task [12374254983257219002](https://jules.google.com/task/12374254983257219002) started by @arran4*