### PR TITLE
fix: display local/metadata descriptions for USE flags when global is missing

### DIFF
--- a/cmd/g2/agg_use_flag.go
+++ b/cmd/g2/agg_use_flag.go
@@ -1,0 +1,29 @@
+package main
+
+func (a *AggUseFlag) Desc() string {
+	if a.GlobalDesc != "" {
+		return a.GlobalDesc
+	}
+	descCounts := make(map[string]int)
+	for _, desc := range a.LocalDescs {
+		if desc != "" {
+			descCounts[desc]++
+		}
+	}
+	for _, desc := range a.MetadataDescs {
+		if desc != "" {
+			descCounts[desc]++
+		}
+	}
+	maxCount := 0
+	maxDesc := ""
+	for desc, count := range descCounts {
+		if count > maxCount {
+			maxCount = count
+			maxDesc = desc
+		} else if count == maxCount && desc < maxDesc { // break ties for deterministic output
+			maxDesc = desc
+		}
+	}
+	return maxDesc
+}

--- a/templates/views/repo_uses.html
+++ b/templates/views/repo_uses.html
@@ -3,7 +3,7 @@
     {{range .UseFlags}}
     <li>
         <a href="{{.Name}}/">{{.Name}}</a> - {{.Count}} package(s)
-        {{if .GlobalDesc}}<br><small>{{.GlobalDesc}}</small>{{end}}
+        {{if .Desc}}<br><small>{{.Desc}}</small>{{end}}
     </li>
     {{end}}
 </ul>

--- a/templates/views/uses.html
+++ b/templates/views/uses.html
@@ -3,7 +3,7 @@
     {{range .UseFlags}}
     <li>
         <a href="{{.Name}}/">{{.Name}}</a> - {{.Count}} package(s)
-        {{if .GlobalDesc}}<br><small>{{.GlobalDesc}}</small>{{end}}
+        {{if .Desc}}<br><small>{{.Desc}}</small>{{end}}
     </li>
     {{end}}
 </ul>


### PR DESCRIPTION
Fixes missing USE flag descriptions on the repository's USE flags list page (`/uses/`).

The templates previously used `{{.GlobalDesc}}`, which only displayed descriptions defined in `use.desc`. If a USE flag was only defined locally or in `metadata.xml`, its description was absent.

This PR introduces an `AggUseFlag.Desc()` method. If `GlobalDesc` is empty, this method falls back to the most frequently used description across all `LocalDescs` and `MetadataDescs`, ensuring users can see descriptions for locally-defined flags.

---
*PR created automatically by Jules for task [17854623698832951556](https://jules.google.com/task/17854623698832951556) started by @arran4*