### PR TITLE
Implement USE_EXPAND flag support

### DIFF
--- a/cmd/g2/models_page.go
+++ b/cmd/g2/models_page.go
@@ -20,6 +20,8 @@ type GenericPageContext struct {
 	Packages             interface{} // Can be []*AggPackage or []PackageData
 	Licenses             []*AggLicense
 	UseFlags             []*AggUseFlag
+	UseExpandDescs        map[string]*g2.UseExpandDesc
+	UseExpandDesc         *g2.UseExpandDesc
 	Projects             []*AggProject
 	Profiles             interface{} // Can be []*AggProfile or []ProfileData
 	Arches               []*AggArch

--- a/cmd/g2/parse_pkg_uses.go
+++ b/cmd/g2/parse_pkg_uses.go
@@ -227,6 +227,23 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 			}
 		}
 
+		if site.UseExpandDescs != nil {
+			for prefix, desc := range site.UseExpandDescs {
+				for suffix, text := range desc.Flags {
+					flagName := prefix + "_" + suffix
+					if aggFlag, ok := globalAggUseFlags[flagName]; ok {
+						if aggFlag.GlobalDesc == "" {
+							aggFlag.GlobalDesc = text
+						}
+					}
+					if aggFlag, ok := repoAggUseFlags[flagName]; ok {
+						if aggFlag.GlobalDesc == "" {
+							aggFlag.GlobalDesc = text
+						}
+					}
+				}
+			}
+		}
 		if site.UseLocalDesc != nil {
 			for pkg, flags := range site.UseLocalDesc.Flags {
 				for flag, desc := range flags {
@@ -303,6 +320,14 @@ func populatePkgUseFlags(site *SiteData) {
 	}
 
 	localDescs := make(map[string]map[string]string)
+	if site.UseExpandDescs != nil {
+		for prefix, desc := range site.UseExpandDescs {
+			for suffix, text := range desc.Flags {
+				flagName := prefix + "_" + suffix
+				globalDescs[flagName] = text
+			}
+		}
+	}
 	if site.UseLocalDesc != nil {
 		localDescs = site.UseLocalDesc.Flags
 	}

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -79,6 +79,8 @@ type SiteData struct {
 	QAPolicy          *g2.QAPolicy
 	UseDesc           *g2.UseDesc
 	UseLocalDesc      *g2.UseLocalDesc
+	UseExpandDescs    map[string]*g2.UseExpandDesc
+	ValidUseExpands   map[string]bool
 	ArchList          *g2.ArchList
 	ArchesDesc        *g2.ArchesDesc
 	InfoPkgs          []g2.InfoPkg
@@ -690,6 +692,12 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		}
 	}
 
+	var useExpandDescs map[string]*g2.UseExpandDesc
+	if descs, err := g2.ParseUseExpandDescFS(sysFS, filepath.ToSlash(filepath.Join(repoDir, "profiles", "desc"))); err == nil {
+		useExpandDescs = descs
+	} else if !os.IsNotExist(err) {
+		log.Printf("Warning: failed to parse use expand desc: %v", err)
+	}
 	var useLocalDesc *g2.UseLocalDesc
 	if f, err := sysFS.Open(filepath.ToSlash(filepath.Join(repoDir, "profiles", "use.local.desc"))); err == nil {
 		defer func() { _ = f.Close() }()
@@ -754,6 +762,8 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		QAPolicy:          qa,
 		UseDesc:           useDesc,
 		UseLocalDesc:      useLocalDesc,
+		UseExpandDescs:    useExpandDescs,
+		ValidUseExpands:   make(map[string]bool),
 		ArchList:          archList,
 		ArchesDesc:        archesDesc,
 		ThirdPartyMirrors: thirdPartyMirrors,
@@ -761,6 +771,12 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		InfoVars:          infoVars,
 		InfoPkgs:          infoPkgs,
 		PackageCount:      0,
+	}
+
+	if site.UseExpandDescs != nil {
+		for prefix := range site.UseExpandDescs {
+			site.ValidUseExpands[prefix] = true
+		}
 	}
 
 	// Calculate PackageCount correctly after parsing all categories
@@ -1685,6 +1701,19 @@ func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggU
 		}
 	}
 
