### PR TITLE
feat: add g2 ebuild diff-json subcommand

### DIFF
--- a/cmd/g2/diff_json.go
+++ b/cmd/g2/diff_json.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/arran4/g2"
+)
+
+func (cfg *CmdEbuildArgConfig) cmdEbuildDiffJson(args []string) error {
+	fs := flag.NewFlagSet("diff-json", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: g2 ebuild diff-json <ebuild file>")
+	}
+	filename := fs.Arg(0)
+
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+
+	// parse with sh-parse-to-json
+	shEbuild, err := g2.ParseEbuild(os.DirFS(dir), base, g2.ParseVariables)
+	if err != nil {
+		return fmt.Errorf("parsing ebuild with shell parser %s: %w", filename, err)
+	}
+
+	// parse with as-json
+	nativeEbuild, err := g2.ParseEbuild(os.DirFS(dir), base, g2.ParseFull)
+	if err != nil {
+		return fmt.Errorf("parsing ebuild with native parser %s: %w", filename, err)
+	}
+
+	// Let's create a map of keys that are present in either parsing method
+	allKeys := make(map[string]bool)
+	for k := range shEbuild.Vars {
+		allKeys[k] = true
+	}
+	for k := range nativeEbuild.Vars {
+		allKeys[k] = true
+	}
+
+	type DiffEntry struct {
+		Key       string `json:"key"`
+		ShVal     string `json:"sh_val,omitempty"`
+		NativeVal string `json:"native_val,omitempty"`
+		Matches   bool   `json:"matches"`
+	}
+
+	var diffs []DiffEntry
+
+	var sortedKeys []string
+	for k := range allKeys {
+		sortedKeys = append(sortedKeys, k)
+	}
+
+	// Sort keys to ensure deterministic output
+	sort.Strings(sortedKeys)
+
+	for _, k := range sortedKeys {
+		shVal := shEbuild.Vars[k]
+		nativeVal := nativeEbuild.Vars[k]
+
+		matches := shVal == nativeVal
+		diffs = append(diffs, DiffEntry{
+			Key:       k,
+			ShVal:     shVal,
+			NativeVal: nativeVal,
+			Matches:   matches,
+		})
+	}
+
+	jsonBytes, err := json.MarshalIndent(diffs, "", "\t")
+	if err != nil {
+		return fmt.Errorf("serializing diff to json: %w", err)
+	}
+
+	fmt.Println(string(jsonBytes))
+
+	return nil
+}

--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -26,6 +26,7 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 		fmt.Printf("\t\t %s \t\t %s\n", "templates", "Manage ebuild templates")
 		fmt.Printf("\t\t %s \t\t %s\n", "sh-parse-to-json", "Parse ebuild using shell parser and output JSON")
 		fmt.Printf("\t\t %s \t\t %s\n", "as-json", "Parse ebuild using native parser and output JSON")
+		fmt.Printf("\t\t %s \t\t %s\n", "diff-json", "Compare output of native and shell parsers")
 	}
 
 	config := &CmdEbuildArgConfig{
@@ -52,6 +53,10 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 	case "as-json":
 		if err := config.cmdEbuildAsJson(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild as-json: %w", err)
+		}
+	case "diff-json":
+		if err := config.cmdEbuildDiffJson(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild diff-json: %w", err)
 		}
 	case "sh-parse-to-json":
 		if err := config.cmdEbuildShParseToJson(fs.Args()[1:]); err != nil {


### PR DESCRIPTION
Adds `g2 ebuild diff-json` subcommand. This addresses the request for a `diff-json` command to serve as the highest leverage next step in validating the native ebuild parser. Output is deterministically sorted JSON.

---
*PR created automatically by Jules for task [6014897065372844077](https://jules.google.com/task/6014897065372844077) started by @arran4*