### PR TITLE
feat: Add `g2 ebuild query` command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 - `doc/g2.1.md` is the canonical maintained man-page source. The generated `md2man` output is build/test output and should not be committed to the repository.
 - Man page updates should aim for actual man-page conventions (e.g., concise, declarative, no marketing bloat, using standard sections like NAME, SYNOPSIS, DESCRIPTION), not README-style feature dumping.
-- When adding or changing commands/features, agents must update:
+- When adding or changing commands/features (like touching subcommands), agents must update:
   - `doc/g2.1.md` to reflect the new functionality.
   - `readme.md` where appropriate.
 - Agents should inspect the real command tree using `go run ./cmd/g2 ...` to document commands accurately, rather than relying on stale markdown docs.
@@ -20,3 +20,6 @@
 - When adding new commands or features to the `g2` application, ensure that you update the `readme.md` file to reflect these additions. The `readme.md` should be considered the central reference for available commands, usage instructions, and examples.
 
 - There is a `g2 dev` subcommand tree specifically for ephemeral tools used by developers and agents (e.g. `g2 dev update-txtar-tests`). These commands do not need to be documented in `readme.md` and are for local utility purposes.
+
+## Adding or Changing Commands
+When adding or changing g2 commands, agents must inspect the actual command tree via the CLI (e.g., `go run ./cmd/g2 ...`) instead of relying on stale docs, and update both `readme.md` and the canonical man page source `doc/g2.1.md` using conventional man-page sections.

--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -26,6 +26,7 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 		fmt.Printf("\t\t %s \t\t %s\n", "templates", "Manage ebuild templates")
 		fmt.Printf("\t\t %s \t\t %s\n", "sh-parse-to-json", "Parse ebuild using shell parser and output JSON")
 		fmt.Printf("\t\t %s \t\t %s\n", "as-json", "Parse ebuild using native parser and output JSON")
+		fmt.Printf("\t\t %s \t\t %s\n", "query", "Query specific fields from parsed output")
 	}
 
 	config := &CmdEbuildArgConfig{
@@ -60,6 +61,10 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 	case "templates":
 		if err := config.cmdEbuildTemplates(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild templates: %w", err)
+		}
+	case "query":
+		if err := config.cmdEbuildQuery(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild query: %w", err)
 		}
 	case "help", "-help", "--help":
 		fs.Usage()
@@ -308,5 +313,67 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildAsJson(args []string) error {
 	}
 
 	fmt.Println(string(jsonBytes))
+	return nil
+}
+
+func (cfg *CmdEbuildArgConfig) cmdEbuildQuery(args []string) error {
+	fs := flag.NewFlagSet("query", flag.ExitOnError)
+	key := fs.String("key", "", "Key to query (e.g. EAPI, DESCRIPTION, IUSE, SRC_URI)")
+	format := fs.String("format", "", "Output format (e.g. lines)")
+
+	// Custom flag parsing to allow `<ebuild file>` before flags like `--key`
+	// Go's flag.Parse() stops at the first non-flag argument.
+	var flagArgs []string
+	var positionalArgs []string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "-") {
+			flagArgs = append(flagArgs, arg)
+			// Handle flag values that don't use '=' (e.g., --key EAPI instead of --key=EAPI)
+			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				flagArgs = append(flagArgs, args[i+1])
+				i++ // Skip the value in the next iteration
+			}
+		} else {
+			positionalArgs = append(positionalArgs, arg)
+		}
+	}
+
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+
+	if len(positionalArgs) != 1 {
+		return fmt.Errorf("usage: g2 ebuild query <ebuild file> --key <key> [--format lines]")
+	}
+
+	if *key == "" {
+		return fmt.Errorf("missing --key argument")
+	}
+
+	filename := positionalArgs[0]
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+
+	ebuild, err := g2.ParseEbuild(os.DirFS(dir), base, g2.ParseFull)
+	if err != nil {
+		return fmt.Errorf("parsing ebuild %s: %w", filename, err)
+	}
+
+	val, ok := ebuild.Vars[*key]
+	if !ok {
+		return nil
+	}
+
+	if *format == "lines" {
+		fields := strings.Fields(val)
+		for _, field := range fields {
+			fmt.Println(field)
+		}
+	} else {
+		fmt.Println(val)
+	}
+
 	return nil
 }

--- a/doc/g2.1.md
+++ b/doc/g2.1.md
@@ -63,6 +63,8 @@ Commands for manipulating and inspecting **.ebuild** files.
   Parses an ebuild using the shell parser and outputs JSON.
 - **as-json** *<ebuild_file>*
   Parses an ebuild natively into JSON format.
+- **query** *<ebuild_file>* `--key` *<key>* [`--format` *lines*]
+  Queries specific fields from a parsed ebuild output, rather than dumping the whole JSON.
 
 ## `overlay`
 Commands for managing a single overlay.

--- a/readme.md
+++ b/readme.md
@@ -151,8 +151,14 @@ g2 ebuild <subcommand>
 * `templates`: Manage ebuild templates.
 * `sh-parse-to-json <ebuild_file>`: Parse an ebuild using the shell parser and output JSON.
 * `as-json <ebuild_file>`: Parse an ebuild using the native parser and output JSON.
+* `query <ebuild_file> --key <key> [--format lines]`: Query specific fields from a parsed ebuild.
 
 **Example Usage:**
+
+Query a specific field from an ebuild:
+```bash
+g2 ebuild query my-package-1.0.ebuild --key SRC_URI --format lines
+```
 
 Parse an ebuild natively into JSON format:
 ```bash


### PR DESCRIPTION
Adds a new `g2 ebuild query` command that makes it easy for humans and tools to extract specific metadata variables from parsed ebuilds. Supports a `--format lines` flag to output space-separated values (like IUSE or SRC_URI) on separate lines.

---
*PR created automatically by Jules for task [6061686181371870464](https://jules.google.com/task/6061686181371870464) started by @arran4*