+	// Integrate USE_EXPAND descriptions
+	if site.UseExpandDescs != nil {
+		for prefix, desc := range site.UseExpandDescs {
+			for suffix, text := range desc.Flags {
+				flagName := prefix + "_" + suffix
+				if aggFlag, ok := aggUseFlags[flagName]; ok {
+					if aggFlag.GlobalDesc == "" {
+						aggFlag.GlobalDesc = text
+					}
+				}
+			}
+		}
+	}
 	if site.UseLocalDesc != nil {
 		for pkg, flags := range site.UseLocalDesc.Flags {
 			for flag, desc := range flags {
@@ -1793,7 +1822,9 @@ type AggregatedData struct {
 	RecentNews    []AggNewsItem
 	TotalPackages int
 	UseFlags      []*AggUseFlag
+	UseExpandDescs map[string]*g2.UseExpandDesc
 	ValidLicenses map[string]bool
+	ValidUseExpands map[string]bool
 }
 
 func prepareAggregatedData(sites []*SiteData) *AggregatedData {
@@ -1805,8 +1836,16 @@ func prepareAggregatedData(sites []*SiteData) *AggregatedData {
 	aggArches := make(map[string]*AggArch)
 	aggMoves := make(map[string]*AggPackageMove)
 	var globalNews []AggNewsItem
+	aggUseExpandDescs := make(map[string]*g2.UseExpandDesc)
 
 	for _, site := range sites {
+		if site.UseExpandDescs != nil {
+			for prefix, desc := range site.UseExpandDescs {
+				if _, ok := aggUseExpandDescs[prefix]; !ok {
+					aggUseExpandDescs[prefix] = desc
+				}
+			}
+		}
 		if site.Projects != nil {
 			for i := range site.Projects.Projects {
 				proj := &site.Projects.Projects[i]
@@ -2015,6 +2054,12 @@ func prepareAggregatedData(sites []*SiteData) *AggregatedData {
 
 	sortedUseFlags, _ := AggregateUseFlags(sites, aggPackages)
 
+	validUseExpands := make(map[string]bool)
+	for _, site := range sites {
+		for prefix := range site.ValidUseExpands {
+			validUseExpands[prefix] = true
+		}
+	}
 	validLicenses := make(map[string]bool)
 	var sortedLicenses []*AggLicense
 	for _, l := range aggLicenses {
@@ -2076,6 +2121,8 @@ func prepareAggregatedData(sites []*SiteData) *AggregatedData {
 		TotalPackages: totalPackages,
 		UseFlags:      sortedUseFlags,
 		ValidLicenses: validLicenses,
+		UseExpandDescs: aggUseExpandDescs,
+		ValidUseExpands: validUseExpands,
 	}
 }
 
@@ -2493,6 +2540,37 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		}
 	}
 
+	if len(data.UseExpandDescs) > 0 {
+		if err := os.MkdirAll(filepath.Join(outDir, "uses_expand"), 0755); err != nil {
+			return fmt.Errorf("creating directory: %w", err)
+		}
+		if err := renderPage(filepath.Join(outDir, "uses_expand", "index.html"), tmpl, "use_expands.html", GenericPageContext{
+			Title:       "USE_EXPAND Flags",
+			BaseURL:     "../",
+			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "USE_EXPAND Flags"}},
+			UseExpandDescs: data.UseExpandDescs,
+			Version:     version,
+			GenInfo:     genInfo,
+		}); err != nil {
+			return fmt.Errorf("rendering page: %w", err)
+		}
+		for prefix, desc := range data.UseExpandDescs {
+			useExpandDir := filepath.Join(outDir, "uses_expand", prefix)
+			if err := os.MkdirAll(useExpandDir, 0755); err != nil {
+				return fmt.Errorf("creating directory %s: %w", useExpandDir, err)
+			}
+			if err := renderPage(filepath.Join(useExpandDir, "index.html"), tmpl, "use_expand.html", GenericPageContext{
+				Title:       "USE_EXPAND: " + prefix,
+				BaseURL:     "../../",
+				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "USE_EXPAND Flags", URL: "../"}, {Name: prefix}},
+				UseExpandDesc: desc,
+				Version:     version,
+				GenInfo:     genInfo,
+			}); err != nil {
+				return fmt.Errorf("rendering page: %w", err)
+			}
+		}
+	}
 	if err := renderPage(filepath.Join(outDir, "licenses", "index.html"), tmpl, "licenses.html", GenericPageContext{
 		Title:       "Licenses",
 		BaseURL:     "../",
@@ -2632,6 +2710,38 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			}
 		}
 
+		if len(site.UseExpandDescs) > 0 {
+			if err := os.MkdirAll(filepath.Join(repoDir, "uses_expand"), 0755); err != nil {
+				return fmt.Errorf("creating directory: %w", err)
+			}
+			if err := renderPage(filepath.Join(repoDir, "uses_expand", "index.html"), tmpl, "repo_use_expands.html", GenericPageContext{
+				Title:       site.RepoName + " - USE_EXPAND Flags",
+				BaseURL:     "../../../",
+				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "USE_EXPAND Flags"}},
+				Repo:        site,
+				Version:     version,
+				GenInfo:     genInfo,
+			}); err != nil {
+				return fmt.Errorf("rendering page: %w", err)
+			}
+			for prefix, desc := range site.UseExpandDescs {
+				useExpandDir := filepath.Join(repoDir, "uses_expand", prefix)
+				if err := os.MkdirAll(useExpandDir, 0755); err != nil {
+					return fmt.Errorf("creating directory %s: %w", useExpandDir, err)
+				}
+				if err := renderPage(filepath.Join(useExpandDir, "index.html"), tmpl, "repo_use_expand.html", GenericPageContext{
+					Title:       site.RepoName + " - USE_EXPAND: " + prefix,
+					BaseURL:     "../../../../",
+					Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "USE_EXPAND Flags", URL: "../"}, {Name: prefix}},
+					Repo:        site,
+					UseExpandDesc: desc,
+					Version:     version,
+					GenInfo:     genInfo,
+				}); err != nil {
+					return fmt.Errorf("rendering page: %w", err)
+				}
+			}
+		}
 		if len(site.Deprecated) > 0 {
 			if err := os.MkdirAll(filepath.Join(repoDir, "deprecated"), 0755); err != nil {
 				return fmt.Errorf("creating directory: %w", err)

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 )
@@ -18,6 +19,7 @@ func getTemplateFuncMap() template.FuncMap {
 		"split":               strings.Split,
 		"formatKeywords":      formatKeywordsFunc,
 		"hasPrefix":           strings.HasPrefix,
+		"groupIUSEFlags":      groupIUSEFlagsFunc,
 	}
 }
 
