### PR TITLE
feat(ebuild): add `deps` subcommand to extract dependency fields

### DIFF
--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -26,6 +26,7 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 		fmt.Printf("\t\t %s \t\t %s\n", "templates", "Manage ebuild templates")
 		fmt.Printf("\t\t %s \t\t %s\n", "sh-parse-to-json", "Parse ebuild using shell parser and output JSON")
 		fmt.Printf("\t\t %s \t\t %s\n", "as-json", "Parse ebuild using native parser and output JSON")
+		fmt.Printf("\t\t %s \t\t %s\n", "deps", "Extract and format dependency fields")
 	}
 
 	config := &CmdEbuildArgConfig{
@@ -60,6 +61,10 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 	case "templates":
 		if err := config.cmdEbuildTemplates(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild templates: %w", err)
+		}
+	case "deps":
+		if err := config.cmdEbuildDeps(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild deps: %w", err)
 		}
 	case "help", "-help", "--help":
 		fs.Usage()
@@ -270,6 +275,152 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildShParseToJson(args []string) error {
 	}
 
 	fmt.Println(string(jsonBytes))
+	return nil
+}
+
+type DepNodeJSON struct {
+	Type      string         `json:"type"`
+	Value     string         `json:"value,omitempty"`
+	Flag      string         `json:"flag,omitempty"`
+	IsNegated bool           `json:"is_negated,omitempty"`
+	Children  []*DepNodeJSON `json:"children,omitempty"`
+}
+
+func convertDepNodeToJSON(node g2.DepNode) *DepNodeJSON {
+	switch n := node.(type) {
+	case g2.DepString:
+		return &DepNodeJSON{Type: "string", Value: string(n)}
+	case g2.DepAnyOf:
+		var children []*DepNodeJSON
+		for _, c := range n.Children {
+			children = append(children, convertDepNodeToJSON(c))
+		}
+		return &DepNodeJSON{Type: "any-of", Children: children}
+	case g2.DepAllOf:
+		var children []*DepNodeJSON
+		for _, c := range n.Children {
+			children = append(children, convertDepNodeToJSON(c))
+		}
+		return &DepNodeJSON{Type: "all-of", Children: children}
+	case g2.DepUseConditional:
+		var children []*DepNodeJSON
+		for _, c := range n.Children {
+			children = append(children, convertDepNodeToJSON(c))
+		}
+		return &DepNodeJSON{Type: "use-conditional", Flag: n.Flag, IsNegated: n.IsNegated, Children: children}
+	}
+	return nil
+}
+
+func (cfg *CmdEbuildArgConfig) cmdEbuildDeps(args []string) error {
+	fs := flag.NewFlagSet("deps", flag.ExitOnError)
+	flatten := fs.Bool("flatten", false, "Flatten dependency trees into a list")
+	atomsOnly := fs.Bool("atoms-only", false, "Extract only package atoms without operators (e.g. dev-libs/foo instead of >=dev-libs/foo-1.2.3)")
+	jsonOutput := fs.Bool("json", false, "Output results in JSON format")
+	onePerLine := fs.Bool("one-per-line", false, "Output each dependency on a new line (only applies to text output)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
+		return fmt.Errorf("usage: g2 ebuild deps [flags] <ebuild files...>")
+	}
+
+	depFields := []string{"DEPEND", "RDEPEND", "BDEPEND", "PDEPEND", "IDEPEND"}
+
+	// To structure JSON across files
+	type FileDeps struct {
+		File string         `json:"file"`
+		Deps map[string]any `json:"deps"`
+	}
+	var allFilesDeps []FileDeps
+
+	for _, filename := range fs.Args() {
+		dir := filepath.Dir(filename)
+		base := filepath.Base(filename)
+
+		ebuild, err := g2.ParseEbuild(os.DirFS(dir), base, g2.ParseVariables)
+		if err != nil {
+			log.Printf("failed to parse %s: %v", filename, err)
+			continue
+		}
+
+		fileDeps := FileDeps{
+			File: filename,
+			Deps: make(map[string]any),
+		}
+
+		for _, field := range depFields {
+			val := ebuild.Vars[field]
+			if val == "" {
+				continue
+			}
+
+			if *flatten {
+				tree := g2.ParseDepTree(val)
+				flatDeps, err := tree.Evaluate(g2.IgnoreUseFlags(true))
+				if err != nil {
+					log.Printf("error evaluating %s in %s: %v", field, filename, err)
+					continue
+				}
+
+				if *atomsOnly {
+					for i, d := range flatDeps {
+						flatDeps[i] = g2.ExtractPackageNameFromDep(d)
+					}
+				}
+
+				if *jsonOutput {
+					fileDeps.Deps[field] = flatDeps
+				} else {
+					if *onePerLine {
+						fmt.Printf("### %s - %s\n", filename, field)
+						for _, d := range flatDeps {
+							fmt.Println(d)
+						}
+						fmt.Println()
+					} else {
+						fmt.Printf("### %s - %s\n%s\n\n", filename, field, strings.Join(flatDeps, " "))
+					}
+				}
+			} else {
+				if *jsonOutput {
+					tree := g2.ParseDepTree(val)
+					var children []*DepNodeJSON
+					for _, n := range tree.Nodes {
+						children = append(children, convertDepNodeToJSON(n))
+					}
+					fileDeps.Deps[field] = children
+				} else {
+					if *onePerLine {
+						// For raw string output, splitting by space is a naive approach,
+						// but since users requested one-per-line for standard format,
+						// printing evaluated/flattened is better, or splitting the raw string.
+						fmt.Printf("### %s - %s\n", filename, field)
+						for _, token := range strings.Fields(val) {
+							fmt.Println(token)
+						}
+						fmt.Println()
+					} else {
+						fmt.Printf("### %s - %s\n%s\n\n", filename, field, val)
+					}
+				}
+			}
+		}
+
+		if *jsonOutput {
+			allFilesDeps = append(allFilesDeps, fileDeps)
+		}
+	}
+
+	if *jsonOutput {
+		out, err := json.MarshalIndent(allFilesDeps, "", "\t")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(out))
+	}
+
 	return nil
 }
 func (cfg *CmdEbuildArgConfig) cmdEbuildAsJson(args []string) error {

--- a/cmd/g2/ebuild_deps_test.go
+++ b/cmd/g2/ebuild_deps_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/txtar"
+)
+
+//go:embed testdata/deps/*.txtar
+var depsTestFS embed.FS
+
+type depsTestOptions struct {
+	Args []string `json:"args"`
+}
+
+func TestEbuildDeps(t *testing.T) {
+	entries, err := fs.Glob(depsTestFS, "testdata/deps/*.txtar")
+	if err != nil {
+		t.Fatalf("glob fixtures: %v", err)
+	}
+
+	for _, fixture := range entries {
+		fixture := fixture
+		t.Run(strings.TrimSuffix(path.Base(fixture), ".txtar"), func(t *testing.T) {
+			raw, err := depsTestFS.ReadFile(fixture)
+			if err != nil {
+				t.Fatalf("read fixture %s: %v", fixture, err)
+			}
+			ar := txtar.Parse(raw)
+
+			inputFS, expectedFS := SplitInputExpected(ar)
+
+			// read options if any
+			var opts depsTestOptions
+			for _, f := range ar.Files {
+				if f.Name == "options.json" {
+					if err := json.Unmarshal(f.Data, &opts); err != nil {
+						t.Fatalf("unmarshal options.json: %v", err)
+					}
+					break
+				}
+			}
+
+			// write inputFS to a temp directory because our command logic relies on real files via flag.Args()
+			tmpDir := t.TempDir()
+			inputFiles, _ := WalkFiles(inputFS, ".")
+			var ebuildFiles []string
+			for _, name := range inputFiles {
+				data, _ := fs.ReadFile(inputFS, name)
+				fpath := filepath.Join(tmpDir, name)
+				_ = os.MkdirAll(filepath.Dir(fpath), 0755)
+				_ = os.WriteFile(fpath, data, 0644)
+				if strings.HasSuffix(name, ".ebuild") {
+					ebuildFiles = append(ebuildFiles, fpath)
+				}
+			}
+
+			// run the command logic intercepting stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			// Because cmdEbuildDeps is a method on CmdEbuildArgConfig
+			// We can initialize it
+			cfg := &CmdEbuildArgConfig{
+				MainArgConfig: &MainArgConfig{},
+			}
+
+			// append ebuilds to arguments
+			args := append(opts.Args, ebuildFiles...)
+
+			err = cfg.cmdEbuildDeps(args)
+
+			// restore stdout and read result
+			_ = w.Close()
+			os.Stdout = oldStdout
+
+			var outBuf bytes.Buffer
+			_, _ = io.Copy(&outBuf, r)
+			got := outBuf.String()
+
+			if err != nil {
+				t.Fatalf("cmdEbuildDeps error: %v", err)
+			}
+
+			// Compare against expected
+			wantFiles, _ := WalkFiles(expectedFS, ".")
+			if len(wantFiles) == 0 {
+				t.Fatalf("no expected files found in fixture")
+			}
+
+			// We only expect one output file in these simple tests
+			wantName := wantFiles[0]
+			wantData, _ := fs.ReadFile(expectedFS, wantName)
+			want := string(wantData)
+
+			// Fix path differences
+			// Our output prints the full temporary path when we pass temporary file path.
+			// But the expected output has the base name.
+			got = strings.ReplaceAll(got, tmpDir + string(filepath.Separator), "")
+
+			if strings.TrimSpace(got) != strings.TrimSpace(want) {
+				t.Errorf("mismatch\nwant:\n%s\n\ngot:\n%s\n", want, got)
+			}
+		})
+	}
+}

