### PR TITLE
feat: display defined phase functions in ebuild details

### DIFF
--- a/ebuild.go
+++ b/ebuild.go
@@ -62,6 +62,16 @@ type funcEntry struct {
 	Value AST
 }
 
+// FuncNames returns a sorted list of all defined function names in the ebuild.
+func (e *Ebuild) FuncNames() []string {
+	var names []string
+	for k := range e.Functions {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func (e *Ebuild) String() string {
 	// Reconstruct a valid-ish ebuild
 	// Since we don't preserve the whole file, we reconstruct what we know.

--- a/templates/views/ebuild_details.html
+++ b/templates/views/ebuild_details.html
@@ -88,6 +88,15 @@
             <td>{{.VersionData.Ebuild.Vars.SLOT}}</td>
         </tr>
     </table>
+    {{$funcNames := .VersionData.Ebuild.FuncNames}}
+    {{if $funcNames}}
+    <h4>Defined Functions</h4>
+    <ul>
+        {{range $funcNames}}
+        <li><code>{{.}}</code></li>
+        {{end}}
+    </ul>
+    {{end}}
 </div>
 
 {{if not .VersionData.EbuildRawURL}}


### PR DESCRIPTION
- Added `FuncNames()` method to `Ebuild` struct to extract and sort function names.
- Updated `ebuild_details.html` to display the list of defined phase functions.

---
*PR created automatically by Jules for task [8415444672115278388](https://jules.google.com/task/8415444672115278388) started by @arran4*