@@ -52,4 +54,45 @@ func buildOwnerEmailLinkFunc(remoteURL, email string) string {
 		return remoteURL
 	}
 	return ""
+}
+
+type UseFlagGroup struct {
+	Name  string
+	Flags []ParsedIUSEFlag
+}
+
+func groupIUSEFlagsFunc(flags []ParsedIUSEFlag, useExpandPrefixes map[string]bool) []UseFlagGroup {
+	groups := make(map[string][]ParsedIUSEFlag)
+	var globalFlags []ParsedIUSEFlag
+
+	for _, f := range flags {
+		var matchedPrefix string
+		for prefix := range useExpandPrefixes {
+			if strings.HasPrefix(f.Name, prefix+"_") {
+				if len(prefix) > len(matchedPrefix) {
+					matchedPrefix = prefix
+				}
+			}
+		}
+
+		if matchedPrefix != "" {
+			groups[matchedPrefix] = append(groups[matchedPrefix], f)
+		} else {
+			globalFlags = append(globalFlags, f)
+		}
+	}
+
+	var result []UseFlagGroup
+	if len(globalFlags) > 0 {
+		result = append(result, UseFlagGroup{Name: "global", Flags: globalFlags})
+	}
+	var groupNames []string
+	for name := range groups {
+		groupNames = append(groupNames, name)
+	}
+	sort.Strings(groupNames)
+	for _, name := range groupNames {
+		result = append(result, UseFlagGroup{Name: name, Flags: groups[name]})
+	}
+	return result
 }

