### PR TITLE
fix: Fix golangci-lint typecheck error for eclassDir

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1298,7 +1298,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 	extractVirtualDeps(site)
 
 	// Parse Eclasses
-	eclassDir := filepath.Join(repoDir, "eclass")
+	eclassDir = filepath.Join(repoDir, "eclass")
 	if info, err := fs.Stat(sysFS, filepath.ToSlash(eclassDir)); err == nil && info.IsDir() {
 		entries, err := fs.ReadDir(sysFS, filepath.ToSlash(eclassDir))
 		if err == nil {


### PR DESCRIPTION
Fixes a `golangci-lint` typecheck error where `eclassDir` was incorrectly being declared again with `:=` instead of assigned with `=`.

---
*PR created automatically by Jules for task [1394405604380429174](https://jules.google.com/task/1394405604380429174) started by @arran4*