### PR TITLE
🔒 Fix Zip Slip vulnerability in zip extraction

### DIFF
--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -116,6 +116,16 @@ func updatePersistentRepo(ctx context.Context, destDir string) error {
 	return nil
 }
 
+type WriteFS interface {
+	MkdirAll(path string, perm os.FileMode) error
+	Create(name string) (io.WriteCloser, error)
+}
+
+type osWriteFS struct{}
+
+func (osWriteFS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
+func (osWriteFS) Create(name string) (io.WriteCloser, error)   { return os.Create(name) }
+
 func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip bool, persistent bool) error {
 	if persistent {
 		gitDir := filepath.Join(destDir, ".git")
@@ -146,7 +156,7 @@ func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip
 			if converter != nil {
 				zipUrl, err := converter(gitUrl)
 				if err == nil {
-					if err := downloadAndExtractZip(ctx, zipUrl, destDir); err == nil {
+					if err := downloadAndExtractZip(ctx, zipUrl, destDir, osWriteFS{}); err == nil {
 						return nil
 					}
 					// If zip fails, we fallback to git clone
@@ -162,7 +172,7 @@ func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip
 	return cmd.Run()
 }
 
-func downloadAndExtractZip(ctx context.Context, zipUrl string, destDir string) error {
+func downloadAndExtractZip(ctx context.Context, zipUrl string, destDir string, wfs WriteFS) error {
 	req, err := http.NewRequestWithContext(ctx, "GET", zipUrl, nil)
 	if err != nil {
 		return err
@@ -216,7 +226,7 @@ func downloadAndExtractZip(ctx context.Context, zipUrl string, destDir string) e
 		}
 	}
 
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := wfs.MkdirAll(destDir, 0755); err != nil {
 		return err
 	}
 
@@ -239,7 +249,7 @@ func downloadAndExtractZip(ctx context.Context, zipUrl string, destDir string) e
 
 		targetPath := filepath.Join(destDir, localPath)
 
-		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		if err := wfs.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
 			return err
 		}
 
@@ -248,7 +258,7 @@ func downloadAndExtractZip(ctx context.Context, zipUrl string, destDir string) e
 			return err
 		}
 
-		out, err := os.Create(targetPath)
+		out, err := wfs.Create(targetPath)
 		if err != nil {
 			_ = rc.Close()
 			return err

--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -229,10 +229,15 @@ func downloadAndExtractZip(ctx context.Context, zipUrl string, destDir string) e
 			relPath = strings.TrimPrefix(f.Name, rootPrefix)
 		}
 
-		targetPath := filepath.Clean(filepath.Join(destDir, relPath))
-		if !strings.HasPrefix(targetPath, filepath.Clean(destDir)+string(os.PathSeparator)) && targetPath != filepath.Clean(destDir) {
-			continue
+		localPath := filepath.FromSlash(relPath)
+		if localPath == "" {
+			continue // Root directory entry stripped by rootPrefix logic
 		}
+		if !filepath.IsLocal(localPath) {
+			return fmt.Errorf("zip slip vulnerability detected: invalid path %q", relPath)
+		}
+
+		targetPath := filepath.Join(destDir, localPath)
 
 		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
 			return err

--- a/cmd/g2/fetch_test.go
+++ b/cmd/g2/fetch_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/tools/txtar"
@@ -88,5 +89,50 @@ package main
 	_, err = os.Stat(filepath.Join(destDir, "myrepo-HEAD"))
 	if err == nil {
 		t.Errorf("myrepo-HEAD directory was not stripped")
+	}
+}
+
+func TestDownloadAndExtractZip_ZipSlip(t *testing.T) {
+	buf := new(bytes.Buffer)
+	zw := zip.NewWriter(buf)
+
+	// Add a normal file
+	w, err := zw.Create("normal.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.Write([]byte("normal"))
+
+	// Add a malicious file
+	wMalicious, err := zw.Create("../../etc/passwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = wMalicious.Write([]byte("malicious"))
+
+	err = zw.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer ts.Close()
+
+	destDir, err := os.MkdirTemp("", "g2-fetch-zipslip-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(destDir) }()
+
+	err = downloadAndExtractZip(context.Background(), ts.URL, destDir)
+	if err == nil {
+		t.Fatal("expected error due to zip slip, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "zip slip vulnerability detected") {
+		t.Errorf("expected zip slip error message, got: %v", err)
 	}
 }

--- a/cmd/g2/fetch_test.go
+++ b/cmd/g2/fetch_test.go
@@ -11,8 +11,29 @@ import (
 	"strings"
 	"testing"
 
+	"io"
 	"golang.org/x/tools/txtar"
 )
+
+type memWriteFS struct {
+	files map[string]*bytes.Buffer
+}
+
+func (m *memWriteFS) MkdirAll(path string, perm os.FileMode) error {
+	return nil
+}
+
+type nopCloser struct{ io.Writer }
+func (nopCloser) Close() error { return nil }
+
+func (m *memWriteFS) Create(name string) (io.WriteCloser, error) {
+	if m.files == nil {
+		m.files = make(map[string]*bytes.Buffer)
+	}
+	buf := new(bytes.Buffer)
+	m.files[name] = buf
+	return nopCloser{Writer: buf}, nil
+}
 
 func TestDownloadAndExtractZipRootPrefix(t *testing.T) {
 	// We use txtar to define the structure and content of our archive clearly.
@@ -64,31 +85,28 @@ package main
 	}))
 	defer ts.Close()
 
-	destDir, err := os.MkdirTemp("", "g2-fetch-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(destDir) }()
+	destDir := "/memfs"
 
-	err = downloadAndExtractZip(context.Background(), ts.URL, destDir)
+	mfs := &memWriteFS{}
+
+	err = downloadAndExtractZip(context.Background(), ts.URL, destDir, mfs)
 	if err != nil {
 		t.Fatalf("downloadAndExtractZip failed: %v", err)
 	}
 
 	// Verify the root prefix "myrepo-HEAD/" was successfully stripped
-	_, err = os.Stat(filepath.Join(destDir, "README.md"))
-	if err != nil {
-		t.Errorf("README.md not found in destDir: %v", err)
+	if _, ok := mfs.files[filepath.Join(destDir, "README.md")]; !ok {
+		t.Errorf("README.md not found in destDir")
 	}
 
-	_, err = os.Stat(filepath.Join(destDir, "src", "main.go"))
-	if err != nil {
-		t.Errorf("src/main.go not found in destDir: %v", err)
+	if _, ok := mfs.files[filepath.Join(destDir, "src", "main.go")]; !ok {
+		t.Errorf("src/main.go not found in destDir")
 	}
 
-	_, err = os.Stat(filepath.Join(destDir, "myrepo-HEAD"))
-	if err == nil {
-		t.Errorf("myrepo-HEAD directory was not stripped")
+	for k := range mfs.files {
+		if strings.Contains(k, "myrepo-HEAD") {
+			t.Errorf("myrepo-HEAD directory was not stripped: found file %q", k)
+		}
 	}
 }
 
@@ -125,13 +143,11 @@ malicious
 	}))
 	defer ts.Close()
 
-	destDir, err := os.MkdirTemp("", "g2-fetch-zipslip-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(destDir) }()
+	destDir := "/memfs"
 
-	err = downloadAndExtractZip(context.Background(), ts.URL, destDir)
+	mfs := &memWriteFS{}
+
+	err = downloadAndExtractZip(context.Background(), ts.URL, destDir, mfs)
 	if err == nil {
 		t.Fatal("expected error due to zip slip, got nil")
 	}

--- a/cmd/g2/fetch_test.go
+++ b/cmd/g2/fetch_test.go
@@ -93,24 +93,28 @@ package main
 }
 
 func TestDownloadAndExtractZip_ZipSlip(t *testing.T) {
+	fixture := `
+-- normal.txt --
+normal
+-- ../../etc/passwd --
+malicious
+`
+	ar := txtar.Parse([]byte(fixture))
+
 	buf := new(bytes.Buffer)
 	zw := zip.NewWriter(buf)
 
-	// Add a normal file
-	w, err := zw.Create("normal.txt")
-	if err != nil {
-		t.Fatal(err)
+	for _, f := range ar.Files {
+		w, err := zw.Create(f.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write(f.Data); err != nil {
+			t.Fatal(err)
+		}
 	}
-	_, _ = w.Write([]byte("normal"))
 
-	// Add a malicious file
-	wMalicious, err := zw.Create("../../etc/passwd")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, _ = wMalicious.Write([]byte("malicious"))
-
-	err = zw.Close()
+	err := zw.Close()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
A Zip Slip (path traversal) vulnerability in the zip archive extraction process within `cmd/g2/fetch.go`.

⚠️ **Risk:** The potential impact if left unfixed
A malicious zip file containing path traversal characters (`../`) could write files outside of the target extraction directory. This could lead to arbitrary file overwrite, which could be leveraged to execute remote code or compromise the system executing the tool.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix implements `filepath.IsLocal` to guarantee the requested relative path explicitly points to a safe, confined path. It also defensively accounts for trailing zip headers that evaluate to an empty path after structural processing to ensure healthy zip directories extract without functional regression. A direct unit test `TestDownloadAndExtractZip_ZipSlip` was added to assert failure paths against explicit payload testing.

---
*PR created automatically by Jules for task [3671366823300211829](https://jules.google.com/task/3671366823300211829) started by @arran4*