--- a/cmd/g2/use.go
+++ b/cmd/g2/use.go
@@ -25,6 +25,9 @@ func (cfg *MainArgConfig) cmdUse(args []string) error {
 		fmt.Printf("\t\t %s \t\t %s\n", "local-desc-remove", "Remove a USE local flag description from use.local.desc")
 		fmt.Printf("\t\t %s \t\t %s\n", "local-desc-edit", "Edit a USE local flag description in use.local.desc")
 		fmt.Printf("\t\t %s \t\t %s\n", "local-desc-list", "List all USE local flag descriptions from use.local.desc")
+		fmt.Printf("\t\t %s \t\t %s\n", "expand-desc-add", "Add a USE_EXPAND flag description")
+		fmt.Printf("\t\t %s \t\t %s\n", "expand-desc-remove", "Remove a USE_EXPAND flag description")
+		fmt.Printf("\t\t %s \t\t %s\n", "expand-desc-list", "List all USE_EXPAND flag descriptions")
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -52,6 +55,12 @@ func (cfg *MainArgConfig) cmdUse(args []string) error {
 		return cfg.cmdUseLocalDescRemove(fs.Args()[1:])
 	case "local-desc-list":
 		return cfg.cmdUseLocalDescList(fs.Args()[1:])
+	case "expand-desc-add", "expand-desc-edit":
+		return cfg.cmdUseExpandDescAdd(fs.Args()[1:])
+	case "expand-desc-remove":
+		return cfg.cmdUseExpandDescRemove(fs.Args()[1:])
+	case "expand-desc-list":
+		return cfg.cmdUseExpandDescList(fs.Args()[1:])
 	case "discover":
 		return cfg.cmdUseDiscover(fs.Args()[1:])
 	default:
@@ -463,6 +472,99 @@ func (cfg *MainArgConfig) cmdUseLocalDescList(args []string) error {
 		for k, v := range flags {
 			fmt.Printf("%s:%s - %s\n", pkg, k, v)
 		}
+	}
+
+	return nil
+}
+
+func (cfg *MainArgConfig) cmdUseExpandDescAdd(args []string) error {
+	fs := flag.NewFlagSet("expand-desc-add/edit", flag.ExitOnError)
+	file := fs.String("file", "", "Path to desc file (e.g. profiles/desc/abi_mips.desc)")
+	flagName := fs.String("flag", "", "USE_EXPAND flag name")
+	desc := fs.String("desc", "", "USE_EXPAND flag description")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *file == "" || *flagName == "" || *desc == "" {
+		return fmt.Errorf("all -file, -flag, and -desc must be provided")
+	}
+
+	name := strings.TrimSuffix(filepath.Base(*file), ".desc")
+
+	ud, err := g2.ParseUseExpandDescFile(*file, name)
+	if err != nil {
+		return fmt.Errorf("parsing %s: %w", *file, err)
+	}
+
+	if ud.Flags == nil {
+		ud.Flags = make(map[string]string)
+	}
+	ud.Flags[*flagName] = *desc
+
+	if err := ud.WriteFile(*file); err != nil {
+		return fmt.Errorf("writing %s: %w", *file, err)
+	}
+
+	log.Printf("Successfully added/edited USE_EXPAND flag '%s' in %s", *flagName, *file)
+	return nil
+}
+
+func (cfg *MainArgConfig) cmdUseExpandDescRemove(args []string) error {
+	fs := flag.NewFlagSet("expand-desc-remove", flag.ExitOnError)
+	file := fs.String("file", "", "Path to desc file (e.g. profiles/desc/abi_mips.desc)")
+	flagName := fs.String("flag", "", "USE_EXPAND flag name to remove")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *file == "" || *flagName == "" {
+		return fmt.Errorf("both -file and -flag must be provided")
+	}
+
+	name := strings.TrimSuffix(filepath.Base(*file), ".desc")
+
+	ud, err := g2.ParseUseExpandDescFile(*file, name)
+	if err != nil {
+		return fmt.Errorf("parsing %s: %w", *file, err)
+	}
+
+	if _, ok := ud.Flags[*flagName]; ok {
+		delete(ud.Flags, *flagName)
+		if err := ud.WriteFile(*file); err != nil {
+			return fmt.Errorf("writing %s: %w", *file, err)
+		}
+		log.Printf("Successfully removed USE_EXPAND flag '%s' from %s", *flagName, *file)
+	} else {
+		log.Printf("USE_EXPAND flag '%s' not found in %s", *flagName, *file)
+	}
+
+	return nil
+}
+
+func (cfg *MainArgConfig) cmdUseExpandDescList(args []string) error {
+	fs := flag.NewFlagSet("expand-desc-list", flag.ExitOnError)
+	file := fs.String("file", "", "Path to desc file (e.g. profiles/desc/abi_mips.desc)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *file == "" {
+		return fmt.Errorf("-file must be provided")
+	}
+
+	name := strings.TrimSuffix(filepath.Base(*file), ".desc")
+
+	ud, err := g2.ParseUseExpandDescFile(*file, name)
+	if err != nil {
+		return fmt.Errorf("parsing %s: %w", *file, err)
+	}
+
+	for k, v := range ud.Flags {
+		fmt.Printf("%s - %s\n", k, v)
 	}
 
 	return nil

--- a/lints/ebuild/use_expand.go
+++ b/lints/ebuild/use_expand.go
@@ -1,0 +1,82 @@
+package ebuild
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+type UseExpandRule struct{}
+
+func init() {
+	rule := &UseExpandRule{}
+	lints.RegisterLintRule(rule)
+	lints.RegisterRuleMetadata(rule.Metadata())
+}
+
+func (r *UseExpandRule) Metadata() lints.RuleMetadata {
+	return lints.RuleMetadata{
+		ID:          "UseExpandUnsupported",
+		Title:       "Unsupported USE_EXPAND flag usage",
+		Description: "Checks if an ebuild uses USE_EXPAND flags that are not defined in the corresponding profiles/desc/*.desc file",
+		Severity:    lints.SeverityError,
+		Source:      "g2",
+		Tags:        []string{"ebuild", "use"},
+	}
+}
+
+func (r *UseExpandRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	// Load USE_EXPAND descriptions
+	descDir := filepath.Join(repoDir, "profiles", "desc")
+	useExpandDescs, err := g2.ParseUseExpandDescDir(descDir)
+	if err != nil || len(useExpandDescs) == 0 {
+		return results // No descriptions available to validate against
+	}
+
+	for _, ver := range pkgData.Versions {
+		if ver.Ebuild == nil || ver.Ebuild.Vars == nil {
+			continue
+		}
+
+		iuse := ver.Ebuild.Vars["IUSE"]
+		if iuse == "" {
+			continue
+		}
+
+		parsedFlags := g2.ParseIUSE(iuse)
+		for _, flag := range parsedFlags {
+			var matchedPrefix, matchedSuffix string
+			for prefix := range useExpandDescs {
+				if strings.HasPrefix(flag, prefix+"_") {
+					// Find the longest matching prefix
+					if len(prefix) > len(matchedPrefix) {
+						matchedPrefix = prefix
+						matchedSuffix = strings.TrimPrefix(flag, prefix+"_")
+					}
+				}
+			}
+
+			if matchedPrefix != "" {
+				expandName := matchedPrefix
+				expandFlag := matchedSuffix
+
+				if desc, ok := useExpandDescs[expandName]; ok {
+					if _, valid := desc.Flags[expandFlag]; !valid {
+						results = append(results, lints.LintResult{
+							RuleMetadata: r.Metadata(),
+							Message:      fmt.Sprintf("Version %s: USE_EXPAND flag '%s' uses unsupported value '%s' (not found in %s.desc)", ver.Version, flag, expandFlag, expandName),
+							File:         fmt.Sprintf("%s-%s.ebuild", pkgData.Name, ver.Version),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return results
+}

--- a/templates/views/ebuild_details.html
+++ b/templates/views/ebuild_details.html
@@ -123,15 +123,26 @@
         <code>euse -D &lt;flag&gt; -p {{.Package.Category}}/{{.Package.Name}}</code>
     </p>
     <div>
-        {{range parseIUSEFlags .VersionData.Ebuild.Vars.IUSE}}
-        <div class="iuse-flag">
-            <a href="{{$.BaseURL}}uses/{{.Name}}/">{{.Name}}</a>
-            {{if .Conditional}}
-            <div class="iuse-tooltip" title="{{.ConditionStr}}">
-                &#10067;
-                <span class="tooltiptext">{{.ConditionStr}}</span>
-            </div>
+        {{range groupIUSEFlags (parseIUSEFlags .VersionData.Ebuild.Vars.IUSE) $.Repo.ValidUseExpands}}
+        <div class="use-group" style="margin-bottom: 10px;">
+            {{if eq .Name "global"}}
+            <h4>Global/Standard Flags</h4>
+            {{else}}
+            <h4>USE_EXPAND: <a href="{{$.BaseURL}}uses_expand/{{.Name}}/">{{.Name}}</a></h4>
             {{end}}
+            <div>
+                {{range .Flags}}
+                <div class="iuse-flag">
+                    <a href="{{$.BaseURL}}uses/{{.Name}}/">{{.Name}}</a>
+                    {{if .Conditional}}
+                    <div class="iuse-tooltip" title="{{.ConditionStr}}">
+                        &#10067;
+                        <span class="tooltiptext">{{.ConditionStr}}</span>
+                    </div>
+                    {{end}}
+                </div>
+                {{end}}
+            </div>
         </div>
         {{end}}
     </div>

--- a/templates/views/repo_use_expand.html
+++ b/templates/views/repo_use_expand.html
@@ -1,0 +1,42 @@
+<div class="header">
+    <h2>{{.Title}}</h2>
+    <div class="breadcrumbs">
+        {{range $index, $bc := .Breadcrumbs}}
+        {{if $index}} &gt; {{end}}
+        {{if $bc.URL}}<a href="{{$bc.URL}}">{{$bc.Name}}</a>{{else}}{{$bc.Name}}{{end}}
+        {{end}}
+    </div>
+</div>
+
+<div class="content">
+    <div class="metadata-section">
+        <h3>Description for {{.UseExpandDesc.Name}}</h3>
+        {{range .UseExpandDesc.Lines}}
+            {{if eq .Flag ""}}
+                <p>{{.Text}}</p>
+            {{end}}
+        {{end}}
+    </div>
+
+    <h3>Flags in {{.UseExpandDesc.Name}}</h3>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>Flag</th>
+                <th>Description</th>
+                <th>Packages Using This Flag</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range $flag, $desc := .UseExpandDesc.Flags}}
+            <tr>
+                <td><strong>{{$flag}}</strong></td>
+                <td>{{$desc}}</td>
+                <td>
+                    <a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/uses/{{$.UseExpandDesc.Name}}_{{$flag}}/">View specific flag page ({{$.UseExpandDesc.Name}}_{{$flag}})</a>
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>

--- a/templates/views/repo_use_expands.html
+++ b/templates/views/repo_use_expands.html
@@ -1,0 +1,28 @@
+<div class="header">
+    <h2>{{.Title}}</h2>
+    <div class="breadcrumbs">
+        {{range $index, $bc := .Breadcrumbs}}
+        {{if $index}} &gt; {{end}}
+        {{if $bc.URL}}<a href="{{$bc.URL}}">{{$bc.Name}}</a>{{else}}{{$bc.Name}}{{end}}
+        {{end}}
+    </div>
+</div>
+
+<div class="content">
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>USE_EXPAND Prefix</th>
+                <th>Flags Count</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range $prefix, $desc := .Repo.UseExpandDescs}}
+            <tr>
+                <td><a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/uses_expand/{{$prefix}}/">{{$prefix}}</a></td>
+                <td>{{len $desc.Flags}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>

--- a/templates/views/use_expand.html
+++ b/templates/views/use_expand.html
@@ -1,0 +1,42 @@
+<div class="header">
+    <h2>{{.Title}}</h2>
+    <div class="breadcrumbs">
+        {{range $index, $bc := .Breadcrumbs}}
+        {{if $index}} &gt; {{end}}
+        {{if $bc.URL}}<a href="{{$bc.URL}}">{{$bc.Name}}</a>{{else}}{{$bc.Name}}{{end}}
+        {{end}}
+    </div>
+</div>
+
+<div class="content">
+    <div class="metadata-section">
+        <h3>Description for {{.UseExpandDesc.Name}}</h3>
+        {{range .UseExpandDesc.Lines}}
+            {{if eq .Flag ""}}
+                <p>{{.Text}}</p>
+            {{end}}
+        {{end}}
+    </div>
+
+    <h3>Flags in {{.UseExpandDesc.Name}}</h3>
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>Flag</th>
+                <th>Description</th>
+                <th>Packages Using This Flag</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range $flag, $desc := .UseExpandDesc.Flags}}
+            <tr>
+                <td><strong>{{$flag}}</strong></td>
+                <td>{{$desc}}</td>
+                <td>
+                    <a href="{{$.BaseURL}}uses/{{$.UseExpandDesc.Name}}_{{$flag}}/">View specific flag page ({{$.UseExpandDesc.Name}}_{{$flag}})</a>
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>

--- a/templates/views/use_expands.html
+++ b/templates/views/use_expands.html
@@ -1,0 +1,28 @@
+<div class="header">
+    <h2>{{.Title}}</h2>
+    <div class="breadcrumbs">
+        {{range $index, $bc := .Breadcrumbs}}
+        {{if $index}} &gt; {{end}}
+        {{if $bc.URL}}<a href="{{$bc.URL}}">{{$bc.Name}}</a>{{else}}{{$bc.Name}}{{end}}
+        {{end}}
+    </div>
+</div>
+
+<div class="content">
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>USE_EXPAND Prefix</th>
+                <th>Flags Count</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range $prefix, $desc := .UseExpandDescs}}
+            <tr>
+                <td><a href="{{$.BaseURL}}uses_expand/{{$prefix}}/">{{$prefix}}</a></td>
+                <td>{{len $desc.Flags}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>

--- a/use_expand_desc.go
+++ b/use_expand_desc.go
@@ -1,0 +1,159 @@
+package g2
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type UseExpandDesc struct {
+	Name        string
+	Flags       map[string]string
+	Lines       []DescLine // ordered list of lines
+}
+
+type DescLine struct {
+	Text string
+	Flag string // empty if it's a comment or blank line
+}
+
+func ParseUseExpandDesc(r io.Reader, name string) (*UseExpandDesc, error) {
+	ud := &UseExpandDesc{
+		Name:  name,
+		Flags: make(map[string]string),
+	}
+
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			ud.Lines = append(ud.Lines, DescLine{Text: line})
+			continue
+		}
+
+		parts := strings.SplitN(trimmed, " - ", 2)
+		if len(parts) == 2 {
+			flag := strings.TrimSpace(parts[0])
+			desc := strings.TrimSpace(parts[1])
+			ud.Flags[flag] = desc
+			ud.Lines = append(ud.Lines, DescLine{Flag: flag})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return ud, nil
+}
+func ParseUseExpandDescFile(filename string, name string) (*UseExpandDesc, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &UseExpandDesc{
+				Name:  name,
+				Flags: make(map[string]string),
+				Lines: []DescLine{
+					{Text: "# Copyright 1999-2024 Gentoo Authors"},
+					{Text: "# Distributed under the terms of the GNU General Public License v2"},
+				},
+			}, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	return ParseUseExpandDesc(file, name)
+}
+
+func ParseUseExpandDescDir(dir string) (map[string]*UseExpandDesc, error) {
+	return ParseUseExpandDescFS(os.DirFS(dir), ".")
+}
+
+func ParseUseExpandDescFS(sysFS fs.FS, dir string) (map[string]*UseExpandDesc, error) {
+	result := make(map[string]*UseExpandDesc)
+
+	entries, err := fs.ReadDir(sysFS, filepath.ToSlash(dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, nil
+		}
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".desc") {
+			continue
+		}
+
+		name := strings.TrimSuffix(entry.Name(), ".desc")
+		path := filepath.Join(dir, entry.Name())
+
+		file, err := sysFS.Open(filepath.ToSlash(path))
+		if err != nil {
+			return nil, err
+		}
+
+		ud, err := ParseUseExpandDesc(file, name)
+		_ = file.Close()
+
+		if err != nil {
+			return nil, err
+		}
+
+		result[name] = ud
+	}
+
+	return result, nil
+}
+
+func (ud *UseExpandDesc) Write(w io.Writer) error {
+	writtenFlags := make(map[string]bool)
+	for _, line := range ud.Lines {
+		if line.Flag != "" {
+			if desc, ok := ud.Flags[line.Flag]; ok {
+				if _, err := fmt.Fprintf(w, "%s - %s\n", line.Flag, desc); err != nil {
+					return err
+				}
+				writtenFlags[line.Flag] = true
+			}
+		} else {
+			if _, err := fmt.Fprintln(w, line.Text); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Write any new flags that were added programmatically
+	var newFlags []string
+	for flag := range ud.Flags {
+		if !writtenFlags[flag] {
+			newFlags = append(newFlags, flag)
+		}
+	}
+	sort.Strings(newFlags)
+	for _, flag := range newFlags {
+		if _, err := fmt.Fprintf(w, "%s - %s\n", flag, ud.Flags[flag]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+func (ud *UseExpandDesc) WriteFile(filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	return ud.Write(file)
+}


### PR DESCRIPTION
Implemented complete backend and frontend handling for Gentoo `USE_EXPAND` flag architecture. This includes parsing capabilities for `profiles/desc/*.desc` files natively, a fully capable CLI management interface to query, add and remove them, a lint rule for flagging non-existent uses in IUSE, and specific UI templates grouping the flags cleanly together on ebuilds and linking them securely to their own separate descriptions section.

---
*PR created automatically by Jules for task [6487658454927932346](https://jules.google.com/task/6487658454927932346) started by @arran4*