### PR TITLE
feat(templates): add euse command hints to USE flag pages

### DIFF
--- a/templates/views/ebuild_details.html
+++ b/templates/views/ebuild_details.html
@@ -100,6 +100,12 @@
 {{if .VersionData.Ebuild.Vars.IUSE}}
 <div class="metadata-section">
     <h3>USE Flags</h3>
+    <p>
+        Manage flags for this package:
+        <code>euse -i &lt;flag&gt; -p {{.Package.Category}}/{{.Package.Name}}</code> |
+        <code>euse -E &lt;flag&gt; -p {{.Package.Category}}/{{.Package.Name}}</code> |
+        <code>euse -D &lt;flag&gt; -p {{.Package.Category}}/{{.Package.Name}}</code>
+    </p>
     <div>
         {{range parseIUSEFlags .VersionData.Ebuild.Vars.IUSE}}
         <div class="iuse-flag">

--- a/templates/views/repo_package.html
+++ b/templates/views/repo_package.html
@@ -160,6 +160,12 @@
 {{if .Package.PkgUseFlags}}
 <div class="metadata-section">
     <h3>USE Flags</h3>
+    <p>
+        Manage flags for this package:
+        <code>euse -i &lt;flag&gt; -p {{.Package.Category}}/{{.Package.Name}}</code> |
+        <code>euse -E &lt;flag&gt; -p {{.Package.Category}}/{{.Package.Name}}</code> |
+        <code>euse -D &lt;flag&gt; -p {{.Package.Category}}/{{.Package.Name}}</code>
+    </p>
     <table>
         <tr>
             <th>Flag</th>

--- a/templates/views/repo_use.html
+++ b/templates/views/repo_use.html
@@ -8,6 +8,15 @@
     </form>
 </div>
 
+<div class="metadata-section">
+    <h3>Manage</h3>
+    <ul>
+        <li>Information: <code>euse -i {{.UseFlag.Name}}</code></li>
+        <li>Enable: <code>euse -E {{.UseFlag.Name}}</code></li>
+        <li>Disable: <code>euse -D {{.UseFlag.Name}}</code></li>
+    </ul>
+</div>
+
 {{if .UseFlag.GlobalDesc}}
 <div class="metadata-section">
     <h3>Global Description</h3>

--- a/templates/views/use.html
+++ b/templates/views/use.html
@@ -8,6 +8,15 @@
     </form>
 </div>
 
+<div class="metadata-section">
+    <h3>Manage</h3>
+    <ul>
+        <li>Information: <code>euse -i {{.UseFlag.Name}}</code></li>
+        <li>Enable: <code>euse -E {{.UseFlag.Name}}</code></li>
+        <li>Disable: <code>euse -D {{.UseFlag.Name}}</code></li>
+    </ul>
+</div>
+
 {{if .UseFlag.GlobalDesc}}
 <div class="metadata-section">
     <h3>Global Description</h3>


### PR DESCRIPTION
Adds `euse` hints on USE flag details pages as requested.

The changes add a 'Manage' section below the search bar on both the global and repository-specific USE flag views. This section provides the `euse -i`, `euse -E`, and `euse -D` commands pre-filled with the current USE flag's name, allowing users to easily copy-paste commands to inspect, enable, or disable the flag.

Testing included generating the static site against testdata, running Playwright UI verification to confirm layout and content, and executing the Go test suite.

---
*PR created automatically by Jules for task [6601518248721799393](https://jules.google.com/task/6601518248721799393) started by @arran4*