### PR TITLE
Add `ebuild explain` subcommand

### DIFF
--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -26,6 +27,7 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 		fmt.Printf("\t\t %s \t\t %s\n", "templates", "Manage ebuild templates")
 		fmt.Printf("\t\t %s \t\t %s\n", "sh-parse-to-json", "Parse ebuild using shell parser and output JSON")
 		fmt.Printf("\t\t %s \t\t %s\n", "as-json", "Parse ebuild using native parser and output JSON")
+		fmt.Printf("\t\t %s \t\t %s\n", "explain", "Human-readable summary output of an ebuild")
 	}
 
 	config := &CmdEbuildArgConfig{
@@ -56,6 +58,10 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 	case "sh-parse-to-json":
 		if err := config.cmdEbuildShParseToJson(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild sh-parse-to-json: %w", err)
+		}
+	case "explain":
+		if err := config.cmdEbuildExplain(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild explain: %w", err)
 		}
 	case "templates":
 		if err := config.cmdEbuildTemplates(fs.Args()[1:]); err != nil {
@@ -270,6 +276,121 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildShParseToJson(args []string) error {
 	}
 
 	fmt.Println(string(jsonBytes))
+	return nil
+}
+
+func (cfg *CmdEbuildArgConfig) cmdEbuildExplain(args []string) error {
+	fs := flag.NewFlagSet("explain", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: g2 ebuild explain <ebuild file>")
+	}
+	filename := fs.Arg(0)
+
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+
+	ebuild, err := g2.ParseEbuild(os.DirFS(dir), base, g2.ParseFull)
+	if err != nil {
+		return fmt.Errorf("parsing ebuild %s: %w", filename, err)
+	}
+
+	fmt.Printf("=== Package Metadata ===\n")
+	fmt.Printf("Name        : %s\n", ebuild.Vars["PN"])
+	fmt.Printf("Version     : %s\n", ebuild.Vars["PV"])
+	if desc, ok := ebuild.Vars["DESCRIPTION"]; ok && desc != "" {
+		fmt.Printf("Description : %s\n", desc)
+	}
+	if home, ok := ebuild.Vars["HOMEPAGE"]; ok && home != "" {
+		fmt.Printf("Homepage    : %s\n", home)
+	}
+	if eapi, ok := ebuild.Vars["EAPI"]; ok && eapi != "" {
+		fmt.Printf("EAPI        : %s\n", eapi)
+	}
+	fmt.Println()
+
+	fmt.Printf("=== Dependencies ===\n")
+	hasDeps := false
+	for _, depVar := range []string{"DEPEND", "RDEPEND", "BDEPEND", "PDEPEND"} {
+		if val, ok := ebuild.Vars[depVar]; ok && val != "" {
+			fmt.Printf("%s:\n", depVar)
+			// Indent slightly to read better
+			lines := strings.Split(val, "\n")
+			for _, line := range lines {
+				trimmed := strings.TrimSpace(line)
+				if trimmed != "" {
+					fmt.Printf("  %s\n", trimmed)
+				}
+			}
+			hasDeps = true
+		}
+	}
+	if !hasDeps {
+		fmt.Println("None")
+	}
+	fmt.Println()
+
+	fmt.Printf("=== Eclasses ===\n")
+	if inherited, ok := ebuild.Vars["INHERITED"]; ok && inherited != "" {
+		fmt.Println(inherited)
+	} else {
+		fmt.Println("None")
+	}
+	fmt.Println()
+
+	fmt.Printf("=== Phases Overridden ===\n")
+	if len(ebuild.Functions) > 0 {
+		var funcs []string
+		for f := range ebuild.Functions {
+			funcs = append(funcs, f)
+		}
+		sort.Strings(funcs)
+		for _, f := range funcs {
+			fmt.Println(f)
+		}
+	} else {
+		fmt.Println("None")
+	}
+	fmt.Println()
+
+	fmt.Printf("=== Fetch Sources ===\n")
+	if len(ebuild.SrcUri) > 0 {
+		for _, u := range ebuild.SrcUri {
+			if u.Filename != "" && u.Filename != filepath.Base(u.URL) {
+				fmt.Printf("%s -> %s\n", u.URL, u.Filename)
+			} else {
+				fmt.Println(u.URL)
+			}
+		}
+	} else if srcUri, ok := ebuild.Vars["SRC_URI"]; ok && srcUri != "" {
+		lines := strings.Split(srcUri, "\n")
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" {
+				fmt.Println(trimmed)
+			}
+		}
+	} else {
+		fmt.Println("None")
+	}
+	fmt.Println()
+
+	fmt.Printf("=== Keywords / License / Slot ===\n")
+	if kw, ok := ebuild.Vars["KEYWORDS"]; ok && kw != "" {
+		fmt.Printf("KEYWORDS : %s\n", kw)
+	}
+	if lic, ok := ebuild.Vars["LICENSE"]; ok && lic != "" {
+		fmt.Printf("LICENSE  : %s\n", lic)
+	}
+	if slot, ok := ebuild.Vars["SLOT"]; ok && slot != "" {
+		fmt.Printf("SLOT     : %s\n", slot)
+	}
+	if iuse, ok := ebuild.Vars["IUSE"]; ok && iuse != "" {
+		fmt.Printf("IUSE     : %s\n", iuse)
+	}
+
 	return nil
 }
 func (cfg *CmdEbuildArgConfig) cmdEbuildAsJson(args []string) error {

--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -279,7 +280,15 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildShParseToJson(args []string) error {
 	return nil
 }
 
-func (cfg *CmdEbuildArgConfig) cmdEbuildExplain(args []string) error {
+func (cfg *CmdEbuildArgConfig) cmdEbuildExplain(args []string, opts ...any) error {
+	var out io.Writer = os.Stdout
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case io.Writer:
+			out = o
+		}
+	}
+
 	fs := flag.NewFlagSet("explain", flag.ExitOnError)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -297,50 +306,50 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildExplain(args []string) error {
 		return fmt.Errorf("parsing ebuild %s: %w", filename, err)
 	}
 
-	fmt.Printf("=== Package Metadata ===\n")
-	fmt.Printf("Name        : %s\n", ebuild.Vars["PN"])
-	fmt.Printf("Version     : %s\n", ebuild.Vars["PV"])
+	fmt.Fprintf(out, "=== Package Metadata ===\n")
+	fmt.Fprintf(out, "Name        : %s\n", ebuild.Vars["PN"])
+	fmt.Fprintf(out, "Version     : %s\n", ebuild.Vars["PV"])
 	if desc, ok := ebuild.Vars["DESCRIPTION"]; ok && desc != "" {
-		fmt.Printf("Description : %s\n", desc)
+		fmt.Fprintf(out, "Description : %s\n", desc)
 	}
 	if home, ok := ebuild.Vars["HOMEPAGE"]; ok && home != "" {
-		fmt.Printf("Homepage    : %s\n", home)
+		fmt.Fprintf(out, "Homepage    : %s\n", home)
 	}
 	if eapi, ok := ebuild.Vars["EAPI"]; ok && eapi != "" {
-		fmt.Printf("EAPI        : %s\n", eapi)
+		fmt.Fprintf(out, "EAPI        : %s\n", eapi)
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 
-	fmt.Printf("=== Dependencies ===\n")
+	fmt.Fprintf(out, "=== Dependencies ===\n")
 	hasDeps := false
 	for _, depVar := range []string{"DEPEND", "RDEPEND", "BDEPEND", "PDEPEND"} {
 		if val, ok := ebuild.Vars[depVar]; ok && val != "" {
-			fmt.Printf("%s:\n", depVar)
+			fmt.Fprintf(out, "%s:\n", depVar)
 			// Indent slightly to read better
 			lines := strings.Split(val, "\n")
 			for _, line := range lines {
 				trimmed := strings.TrimSpace(line)
 				if trimmed != "" {
-					fmt.Printf("  %s\n", trimmed)
+					fmt.Fprintf(out, "  %s\n", trimmed)
 				}
 			}
 			hasDeps = true
 		}
 	}
 	if !hasDeps {
-		fmt.Println("None")
+		fmt.Fprintln(out, "None")
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 
-	fmt.Printf("=== Eclasses ===\n")
+	fmt.Fprintf(out, "=== Eclasses ===\n")
 	if inherited, ok := ebuild.Vars["INHERITED"]; ok && inherited != "" {
-		fmt.Println(inherited)
+		fmt.Fprintln(out, inherited)
 	} else {
-		fmt.Println("None")
+		fmt.Fprintln(out, "None")
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 
-	fmt.Printf("=== Phases Overridden ===\n")
+	fmt.Fprintf(out, "=== Phases Overridden ===\n")
 	if len(ebuild.Functions) > 0 {
 		var funcs []string
 		for f := range ebuild.Functions {
@@ -348,20 +357,20 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildExplain(args []string) error {
 		}
 		sort.Strings(funcs)
 		for _, f := range funcs {
-			fmt.Println(f)
+			fmt.Fprintln(out, f)
 		}
 	} else {
-		fmt.Println("None")
+		fmt.Fprintln(out, "None")
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 
-	fmt.Printf("=== Fetch Sources ===\n")
+	fmt.Fprintf(out, "=== Fetch Sources ===\n")
 	if len(ebuild.SrcUri) > 0 {
 		for _, u := range ebuild.SrcUri {
 			if u.Filename != "" && u.Filename != filepath.Base(u.URL) {
-				fmt.Printf("%s -> %s\n", u.URL, u.Filename)
+				fmt.Fprintf(out, "%s -> %s\n", u.URL, u.Filename)
 			} else {
-				fmt.Println(u.URL)
+				fmt.Fprintln(out, u.URL)
 			}
 		}
 	} else if srcUri, ok := ebuild.Vars["SRC_URI"]; ok && srcUri != "" {
@@ -369,26 +378,26 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildExplain(args []string) error {
 		for _, line := range lines {
 			trimmed := strings.TrimSpace(line)
 			if trimmed != "" {
-				fmt.Println(trimmed)
+				fmt.Fprintln(out, trimmed)
 			}
 		}
 	} else {
-		fmt.Println("None")
+		fmt.Fprintln(out, "None")
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 
-	fmt.Printf("=== Keywords / License / Slot ===\n")
+	fmt.Fprintf(out, "=== Keywords / License / Slot ===\n")
 	if kw, ok := ebuild.Vars["KEYWORDS"]; ok && kw != "" {
-		fmt.Printf("KEYWORDS : %s\n", kw)
+		fmt.Fprintf(out, "KEYWORDS : %s\n", kw)
 	}
 	if lic, ok := ebuild.Vars["LICENSE"]; ok && lic != "" {
-		fmt.Printf("LICENSE  : %s\n", lic)
+		fmt.Fprintf(out, "LICENSE  : %s\n", lic)
 	}
 	if slot, ok := ebuild.Vars["SLOT"]; ok && slot != "" {
-		fmt.Printf("SLOT     : %s\n", slot)
+		fmt.Fprintf(out, "SLOT     : %s\n", slot)
 	}
 	if iuse, ok := ebuild.Vars["IUSE"]; ok && iuse != "" {
-		fmt.Printf("IUSE     : %s\n", iuse)
+		fmt.Fprintf(out, "IUSE     : %s\n", iuse)
 	}
 
 	return nil

--- a/cmd/g2/ebuild_explain_test.go
+++ b/cmd/g2/ebuild_explain_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/txtar"
+)
+
+func TestEbuildExplainCommand(t *testing.T) {
+	fixturePath := "testdata/ebuild-explain-basic.txtar"
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", fixturePath, err)
+	}
+
+	ar := txtar.Parse(raw)
+
+	tmpDir, err := os.MkdirTemp("", "ebuild-explain-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var ebuildFile string
+	var expectedOutput string
+	for _, f := range ar.Files {
+		if strings.HasSuffix(f.Name, ".ebuild") {
+			ebuildFile = filepath.Join(tmpDir, f.Name)
+			err := os.WriteFile(ebuildFile, f.Data, 0644)
+			if err != nil {
+				t.Fatalf("failed to write %s: %v", f.Name, err)
+			}
+		} else if f.Name == "expected.txt" {
+			expectedOutput = string(f.Data)
+		}
+	}
+
+	if ebuildFile == "" {
+		t.Fatalf("no ebuild file found in fixture")
+	}
+
+	cfg := &MainArgConfig{
+		Args: []string{"g2"},
+	}
+
+	cmdCfg := &CmdEbuildArgConfig{
+		MainArgConfig: cfg,
+	}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = cmdCfg.cmdEbuildExplain([]string{ebuildFile})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("cmdEbuildExplain failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	gotOutput := buf.String()
+
+	if strings.TrimSpace(gotOutput) != strings.TrimSpace(expectedOutput) {
+		t.Errorf("output mismatch.\nwant:\n%s\ngot:\n%s", expectedOutput, gotOutput)
+	}
+}

--- a/cmd/g2/ebuild_explain_test.go
+++ b/cmd/g2/ebuild_explain_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,22 +51,13 @@ func TestEbuildExplainCommand(t *testing.T) {
 		MainArgConfig: cfg,
 	}
 
-	// Capture stdout
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err = cmdCfg.cmdEbuildExplain([]string{ebuildFile})
-
-	w.Close()
-	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	err = cmdCfg.cmdEbuildExplain([]string{ebuildFile}, &buf)
 
 	if err != nil {
 		t.Fatalf("cmdEbuildExplain failed: %v", err)
 	}
 
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
 	gotOutput := buf.String()
 
 	if strings.TrimSpace(gotOutput) != strings.TrimSpace(expectedOutput) {

--- a/cmd/g2/testdata/ebuild-explain-basic.txtar
+++ b/cmd/g2/testdata/ebuild-explain-basic.txtar
@@ -1,0 +1,73 @@
+test: ebuild explain command on a basic ebuild
+
+-- testpkg-1.0.ebuild --
+EAPI=8
+
+DESCRIPTION="Test Package 1.0"
+HOMEPAGE="https://example.com/testpkg"
+SRC_URI="https://example.com/testpkg-1.0.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test doc"
+
+DEPEND="dev-libs/libfoo
+    test? ( dev-util/testframework )"
+RDEPEND="${DEPEND}
+    sys-apps/sed"
+BDEPEND="virtual/pkgconfig"
+
+inherit git-r3
+
+pkg_setup() {
+    echo "setup"
+}
+
+src_unpack() {
+    git-r3_src_unpack
+}
+
+src_compile() {
+    emake
+}
+
+src_install() {
+    emake DESTDIR="${D}" install
+}
+-- expected.txt --
+=== Package Metadata ===
+Name        : testpkg
+Version     : 1.0
+Description : Test Package 1.0
+Homepage    : https://example.com/testpkg
+EAPI        : 8
+
+=== Dependencies ===
+DEPEND:
+  dev-libs/libfoo
+  test? ( dev-util/testframework )
+RDEPEND:
+  dev-libs/libfoo
+  test? ( dev-util/testframework )
+  sys-apps/sed
+BDEPEND:
+  virtual/pkgconfig
+
+=== Eclasses ===
+git-r3
+
+=== Phases Overridden ===
+pkg_setup
+src_compile
+src_install
+src_unpack
+
+=== Fetch Sources ===
+https://example.com/testpkg-1.0.tar.gz
+
+=== Keywords / License / Slot ===
+KEYWORDS : ~amd64 ~x86
+LICENSE  : GPL-2
+SLOT     : 0
+IUSE     : test doc

--- a/doc/g2.1.md
+++ b/doc/g2.1.md
@@ -63,6 +63,8 @@ Commands for manipulating and inspecting **.ebuild** files.
   Parses an ebuild using the shell parser and outputs JSON.
 - **as-json** *<ebuild_file>*
   Parses an ebuild natively into JSON format.
+- **explain** *<ebuild_file>*
+  Output a human-readable summary of an ebuild.
 
 ## `overlay`
 Commands for managing a single overlay.

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ g2 ebuild <subcommand>
 * `templates`: Manage ebuild templates.
 * `sh-parse-to-json <ebuild_file>`: Parse an ebuild using the shell parser and output JSON.
 * `as-json <ebuild_file>`: Parse an ebuild using the native parser and output JSON.
+* `explain <ebuild_file>`: Output a human-readable summary of an ebuild.
 
 **Example Usage:**
 

--- a/testdata/test-overlay/sys-apps/testpkg/testpkg-2.0.ebuild
+++ b/testdata/test-overlay/sys-apps/testpkg/testpkg-2.0.ebuild
@@ -1,1 +1,34 @@
-KEYWORDS="amd64 ~x86"
+EAPI=8
+
+DESCRIPTION="Test Package 2.0"
+HOMEPAGE="https://example.com/testpkg"
+SRC_URI="https://example.com/testpkg-2.0.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test doc"
+
+DEPEND="dev-libs/libfoo
+    test? ( dev-util/testframework )"
+RDEPEND="${DEPEND}
+    sys-apps/sed"
+BDEPEND="virtual/pkgconfig"
+
+inherit git-r3
+
+pkg_setup() {
+    echo "setup"
+}
+
+src_unpack() {
+    git-r3_src_unpack
+}
+
+src_compile() {
+    emake
+}
+
+src_install() {
+    emake DESTDIR="${D}" install
+}


### PR DESCRIPTION
Added `ebuild explain` subcommand to `g2 ebuild` which provides a nicely structured human-readable textual output of an ebuild's contents.

---
*PR created automatically by Jules for task [2106719698026508891](https://jules.google.com/task/2106719698026508891) started by @arran4*