--- a/cmd/g2/testdata/deps/basic-flattened.txtar
+++ b/cmd/g2/testdata/deps/basic-flattened.txtar
@@ -1,0 +1,27 @@
+test: flatten atoms only with simple dependencies
+
+-- input/test.ebuild --
+EAPI=8
+DEPEND="dev-libs/foo dev-libs/bar[use]"
+RDEPEND=">=dev-libs/foo-1.2.3"
+BDEPEND="virtual/pkgconfig"
+PDEPEND="sys-apps/baz"
+IDEPEND="sys-apps/qux"
+-- options.json --
+{"args": ["--flatten", "--atoms-only", "--one-per-line"]}
+-- expected/out.txt --
+### test.ebuild - DEPEND
+dev-libs/foo
+dev-libs/bar
+
+### test.ebuild - RDEPEND
+dev-libs/foo
+
+### test.ebuild - BDEPEND
+virtual/pkgconfig
+
+### test.ebuild - PDEPEND
+sys-apps/baz
+
+### test.ebuild - IDEPEND
+sys-apps/qux

--- a/cmd/g2/testdata/deps/conditionals-flattened.txtar
+++ b/cmd/g2/testdata/deps/conditionals-flattened.txtar
@@ -1,0 +1,11 @@
+test: flatten atoms only with conditionals
+
+-- input/test.ebuild --
+EAPI=8
+DEPEND="flag? ( dev-libs/foo ) !flag? ( dev-libs/bar )"
+-- options.json --
+{"args": ["--flatten", "--atoms-only", "--one-per-line"]}
+-- expected/out.txt --
+### test.ebuild - DEPEND
+dev-libs/foo
+dev-libs/bar

