### PR TITLE
feat(cli): add `ebuild diff-json` subcommand

### DIFF
--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -24,6 +25,7 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 		fmt.Printf("\t%s\n", strings.Join(cfg.Args, " "))
 		fmt.Printf("\t\t %s \t\t %s\n", "init", "Initialize an ebuild from a template")
 		fmt.Printf("\t\t %s \t\t %s\n", "templates", "Manage ebuild templates")
+		fmt.Printf("\t\t %s \t\t %s\n", "diff-json", "Compare as-json vs sh-parse-to-json and output semantic differences")
 		fmt.Printf("\t\t %s \t\t %s\n", "sh-parse-to-json", "Parse ebuild using shell parser and output JSON")
 		fmt.Printf("\t\t %s \t\t %s\n", "as-json", "Parse ebuild using native parser and output JSON")
 	}
@@ -56,6 +58,10 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 	case "sh-parse-to-json":
 		if err := config.cmdEbuildShParseToJson(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild sh-parse-to-json: %w", err)
+		}
+	case "diff-json":
+		if err := config.cmdEbuildDiffJson(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild diff-json: %w", err)
 		}
 	case "templates":
 		if err := config.cmdEbuildTemplates(fs.Args()[1:]); err != nil {
@@ -303,6 +309,93 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildAsJson(args []string) error {
 		jsonBytes, err = json.MarshalIndent(ebuilds, "", "\t")
 	}
 
+	if err != nil {
+		return fmt.Errorf("serializing to json: %w", err)
+	}
+
+	fmt.Println(string(jsonBytes))
+	return nil
+}
+
+func (cfg *CmdEbuildArgConfig) cmdEbuildDiffJson(args []string) error {
+	fs := flag.NewFlagSet("diff-json", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: g2 ebuild diff-json <ebuild file>")
+	}
+	filename := fs.Arg(0)
+
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+
+	ebuildSh, err := g2.ParseEbuild(os.DirFS(dir), base, g2.ParseVariables)
+	if err != nil {
+		return fmt.Errorf("parsing ebuild using shell parser %s: %w", filename, err)
+	}
+
+	ebuildAs, err := g2.ParseEbuild(os.DirFS(dir), base, g2.ParseFull)
+	if err != nil {
+		return fmt.Errorf("parsing ebuild using native parser %s: %w", filename, err)
+	}
+
+	type DiffResult struct {
+		Key       string      `json:"key"`
+		ShValue   interface{} `json:"sh_value"`
+		AsValue   interface{} `json:"as_value"`
+		Difference string     `json:"difference"`
+	}
+
+	diffs := make([]DiffResult, 0)
+
+	// Compare Vars
+	allKeys := make(map[string]bool)
+	for k := range ebuildSh.Vars {
+		allKeys[k] = true
+	}
+	for k := range ebuildAs.Vars {
+		allKeys[k] = true
+	}
+
+	// Sort keys for deterministic output
+	var sortedKeys []string
+	for k := range allKeys {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	for _, k := range sortedKeys {
+		vSh, okSh := ebuildSh.Vars[k]
+		vAs, okAs := ebuildAs.Vars[k]
+
+		if okSh && okAs {
+			if vSh != vAs {
+				diffs = append(diffs, DiffResult{
+					Key:        k,
+					ShValue:    vSh,
+					AsValue:    vAs,
+					Difference: "value_mismatch",
+				})
+			}
+		} else if okSh {
+			diffs = append(diffs, DiffResult{
+				Key:        k,
+				ShValue:    vSh,
+				AsValue:    nil,
+				Difference: "missing_in_as",
+			})
+		} else if okAs {
+			diffs = append(diffs, DiffResult{
+				Key:        k,
+				ShValue:    nil,
+				AsValue:    vAs,
+				Difference: "missing_in_sh",
+			})
+		}
+	}
+
+	jsonBytes, err := json.MarshalIndent(diffs, "", "\t")
 	if err != nil {
 		return fmt.Errorf("serializing to json: %w", err)
 	}

--- a/doc/g2.1.md
+++ b/doc/g2.1.md
@@ -59,6 +59,8 @@ Commands for manipulating and inspecting **.ebuild** files.
   Initializes a new ebuild from the specified template.
 - **templates**
   Manages ebuild templates.
+- **diff-json** *<ebuild_file>*
+  Compares as-json vs sh-parse-to-json for the same file and reports semantic differences.
 - **sh-parse-to-json** *<ebuild_file>*
   Parses an ebuild using the shell parser and outputs JSON.
 - **as-json** *<ebuild_file>*

--- a/ebuild_diff_txtar_test.go
+++ b/ebuild_diff_txtar_test.go
@@ -1,0 +1,102 @@
+package g2_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/tools/txtar"
+)
+
+var diffEbuildsArchive = []byte(`
+-- testpkg-1.0.ebuild --
+EAPI=8
+
+DESCRIPTION="Test ebuild"
+HOMEPAGE="https://example.com"
+SRC_URI="https://example.com/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 ~x86"
+
+IUSE="test"
+
+DEPEND="dev-libs/foo"
+RDEPEND="${DEPEND}"
+
+if [[ ${PV} == "9999" ]]; then
+    PROPERTIES="live"
+fi
+
+src_prepare() {
+    default
+    eapply_user
+}
+-- testpkg-1.0.json --
+[]
+`)
+
+func TestEbuildDiffJsonCommand(t *testing.T) {
+	archive := txtar.Parse(diffEbuildsArchive)
+
+	tmpDir := t.TempDir()
+
+	for _, f := range archive.Files {
+		path := filepath.Join(tmpDir, f.Name)
+		if err := os.WriteFile(path, f.Data, 0644); err != nil {
+			t.Fatalf("writing file %s: %v", f.Name, err)
+		}
+	}
+
+	for _, f := range archive.Files {
+		if strings.HasSuffix(f.Name, ".ebuild") {
+			t.Run(f.Name, func(t *testing.T) {
+				jsonName := strings.TrimSuffix(f.Name, ".ebuild") + ".json"
+				expectedJSON, err := os.ReadFile(filepath.Join(tmpDir, jsonName))
+				if err != nil {
+					t.Fatalf("reading expected JSON: %v", err)
+				}
+
+				// Build the CLI
+				cliPath := filepath.Join(tmpDir, "g2")
+				cmd := exec.Command("go", "build", "-o", cliPath, "./cmd/g2")
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("building g2: %v", err)
+				}
+
+				// Run diff-json
+				cmd = exec.Command(cliPath, "ebuild", "diff-json", filepath.Join(tmpDir, f.Name))
+				var out bytes.Buffer
+				cmd.Stdout = &out
+				cmd.Stderr = os.Stderr
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("running g2 ebuild diff-json: %v", err)
+				}
+
+				// Compare JSON
+				var expected, actual []map[string]interface{}
+				if err := json.Unmarshal(expectedJSON, &expected); err != nil {
+					t.Fatalf("parsing expected JSON: %v", err)
+				}
+				if err := json.Unmarshal(out.Bytes(), &actual); err != nil {
+					t.Fatalf("parsing actual JSON output: %v", err)
+				}
+
+				// Normalize and compare
+				eBytes, _ := json.MarshalIndent(expected, "", "\t")
+				aBytes, _ := json.MarshalIndent(actual, "", "\t")
+
+				if string(eBytes) != string(aBytes) {
+					t.Errorf("JSON mismatch:\nExpected:\n%s\n\nActual:\n%s", string(eBytes), string(aBytes))
+				}
+			})
+		}
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -149,6 +149,7 @@ g2 ebuild <subcommand>
 
 * `init <template_name>`: Initialize an ebuild from a template.
 * `templates`: Manage ebuild templates.
+* `diff-json <ebuild_file>`: Compare as-json vs sh-parse-to-json and output semantic differences.
 * `sh-parse-to-json <ebuild_file>`: Parse an ebuild using the shell parser and output JSON.
 * `as-json <ebuild_file>`: Parse an ebuild using the native parser and output JSON.
 


### PR DESCRIPTION
Add a command to compare variables retrieved using `ParseFull` and `ParseVariables` to find and pinpoint specific gaps in parser feature parity. Also added `txtar` end to end tests with json snapshots.

---
*PR created automatically by Jules for task [11740609299125488548](https://jules.google.com/task/11740609299125488548) started by @arran4*