### PR TITLE
Introduce pure memory based git checkout

### DIFF
--- a/cmd/g2/billy_fs.go
+++ b/cmd/g2/billy_fs.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+
+	"github.com/go-git/go-billy/v5"
+)
+
+type BillyFS struct {
+	bfs billy.Filesystem
+}
+
+func NewBillyFS(bfs billy.Filesystem) *BillyFS {
+	return &BillyFS{bfs: bfs}
+}
+
+func (b *BillyFS) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+
+	info, err := b.bfs.Stat(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+		}
+		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+	}
+
+	if info.IsDir() {
+		return &billyDirFile{
+			fs:   b.bfs,
+			name: name,
+			info: info,
+		}, nil
+	}
+
+	f, err := b.bfs.Open(name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+	}
+
+	return &billyFile{
+		File: f,
+		info: info,
+		name: name,
+	}, nil
+}
+
+func (b *BillyFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+
+	entries, err := b.bfs.ReadDir(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+		}
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: err}
+	}
+
+	dirEntries := make([]fs.DirEntry, len(entries))
+	for i, entry := range entries {
+		dirEntries[i] = fs.FileInfoToDirEntry(entry)
+	}
+	return dirEntries, nil
+}
+
+func (b *BillyFS) Stat(name string) (fs.FileInfo, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+
+	info, err := b.bfs.Stat(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+		}
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
+	}
+	return info, nil
+}
+
+func (b *BillyFS) ReadFile(name string) ([]byte, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrInvalid}
+	}
+
+	f, err := b.bfs.Open(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrNotExist}
+		}
+		return nil, &fs.PathError{Op: "readfile", Path: name, Err: err}
+	}
+	defer f.Close()
+
+	return io.ReadAll(f)
+}
+
+func (b *BillyFS) Sub(dir string) (fs.FS, error) {
+	if dir == "." {
+		return b, nil
+	}
+	ch, err := b.bfs.Chroot(dir)
+	if err != nil {
+		return nil, err
+	}
+	return NewBillyFS(ch), nil
+}
+
+type billyFile struct {
+	billy.File
+	info fs.FileInfo
+	name string
+}
+
+func (f *billyFile) Stat() (fs.FileInfo, error) {
+	return f.info, nil
+}
+
+type billyDirFile struct {
+	fs     billy.Filesystem
+	name   string
+	info   fs.FileInfo
+	offset int
+}
+
+func (d *billyDirFile) Stat() (fs.FileInfo, error) {
+	return d.info, nil
+}
+
+func (d *billyDirFile) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.name, Err: errors.New("is a directory")}
+}
+
+func (d *billyDirFile) Close() error {
+	return nil
+}
+
+func (d *billyDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	infos, err := d.fs.ReadDir(d.name)
+	if err != nil {
+		return nil, &fs.PathError{Op: "readdir", Path: d.name, Err: err}
+	}
+
+	if d.offset >= len(infos) {
+		if n <= 0 {
+			return nil, nil
+		}
+		return nil, io.EOF
+	}
+
+	var end int
+	if n <= 0 {
+		end = len(infos)
+	} else {
+		end = d.offset + n
+		if end > len(infos) {
+			end = len(infos)
+		}
+	}
+
+	entries := make([]fs.DirEntry, end-d.offset)
+	for i, info := range infos[d.offset:end] {
+		entries[i] = fs.FileInfoToDirEntry(info)
+	}
+
+	d.offset = end
+	return entries, nil
+}
+
+// Ensure billy wrapper functions implement required interfaces
+var _ fs.FS = (*BillyFS)(nil)
+var _ fs.ReadDirFS = (*BillyFS)(nil)
+var _ fs.StatFS = (*BillyFS)(nil)
+var _ fs.ReadFileFS = (*BillyFS)(nil)
+var _ fs.SubFS = (*BillyFS)(nil)

--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -13,6 +13,11 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/storage/memory"
 )
 
 type ZipUrlConverter func(gitUrl string) (string, error)
@@ -68,6 +73,35 @@ func giteaUrlConverter(gitUrl string) (string, error) {
 	}
 	path := strings.TrimSuffix(u.Path, ".git")
 	return fmt.Sprintf("https://%s%s/archive/HEAD.zip", u.Host, path), nil