--- a/cmd/g2/testdata/deps/json-unflattened.txtar
+++ b/cmd/g2/testdata/deps/json-unflattened.txtar
@@ -2,7 +2,7 @@ test: output structured JSON
 
 -- input/test.ebuild --
 EAPI=8
-DEPEND="dev-libs/foo || ( dev-libs/bar dev-libs/baz )"
+DEPEND="dev-libs/foo || ( dev-libs/bar dev-libs/baz ) flag? ( dev-libs/qux )"
 -- options.json --
 {"args": ["--json"]}
 -- expected/out.txt --
@@ -25,6 +25,16 @@ DEPEND="dev-libs/foo || ( dev-libs/bar dev-libs/baz )"
 						{
 							"type": "string",
 							"value": "dev-libs/baz"
+						}
+					]
+				},
+				{
+					"type": "use-conditional",
+					"flag": "flag",
+					"children": [
+						{
+							"type": "string",
+							"value": "dev-libs/qux"
 						}
 					]
 				}

--- a/cmd/g2/testdata/deps/json-unflattened.txtar
+++ b/cmd/g2/testdata/deps/json-unflattened.txtar
@@ -1,0 +1,34 @@
+test: output structured JSON
+
+-- input/test.ebuild --
+EAPI=8
+DEPEND="dev-libs/foo || ( dev-libs/bar dev-libs/baz )"
+-- options.json --
+{"args": ["--json"]}
+-- expected/out.txt --
+[
+	{
+		"file": "test.ebuild",
+		"deps": {
+			"DEPEND": [
+				{
+					"type": "string",
+					"value": "dev-libs/foo"
+				},
+				{
+					"type": "any-of",
+					"children": [
+						{
+							"type": "string",
+							"value": "dev-libs/bar"
+						},
+						{
+							"type": "string",
+							"value": "dev-libs/baz"
+						}
+					]
+				}
+			]
+		}
+	}
+]


### PR DESCRIPTION
Adds a new `deps` subcommand to the `g2 ebuild` tool to allow users to extract and analyze package dependencies. Users can provide one or more ebuild files, and the command parses their dependency variables. Flags provide extensive control over the output format (flattened strings, package atoms only, structured JSON).

---
*PR created automatically by Jules for task [11264589494908663200](https://jules.google.com/task/11264589494908663200) started by @arran4*