### PR TITLE
fix: clean up temporary directories during concurrent remote repository fetching

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -3390,6 +3390,8 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			log.Printf("[START] Fetching remote repository: %s (%s)", repo.Name, gitUrl)
 
 			repoPath := filepath.Join(tmpDir, repo.Name)
+			defer func() { _ = os.RemoveAll(repoPath) }()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 


### PR DESCRIPTION
When running `g2 overlays site generate`, the app loops through the repositories, concurrently fetches and parses each, but keeps the fetched directories around until the end of the entire loop. For massive lists of overlays, this can lead to disk space exhaustion.

This change introduces a cleanup `defer os.RemoveAll(repoPath)` operation inside the worker goroutine, guaranteeing the repo is deleted right after its memory models (`SiteData`) are populated and stored, whether it succeeds or fails.

---
*PR created automatically by Jules for task [13015150337211064867](https://jules.google.com/task/13015150337211064867) started by @arran4*