+}
+
+func FetchRepoMemory(ctx context.Context, gitUrl string, retries int) (*git.Repository, billy.Filesystem, error) {
+	var err error
+	var repo *git.Repository
+	var fs billy.Filesystem
+
+	for i := 0; i <= retries; i++ {
+		if i > 0 {
+			log.Printf("Retrying fetch for %s in memory (attempt %d/%d)...", gitUrl, i, retries)
+			time.Sleep(1 * time.Second)
+		}
+
+		storer := memory.NewStorage()
+		fs = memfs.New()
+
+		repo, err = git.CloneContext(ctx, storer, fs, &git.CloneOptions{
+			URL:          gitUrl,
+			Depth:        1,
+			SingleBranch: true,
+			Progress:     os.Stdout,
+		})
+
+		if err == nil {
+			return repo, fs, nil
+		}
+		log.Printf("Fetch attempt %d failed for %s in memory: %v", i+1, gitUrl, err)
+	}
+	return nil, nil, err
 }
 
 func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool, retries int) error {

--- a/cmd/g2/git_util.go
+++ b/cmd/g2/git_util.go
@@ -12,9 +12,15 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
-func getFileModTime(repoDir string, relPath string, fast bool) time.Time {
-	repo, err := git.PlainOpen(repoDir)
-	if err == nil {
+func getFileModTime(repoDir string, relPath string, fast bool, preOpenedRepo *git.Repository) time.Time {
+	var repo *git.Repository
+	var err error
+	if preOpenedRepo != nil {
+		repo = preOpenedRepo
+	} else {
+		repo, err = git.PlainOpen(repoDir)
+	}
+	if err == nil && repo != nil {
 		head, err := repo.Head()
 		if err == nil {
 			if fast {
@@ -85,7 +91,17 @@ func getFileModTime(repoDir string, relPath string, fast bool) time.Time {
 	return time.Now()
 }
 
-func getGitOriginURL(repoDir string) (string, error) {
+func getGitOriginURL(repoDir string, preOpenedRepo *git.Repository) (string, error) {
+	if preOpenedRepo != nil {
+		remote, err := preOpenedRepo.Remote("origin")
+		if err == nil && remote != nil {
+			if len(remote.Config().URLs) > 0 {
+				return remote.Config().URLs[0], nil
+			}
+		}
+		return "", fmt.Errorf("remote.origin.url not found in pre-opened repository")
+	}
+
 	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
 	cmd.Dir = repoDir
 	out, err := cmd.Output()
@@ -99,7 +115,24 @@ func getGitOriginURL(repoDir string) (string, error) {
 	return url, nil
 }
 
-func getFileCommit(repoDir string, filepath string) (string, error) {
+func getFileCommit(repoDir string, filepath string, preOpenedRepo *git.Repository) (string, error) {
+	if preOpenedRepo != nil {
+		head, err := preOpenedRepo.Head()
+		if err == nil {
+			commitIter, err := preOpenedRepo.Log(&git.LogOptions{
+				From:     head.Hash(),
+				FileName: &filepath,
+			})
+			if err == nil {
+				commit, err := commitIter.Next()
+				if err == nil && commit != nil {
+					return commit.Hash.String(), nil
+				}
+			}
+		}
+		return "", fmt.Errorf("file commit not found in pre-opened repository")
+	}
+
 	cmd := exec.Command("git", "log", "-n", "1", "--pretty=format:%H", "--", filepath)
 	cmd.Dir = repoDir
 	out, err := cmd.Output()

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -3422,6 +3422,8 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
+			var siteData *SiteData
+
 			if useMemory {
 				log.Printf("[START] Fetching remote repository into memory: %s (%s)", repo.Name, gitUrl)
 
@@ -3443,7 +3445,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				sysFS := NewBillyFS(bfs)
 
 				t1 := time.Now()
-				siteData, err := parseRepo(sysFS, ".", repo.Name, fastGit, &repoCopy, SourceURL(gitUrl), gitRepo)
+				siteData, err = parseRepo(sysFS, ".", repo.Name, fastGit, &repoCopy, SourceURL(gitUrl), gitRepo)
 				if err != nil {
 					log.Printf("Failed to parse repo %s from memory: %v", repo.Name, err)
 					return nil
@@ -3454,11 +3456,6 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				siteData.CheckoutTime = checkoutTime.String()
 				siteData.ProcessTime = processTime.String()
 				siteData.GitSize = "Memory"
-
-				allSitesMu.Lock()
-				allSites = append(allSites, siteData)
-				allSitesMu.Unlock()
-				return nil
 			} else {
 				log.Printf("[START] Fetching remote repository: %s (%s)", repo.Name, gitUrl)
 
@@ -3492,7 +3489,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				repoCopy := repo
 
 				t1 := time.Now()
-				siteData, err := parseRepo(os.DirFS(repoPath), ".", repo.Name, fastGit, &repoCopy, SourceURL(gitUrl))
+				siteData, err = parseRepo(os.DirFS(repoPath), ".", repo.Name, fastGit, &repoCopy, SourceURL(gitUrl))
 				if err != nil {
 					log.Printf("Failed to parse repo %s: %v", repo.Name, err)
 					return nil
@@ -3508,12 +3505,12 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				siteData.CheckoutTime = checkoutTime.String()
 				siteData.ProcessTime = processTime.String()
 				siteData.GitSize = gitSize
-
-				allSitesMu.Lock()
-				allSites = append(allSites, siteData)
-				allSitesMu.Unlock()
-				return nil
 			}
+
+			allSitesMu.Lock()
+			allSites = append(allSites, siteData)
+			allSitesMu.Unlock()
+			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -23,6 +23,7 @@ import (
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints"
 	"github.com/arran4/g2/lints/ebuild"
+	"github.com/go-git/go-git/v5"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -226,6 +227,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	recentDurOpt := fs.String("recent-duration", "3mo", "Duration to consider an update 'recent' (e.g. 3mo, 14d, 72h)")
 	fastGit := fs.Bool("fast-git-modtime", false, "Use fast (O(1)) but potentially less reliable go-git file log lookup")
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
+	useMemory := fs.Bool("use-memory", false, "Use pure memory based git checkout for speed")
 
 	if err := fs.Parse(args[2:]); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
@@ -255,42 +257,68 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	var siteData *SiteData
 
 	if isRemote {
-		tmpDir, err := os.MkdirTemp("", "g2-overlay-*")
-		if err != nil {
-			return fmt.Errorf("creating temp dir: %w", err)
+		if *useMemory {
+			cleanup = func() {}
+			log.Printf("Cloning remote repository into memory: %s", location)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			t0 := time.Now()
+			repo, bfs, err := FetchRepoMemory(ctx, location, 0)
+			if err != nil {
+				return fmt.Errorf("cloning repository into memory: %w", err)
+			}
+			checkoutTime := time.Since(t0)
+
+			sysFS := NewBillyFS(bfs)
+
+			t1 := time.Now()
+			siteData, err = parseRepo(sysFS, ".", "Gentoo Packages", *fastGit, nil, SourceURL(location), repo)
+			if err != nil {
+				return fmt.Errorf("parsing repo from memory: %w", err)
+			}
+			processTime := time.Since(t1)
+
+			siteData.CheckoutTime = checkoutTime.String()
+			siteData.ProcessTime = processTime.String()
+			siteData.GitSize = "Memory"
+		} else {
+			tmpDir, err := os.MkdirTemp("", "g2-overlay-*")
+			if err != nil {
+				return fmt.Errorf("creating temp dir: %w", err)
+			}
+			cleanup = func() { _ = os.RemoveAll(tmpDir) }
+
+			log.Printf("Cloning remote repository: %s", location)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			t0 := time.Now()
+			if err := FetchRepo(ctx, location, tmpDir, *useZip, 0); err != nil {
+				cleanup()
+				return fmt.Errorf("cloning repository: %w", err)
+			}
+			checkoutTime := time.Since(t0)
+
+			parseLocation = tmpDir
+
+			size, err := getDirSize(parseLocation)
+			var gitSize string
+			if err == nil {
+				gitSize = fmt.Sprintf("%.2f MB", float64(size)/(1024*1024))
+			}
+
+			t1 := time.Now()
+			siteData, err = parseRepo(os.DirFS(parseLocation), ".", "Gentoo Packages", *fastGit, nil, SourceURL(location))
+			if err != nil {
+				return fmt.Errorf("parsing repo: %w", err)
+			}
+			processTime := time.Since(t1)
+
+			siteData.CheckoutTime = checkoutTime.String()
+			siteData.ProcessTime = processTime.String()
+			siteData.GitSize = gitSize
 		}
-		cleanup = func() { _ = os.RemoveAll(tmpDir) }
-
-		log.Printf("Cloning remote repository: %s", location)
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-
-		t0 := time.Now()
-		if err := FetchRepo(ctx, location, tmpDir, *useZip, 0); err != nil {
-			cleanup()
-			return fmt.Errorf("cloning repository: %w", err)
-		}
-		checkoutTime := time.Since(t0)
-
-		parseLocation = tmpDir
-
-		size, err := getDirSize(parseLocation)
-		var gitSize string
-		if err == nil {
-			gitSize = fmt.Sprintf("%.2f MB", float64(size)/(1024*1024))
-		}
-
-		t1 := time.Now()
-		siteData, err = parseRepo(os.DirFS(parseLocation), ".", "Gentoo Packages", *fastGit, nil, SourceURL(location))
-		if err != nil {
-			return fmt.Errorf("parsing repo: %w", err)
-		}
-		processTime := time.Since(t1)
-
-		siteData.CheckoutTime = checkoutTime.String()
-		siteData.ProcessTime = processTime.String()
-		siteData.GitSize = gitSize
-
 	} else {
 		parseLocation = location
 		cleanup = func() {}
@@ -346,6 +374,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	recentDurOpt := fs.String("recent-duration", "3mo", "Duration to consider an update 'recent' (e.g. 3mo, 14d, 72h)")
 	fastGit := fs.Bool("fast-git-modtime", false, "Use fast (O(1)) but potentially less reliable go-git file log lookup")
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
+	useMemory := fs.Bool("use-memory", false, "Use pure memory based git checkout for speed")
 	concurrency := fs.Int("concurrency", 4, "Maximum number of concurrent repository fetches/parses")
 	retries := fs.Int("retries", 3, "Number of times to retry fetching a repository")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue parsing other repositories even if fetching one fails")
@@ -370,7 +399,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	}
 
 	log.Printf("Generating site (v%s) from remote repositories: %s into %s", version, location, *outDir)
-	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError)
+	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *useMemory, *concurrency, *retries, *continueOnError)
 }
 
 func parseLayoutConfFromFS(sysFS fs.FS, path string) (*g2.LayoutConf, error) {
@@ -586,10 +615,13 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 	var repoName string
 	var remoteURL string
 
+	var gitRepo *git.Repository
 	for _, opt := range opts {
 		switch o := opt.(type) {
 		case SourceURL:
 			remoteURL = string(o)
+		case *git.Repository:
+			gitRepo = o
 		}
 	}
 
@@ -605,7 +637,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		remoteURL = ""
 
 		// 1. Git origin URL
-		gitURL, err := getGitOriginURL(repoDir)
+		gitURL, err := getGitOriginURL(repoDir, gitRepo)
 		if err == nil && !isUselessURL(gitURL) {
 			remoteURL = gitURL
 		}
@@ -822,7 +854,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		if authors, err := g2.ParseAuthors(authorsFile); err == nil {
 			site.Authors = authors
 			if remoteURL != "" {
-				commitHash, err := getFileCommit(repoDir, "metadata/AUTHORS")
+				commitHash, err := getFileCommit(repoDir, "metadata/AUTHORS", gitRepo)
 				if err == nil && commitHash != "" {
 					site.AuthorsURL = generateGitHubRawURL(remoteURL, commitHash, "metadata/AUTHORS")
 				}
@@ -967,13 +999,13 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 				var ebuildRawURL string
 				relPath, _ := filepath.Rel(repoDir, ebuildPath)
 				if remoteURL != "" {
-					commitHash, _ := getFileCommit(repoDir, relPath)
+					commitHash, _ := getFileCommit(repoDir, relPath, gitRepo)
 					if commitHash != "" {
 						ebuildRawURL = generateGitHubRawURL(remoteURL, commitHash, relPath)
 					}
 				}
 
-				modTime := getFileModTime(repoDir, relPath, fastGit)
+				modTime := getFileModTime(repoDir, relPath, fastGit, gitRepo)
 				if modTime.After(pkgData.ModTime) {
 					pkgData.ModTime = modTime
 				}
@@ -1078,7 +1110,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 
 			if remoteURL != "" {
 				relPath, _ := filepath.Rel(repoDir, metaPath)
-				commitHash, _ := getFileCommit(repoDir, relPath)
+				commitHash, _ := getFileCommit(repoDir, relPath, gitRepo)
 				if commitHash != "" {
 					pkgData.MetadataRawURL = generateGitHubRawURL(remoteURL, commitHash, relPath)
 				}
@@ -1126,7 +1158,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 							}
 							if remoteURL != "" {
 								relPath, _ := filepath.Rel(repoDir, fd.Path)
-								commitHash, _ := getFileCommit(repoDir, relPath)
+								commitHash, _ := getFileCommit(repoDir, relPath, gitRepo)
 								if commitHash != "" {
 									fd.RawURL = generateGitHubRawURL(remoteURL, commitHash, relPath)
 								}
@@ -3314,7 +3346,7 @@ func renderPage(path string, tmpl *template.Template, name string, data interfac
 	return nil
 }
 
-func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool) error {
+func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, useMemory bool, concurrency int, retries int, continueOnError bool) error {
 	var data []byte
 	var err error
 
@@ -3387,62 +3419,101 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 		}
 
 		g.Go(func() error {
-			log.Printf("[START] Fetching remote repository: %s (%s)", repo.Name, gitUrl)
-
-			repoPath := filepath.Join(tmpDir, repo.Name)
-			defer func() { _ = os.RemoveAll(repoPath) }()
-
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			t0 := time.Now()
-			if err := FetchRepo(ctx, gitUrl, repoPath, useZip, retries); err != nil {
-				log.Printf("Failed to fetch %s: %v", repo.Name, err)
-				if !continueOnError {
-					return fmt.Errorf("fetching %s: %w", repo.Name, err)
+			if useMemory {
+				log.Printf("[START] Fetching remote repository into memory: %s (%s)", repo.Name, gitUrl)
+
+				t0 := time.Now()
+				gitRepo, bfs, err := FetchRepoMemory(ctx, gitUrl, retries)
+				if err != nil {
+					log.Printf("Failed to fetch %s in memory: %v", repo.Name, err)
+					if !continueOnError {
+						return fmt.Errorf("fetching %s in memory: %w", repo.Name, err)
+					}
+					return nil
 				}
+				checkoutTime := time.Since(t0)
+				log.Printf("[DONE] Finished fetching repository %s in memory in %s", repo.Name, checkoutTime)
+
+				log.Printf("[START] Parsing repository from memory: %s", repo.Name)
+
+				repoCopy := repo
+				sysFS := NewBillyFS(bfs)
+
+				t1 := time.Now()
+				siteData, err := parseRepo(sysFS, ".", repo.Name, fastGit, &repoCopy, SourceURL(gitUrl), gitRepo)
+				if err != nil {
+					log.Printf("Failed to parse repo %s from memory: %v", repo.Name, err)
+					return nil
+				}
+				processTime := time.Since(t1)
+				log.Printf("[DONE] Finished parsing repository %s from memory in %s", repo.Name, processTime)
+
+				siteData.CheckoutTime = checkoutTime.String()
+				siteData.ProcessTime = processTime.String()
+				siteData.GitSize = "Memory"
+
+				allSitesMu.Lock()
+				allSites = append(allSites, siteData)
+				allSitesMu.Unlock()
+				return nil
+			} else {
+				log.Printf("[START] Fetching remote repository: %s (%s)", repo.Name, gitUrl)
+
+				repoPath := filepath.Join(tmpDir, repo.Name)
+				defer func() { _ = os.RemoveAll(repoPath) }()
+
+				t0 := time.Now()
+				if err := FetchRepo(ctx, gitUrl, repoPath, useZip, retries); err != nil {
+					log.Printf("Failed to fetch %s: %v", repo.Name, err)
+					if !continueOnError {
+						return fmt.Errorf("fetching %s: %w", repo.Name, err)
+					}
+					return nil
+				}
+				checkoutTime := time.Since(t0)
+				freeSpace, err := getFreeSpace(repoPath)
+				if err == nil {
+					log.Printf("[DONE] Finished fetching repository %s in %s. Free space: %.2f MB", repo.Name, checkoutTime, float64(freeSpace)/(1024*1024))
+				} else {
+					log.Printf("[DONE] Finished fetching repository %s in %s", repo.Name, checkoutTime)
+				}
+
+				log.Printf("[START] Parsing repository: %s", repo.Name)
+
+				size, err := getDirSize(repoPath)
+				var gitSize string
+				if err == nil {
+					gitSize = fmt.Sprintf("%.2f MB", float64(size)/(1024*1024))
+				}
+
+				repoCopy := repo
+
+				t1 := time.Now()
+				siteData, err := parseRepo(os.DirFS(repoPath), ".", repo.Name, fastGit, &repoCopy, SourceURL(gitUrl))
+				if err != nil {
+					log.Printf("Failed to parse repo %s: %v", repo.Name, err)
+					return nil
+				}
+				processTime := time.Since(t1)
+				freeSpaceAfter, err := getFreeSpace(repoPath)
+				if err == nil {
+					log.Printf("[DONE] Finished parsing repository %s in %s. Free space: %.2f MB", repo.Name, processTime, float64(freeSpaceAfter)/(1024*1024))
+				} else {
+					log.Printf("[DONE] Finished parsing repository %s in %s", repo.Name, processTime)
+				}
+
+				siteData.CheckoutTime = checkoutTime.String()
+				siteData.ProcessTime = processTime.String()
+				siteData.GitSize = gitSize
+
+				allSitesMu.Lock()
+				allSites = append(allSites, siteData)
+				allSitesMu.Unlock()
 				return nil
 			}
-			checkoutTime := time.Since(t0)
-			freeSpace, err := getFreeSpace(repoPath)
-			if err == nil {
-				log.Printf("[DONE] Finished fetching repository %s in %s. Free space: %.2f MB", repo.Name, checkoutTime, float64(freeSpace)/(1024*1024))
-			} else {
-				log.Printf("[DONE] Finished fetching repository %s in %s", repo.Name, checkoutTime)
-			}
-
-			log.Printf("[START] Parsing repository: %s", repo.Name)
-
-			size, err := getDirSize(repoPath)
-			var gitSize string
-			if err == nil {
-				gitSize = fmt.Sprintf("%.2f MB", float64(size)/(1024*1024))
-			}
-
-			repoCopy := repo
-
-			t1 := time.Now()
-			siteData, err := parseRepo(os.DirFS(repoPath), ".", repo.Name, fastGit, &repoCopy, SourceURL(gitUrl))
-			if err != nil {
-				log.Printf("Failed to parse repo %s: %v", repo.Name, err)
-				return nil
-			}
-			processTime := time.Since(t1)
-			freeSpaceAfter, err := getFreeSpace(repoPath)
-			if err == nil {
-				log.Printf("[DONE] Finished parsing repository %s in %s. Free space: %.2f MB", repo.Name, processTime, float64(freeSpaceAfter)/(1024*1024))
-			} else {
-				log.Printf("[DONE] Finished parsing repository %s in %s", repo.Name, processTime)
-			}
-
-			siteData.CheckoutTime = checkoutTime.String()
-			siteData.ProcessTime = processTime.String()
-			siteData.GitSize = gitSize
-
-			allSitesMu.Lock()
-			allSites = append(allSites, siteData)
-			allSitesMu.Unlock()
-			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/go-git/go-git/v5 v5.17.1
+	github.com/go-git/go-git/v5 v5.17.2
 	golang.org/x/crypto v0.46.0
 	golang.org/x/text v0.32.0
 	golang.org/x/tools v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMj
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5Jk=
 github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
+github.com/go-git/go-git/v5 v5.17.2 h1:B+nkdlxdYrvyFK4GPXVU8w1U+YkbsgciIR7f2sZJ104=
+github.com/go-git/go-git/v5 v5.17.2/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
Adds a pure memory-based Git checkout option using `go-git` to improve fetching and parsing speed.

---
*PR created automatically by Jules for task [2867085770504921921](https://jules.google.com/task/2867085770504921921) started by @arran4*