### PR TITLE
Fix 404 for arches index page and conditionally render dashboard link

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -2484,6 +2484,7 @@ func generateGlobalPages(outDir string, tmpl *template.Template, sites []*SiteDa
 		UseFlags:             data.UseFlags,
 		Projects:             data.Projects,
 		Profiles:             data.Profiles,
+		Arches:               data.Arches,
 		Version:              version,
 		GenInfo:              genInfo,
 		RecentDurationString: recentDurationStr,
@@ -2742,37 +2743,35 @@ func generatePackagePages(outDir string, tmpl *template.Template, data *Aggregat
 
 func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *AggregatedData, title, version string, genInfo GenerationInfo) error {
 	// Arches
-	if len(data.Arches) > 0 {
-		if err := os.MkdirAll(filepath.Join(outDir, "arches"), 0755); err != nil {
-			return fmt.Errorf("creating directory: %w", err)
+	if err := os.MkdirAll(filepath.Join(outDir, "arches"), 0755); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+	if err := renderPage(filepath.Join(outDir, "arches", "index.html"), tmpl, "arches.html", GenericPageContext{
+		Title:       "Architectures",
+		BaseURL:     "../",
+		Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Architectures"}},
+		Arches:      data.Arches,
+		Version:     version,
+		GenInfo:     genInfo,
+	}); err != nil {
+		return fmt.Errorf("rendering page: %w", err)
+	}
+
+	for _, a := range data.Arches {
+		archDir := filepath.Join(outDir, "arches", a.Name)
+		if err := os.MkdirAll(archDir, 0755); err != nil {
+			return fmt.Errorf("creating directory %s: %w", archDir, err)
 		}
-		if err := renderPage(filepath.Join(outDir, "arches", "index.html"), tmpl, "arches.html", GenericPageContext{
-			Title:       "Architectures",
-			BaseURL:     "../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Architectures"}},
-			Arches:      data.Arches,
+
+		if err := renderPage(filepath.Join(archDir, "index.html"), tmpl, "arch.html", GenericPageContext{
+			Title:       "Architecture: " + a.Name,
+			BaseURL:     "../../",
+			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "Architectures", URL: "../../arches/"}, {Name: a.Name}},
+			Arch:        a,
 			Version:     version,
 			GenInfo:     genInfo,
 		}); err != nil {
 			return fmt.Errorf("rendering page: %w", err)
-		}
-
-		for _, a := range data.Arches {
-			archDir := filepath.Join(outDir, "arches", a.Name)
-			if err := os.MkdirAll(archDir, 0755); err != nil {
-				return fmt.Errorf("creating directory %s: %w", archDir, err)
-			}
-
-			if err := renderPage(filepath.Join(archDir, "index.html"), tmpl, "arch.html", GenericPageContext{
-				Title:       "Architecture: " + a.Name,
-				BaseURL:     "../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "Architectures", URL: "../../arches/"}, {Name: a.Name}},
-				Arch:        a,
-				Version:     version,
-				GenInfo:     genInfo,
-			}); err != nil {
-				return fmt.Errorf("rendering page: %w", err)
-			}
 		}
 	}
 

--- a/templates/views/dashboard.html
+++ b/templates/views/dashboard.html
@@ -35,7 +35,9 @@
         {{if and .Profiles (gt (len .Profiles) 0)}}
         <li><a href="profiles/">Profiles</a></li>
         {{end}}
+        {{if and .Arches (gt (len .Arches) 0)}}
         <li><a href="arches/">Architectures</a></li>
+        {{end}}
         {{if and .GlobalNews (gt (len .GlobalNews) 0)}}
         <li><a href="news/">News ({{len .GlobalNews}})</a></li>
         {{end}}


### PR DESCRIPTION
This commit addresses the issue where the `arches/` link from the dashboard results in a 404 error when there are no architectures defined. It applies two fixes: first, it always generates the empty `arches/index.html` directory so keyword links will resolve safely instead of returning 404. Second, it hides the Architectures link from the dashboard when the overlay has zero defined architectures, matching the behavior of similar dashboard elements like Profiles.

---
*PR created automatically by Jules for task [9324375128470821969](https://jules.google.com/task/9324375128470821969) started by @arran4*