### PR TITLE
🧹 [code health] Remove outdated manifest TODO comment from repo_package.html

### DIFF
--- a/templates/views/repo_package.html
+++ b/templates/views/repo_package.html
@@ -254,7 +254,6 @@
     </table>
     <details>
         <summary>Unmatched Entries</summary>
-        <!-- TODO: add to lint, and create a subcommand manifest clean, manifest verify, manifest verify -download etc -->
         <table>
             <tr>
                 <th>Type</th>


### PR DESCRIPTION
🎯 **What:** Removed the obsolete `TODO: add to lint, and create a subcommand manifest clean, manifest verify, manifest verify -download etc` comment from `templates/views/repo_package.html`.
💡 **Why:** The mentioned features (`manifest clean`, `manifest verify`) are already implemented in `cmd/g2/main.go`. This cleans up a stale TODO comment from the template and improves readability.
✅ **Verification:** Ran `go test ./...` and `golangci-lint run`. Both pass.
✨ **Result:** Improved code health by removing an outdated TODO comment.

---
*PR created automatically by Jules for task [3095941148404081370](https://jules.google.com/task/3095941148404081370) started by @arran4*