### PR TITLE
feat(cli): add ebuild tag and bump-version subcommands

### DIFF
--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -35,6 +35,8 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 		fmt.Printf("\t\t %s \t\t %s\n", "check", "A lightweight structural validator for ebuild files (alias: lint)")
 		fmt.Printf("\t\t %s \t\t %s\n", "deps", "Extract and format dependency fields")
 		fmt.Printf("\t\t %s \t\t %s\n", "query", "Query specific fields from parsed output")
+		fmt.Printf("\t\t %s \t\t %s\n", "bump-version", "Rename ebuild to a new version and fix references")
+		fmt.Printf("\t\t %s \t\t %s\n", "tag", "Ebuild specific tag subcommand supporting version comparisons")
 	}
 
 	config := &CmdEbuildArgConfig{
@@ -85,6 +87,14 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 	case "query":
 		if err := config.cmdEbuildQuery(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild query: %w", err)
+		}
+	case "bump-version":
+		if err := config.cmdEbuildBumpVersion(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild bump-version: %w", err)
+		}
+	case "tag":
+		if err := config.cmdEbuildTag(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild tag: %w", err)
 		}
 	case "help", "-help", "--help":
 		fs.Usage()

--- a/cmd/g2/ebuild_bump_version.go
+++ b/cmd/g2/ebuild_bump_version.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/arran4/g2"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (cfg *CmdEbuildArgConfig) cmdEbuildBumpVersion(args []string) error {
+	fs := flag.NewFlagSet("bump-version", flag.ExitOnError)
+	tagOnly := fs.Bool("tag", false, "Only focus on the ebuild file, do not update Manifest")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() != 2 {
+		return fmt.Errorf("usage: g2 ebuild bump-version [--tag] <old-ebuild> <new-version>")
+	}
+
+	oldEbuildPath := fs.Arg(0)
+	newVersion := fs.Arg(1)
+
+	// Clean the path
+	oldEbuildPath = filepath.Clean(oldEbuildPath)
+	dir := filepath.Dir(oldEbuildPath)
+	base := filepath.Base(oldEbuildPath)
+
+	if !strings.HasSuffix(base, ".ebuild") {
+		return fmt.Errorf("expected ebuild file, got %s", base)
+	}
+
+	vars := g2.ParseEbuildVariables(base)
+	if vars == nil || vars["PN"] == "" {
+		return fmt.Errorf("failed to parse PN from ebuild filename %s", base)
+	}
+	pn := vars["PN"]
+
+	// Rename ebuild
+	newBase := fmt.Sprintf("%s-%s.ebuild", pn, newVersion)
+	newEbuildPath := filepath.Join(dir, newBase)
+
+	log.Printf("Bumping %s to version %s (%s)\n", base, newVersion, newBase)
+
+	if err := os.Rename(oldEbuildPath, newEbuildPath); err != nil {
+		return fmt.Errorf("failed to rename ebuild: %w", err)
+	}
+
+	if *tagOnly {
+		log.Printf("Tag mode specified, skipping Manifest update.")
+		return nil
+	}
+
+	// Fix References (Manifest)
+	// We check if Manifest exists
+	manifestPath := filepath.Join(dir, "Manifest")
+	if _, err := os.Stat(manifestPath); err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("No Manifest found in %s, skipping Manifest update.", dir)
+			return nil
+		}
+		return fmt.Errorf("failed to stat Manifest: %w", err)
+	}
+
+	// 1. Remove entries for the old ebuild
+	content, err := os.ReadFile(newEbuildPath)
+	if err != nil {
+		return fmt.Errorf("failed to read new ebuild %s: %w", newEbuildPath, err)
+	}
+
+	oldVars := vars
+	if oldVars["P"] == "" {
+		// Calculate P if missing
+		oldVars["P"] = strings.TrimSuffix(base, ".ebuild")
+	}
+	oldUris, _ := g2.ExtractURIs(string(content), oldVars)
+
+	newVars := map[string]string{
+		"P":  pn + "-" + newVersion,
+		"PN": pn,
+		"PV": newVersion,
+	}
+	newUris, err := g2.ExtractURIs(string(content), newVars)
+	if err != nil {
+		log.Printf("Warning: failed to extract URIs from new ebuild: %v", err)
+		newUris = nil
+	}
+
+	// Check all other ebuilds in the directory to see if they need the old URIs
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	neededByOthers := make(map[string]bool)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".ebuild") || entry.Name() == newBase {
+			continue
+		}
+
+		otherVars := g2.ParseEbuildVariables(entry.Name())
+		if otherVars == nil {
+			continue
+		}
+
+		otherContent, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+
+		otherUris, _ := g2.ExtractURIs(string(otherContent), otherVars)
+		for _, u := range otherUris {
+			neededByOthers[u.Filename] = true
+		}
+	}
+
+	// Remove old URIs and download new ones
+	manifest, err := g2.ParseManifest(manifestPath)
+	if err != nil {
+		return fmt.Errorf("failed to parse manifest: %w", err)
+	}
+
+	for _, uri := range oldUris {
+		// Only remove if it's not present in the new ones AND not needed by other ebuilds
+		foundInNew := false
+		for _, newUri := range newUris {
+			if uri.Filename == newUri.Filename {
+				foundInNew = true
+				break
+			}
+		}
+		if !foundInNew && !neededByOthers[uri.Filename] {
+			log.Printf("Removing old manifest entry: %s", uri.Filename)
+			manifest.Remove(uri.Filename)
+		}
+	}
+
+	// 2. Add entries for the new ebuild
+	// Find the hashes required
+	hashes := []string{g2.HashBlake2b, g2.HashSha512} // Default
+	repoDir := filepath.Dir(dir)
+	layoutConfPath := filepath.Join(repoDir, "metadata", "layout.conf")
+	if lc, err := g2.ParseLayoutConf(layoutConfPath); err == nil {
+		if manifestHashes := lc.GetValuesAsSlice("manifest-hashes"); len(manifestHashes) > 0 {
+			hashes = manifestHashes
+		}
+	}
+
+	for _, uri := range newUris {
+		if manifest.GetEntry(uri.Filename) == nil {
+			log.Printf("Fetching and hashing new manifest entry: %s (%s)", uri.Filename, uri.URL)
+			checksums, err := g2.DownloadAndChecksum(uri.URL, hashes)
+			if err != nil {
+				// Don't fail the whole bump if one file is missing, maybe it hasn't been uploaded yet or is a dummy test
+				log.Printf("Warning: error downloading and checksumming %s: %v", uri.URL, err)
+				continue
+			}
+
+			entry := g2.NewManifestEntry("DIST", uri.Filename, checksums.Size)
+			for _, h := range g2.AllHashes {
+				if checksums.Hashes[h] != "" {
+					entry.AddHash(h, checksums.Hashes[h])
+				}
+			}
+			manifest.AddOrReplace(entry)
+		}
+	}
+
+	manifest.Sort()
+	if err := os.WriteFile(manifestPath, []byte(manifest.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write updated Manifest: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/g2/ebuild_bump_version.go
+++ b/cmd/g2/ebuild_bump_version.go
@@ -13,16 +13,20 @@ import (
 func (cfg *CmdEbuildArgConfig) cmdEbuildBumpVersion(args []string) error {
 	fs := flag.NewFlagSet("bump-version", flag.ExitOnError)
 	tagOnly := fs.Bool("tag", false, "Only focus on the ebuild file, do not update Manifest")
+	bumpRevision := fs.Bool("revision", false, "Bump the revision version")
+	bumpPatch := fs.Bool("patch", false, "Bump the patch version")
+	bumpMinor := fs.Bool("minor", false, "Bump the minor version")
+	bumpMajor := fs.Bool("major", false, "Bump the major version")
+
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	if fs.NArg() != 2 {
-		return fmt.Errorf("usage: g2 ebuild bump-version [--tag] <old-ebuild> <new-version>")
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: g2 ebuild bump-version [--tag] [--revision|--patch|--minor|--major] <old-ebuild> [new-version]")
 	}
 
 	oldEbuildPath := fs.Arg(0)
-	newVersion := fs.Arg(1)
 
 	// Clean the path
 	oldEbuildPath = filepath.Clean(oldEbuildPath)
@@ -38,6 +42,33 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildBumpVersion(args []string) error {
 		return fmt.Errorf("failed to parse PN from ebuild filename %s", base)
 	}
 	pn := vars["PN"]
+
+	var newVersion string
+	if *bumpRevision || *bumpPatch || *bumpMinor || *bumpMajor {
+		if fs.NArg() > 1 {
+			return fmt.Errorf("cannot specify both bump flags and a manual new-version")
+		}
+		gv := g2.ParseGentooVersion(vars["PV"])
+		if !gv.IsValid {
+			return fmt.Errorf("could not parse version %s for incrementing", vars["PV"])
+		}
+
+		if *bumpRevision {
+			gv.IncrementPart("revision")
+		} else if *bumpMajor {
+			gv.IncrementPart("major")
+		} else if *bumpMinor {
+			gv.IncrementPart("minor")
+		} else if *bumpPatch {
+			gv.IncrementPart("patch")
+		}
+		newVersion = gv.String()
+	} else {
+		if fs.NArg() != 2 {
+			return fmt.Errorf("usage: g2 ebuild bump-version [--tag] <old-ebuild> <new-version>")
+		}
+		newVersion = fs.Arg(1)
+	}
 
 	// Rename ebuild
 	newBase := fmt.Sprintf("%s-%s.ebuild", pn, newVersion)

--- a/cmd/g2/ebuild_bump_version_test.go
+++ b/cmd/g2/ebuild_bump_version_test.go
@@ -59,6 +59,17 @@ SRC_URI="https://example.com/${P}.tar.gz"
 		t.Errorf("New ebuild file %s was not created: %v", newEbuildPath, err)
 	}
 
+	// Now try bumping with -revision flag instead of explicit version
+	args2 := []string{"-revision", newEbuildPath}
+	if err := cfg.cmdEbuildBumpVersion(args2); err != nil {
+		t.Fatalf("cmdEbuildBumpVersion with -revision failed: %v", err)
+	}
+	newPvRevision := "1.1.0-r1"
+	newEbuildRevisionPath := filepath.Join(tmpDir, pn+"-"+newPvRevision+".ebuild")
+	if _, err := os.Stat(newEbuildRevisionPath); err != nil {
+		t.Errorf("New ebuild file %s was not created by revision bump: %v", newEbuildRevisionPath, err)
+	}
+
 	// Check if manifest is updated properly
 	newManifestBytes, err := os.ReadFile(manifestPath)
 	if err != nil {

--- a/cmd/g2/ebuild_bump_version_test.go
+++ b/cmd/g2/ebuild_bump_version_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEbuildBumpVersion(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir, err := os.MkdirTemp("", "ebuild-bump-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a fake ebuild
+	pn := "testpkg"
+	oldPv := "1.0.0"
+	oldEbuildName := pn + "-" + oldPv + ".ebuild"
+	oldEbuildPath := filepath.Join(tmpDir, oldEbuildName)
+
+	// Create some dummy ebuild content.
+	ebuildContent := `
+EAPI=8
+DESCRIPTION="A test package"
+SRC_URI="https://example.com/${P}.tar.gz"
+`
+	if err := os.WriteFile(oldEbuildPath, []byte(ebuildContent), 0644); err != nil {
+		t.Fatalf("Failed to create fake ebuild: %v", err)
+	}
+
+	// Create a dummy manifest
+	manifestPath := filepath.Join(tmpDir, "Manifest")
+	manifestContent := `DIST testpkg-1.0.0.tar.gz 1024 BLAKE2B 1234567890abcdef SHA512 1234567890abcdef
+`
+	if err := os.WriteFile(manifestPath, []byte(manifestContent), 0644); err != nil {
+		t.Fatalf("Failed to create dummy manifest: %v", err)
+	}
+
+	// Run the bump-version command
+	cfg := &CmdEbuildArgConfig{}
+	newPv := "1.1.0"
+
+	args := []string{oldEbuildPath, newPv}
+	if err := cfg.cmdEbuildBumpVersion(args); err != nil {
+		t.Fatalf("cmdEbuildBumpVersion failed: %v", err)
+	}
+
+	// Check if old ebuild is gone
+	if _, err := os.Stat(oldEbuildPath); !os.IsNotExist(err) {
+		t.Errorf("Old ebuild file %s was not removed/renamed", oldEbuildPath)
+	}
+
+	// Check if new ebuild exists
+	newEbuildPath := filepath.Join(tmpDir, pn+"-"+newPv+".ebuild")
+	if _, err := os.Stat(newEbuildPath); err != nil {
+		t.Errorf("New ebuild file %s was not created: %v", newEbuildPath, err)
+	}
+
+	// Check if manifest is updated properly
+	newManifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("Failed to read manifest: %v", err)
+	}
+
+	newManifestContent := string(newManifestBytes)
+
+	// Old entry should be removed
+	if strings.Contains(newManifestContent, "testpkg-1.0.0.tar.gz") {
+		t.Errorf("Manifest still contains old entry")
+	}
+
+	// Note: in a real environment it would download the new URI and add the checksum.
+	// However, `DownloadAndChecksum` on `example.com` would fail.
+	// In our code, if DownloadAndChecksum fails, it just skips that URI, leaving an empty manifest or
+	// removing the old entry. We can just verify the old entry is removed.
+}

--- a/cmd/g2/ebuild_bump_version_test.go
+++ b/cmd/g2/ebuild_bump_version_test.go
@@ -13,7 +13,7 @@ func TestEbuildBumpVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create a fake ebuild
 	pn := "testpkg"

--- a/cmd/g2/ebuild_tag.go
+++ b/cmd/g2/ebuild_tag.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/arran4/g2"
+)
+
+func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string) error {
+	fs := flag.NewFlagSet("tag", flag.ExitOnError)
+	dir := fs.String("dir", ".", "Directory to search for ebuilds")
+	compare := fs.String("compare", "", "Compare a version to the highest tag (outputs -, =, or +)")
+	downgrades := fs.Bool("downgrades", false, "Include downgrades in comparison")
+	bumpPatch := fs.Bool("patch", false, "Bump the patch version")
+	bumpMinor := fs.Bool("minor", false, "Bump the minor version")
+	bumpMajor := fs.Bool("major", false, "Bump the major version")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(*dir)
+	if err != nil {
+		return fmt.Errorf("failed to read directory %s: %w", *dir, err)
+	}
+
+	var versions []string
+	var pn string
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".ebuild") {
+			continue
+		}
+
+		vars := g2.ParseEbuildVariables(entry.Name())
+		if vars == nil || vars["PV"] == "" {
+			continue
+		}
+
+		if pn == "" {
+			pn = vars["PN"]
+		} else if pn != vars["PN"] {
+			log.Printf("Warning: mixed package names found in directory: %s and %s", pn, vars["PN"])
+		}
+
+		versions = append(versions, vars["PV"])
+	}
+
+	if len(versions) == 0 {
+		return fmt.Errorf("no ebuilds found in %s", *dir)
+	}
+
+	// Sort versions using g2.CompareVersions
+	sort.Slice(versions, func(i, j int) bool {
+		return g2.CompareVersions(versions[i], versions[j]) < 0
+	})
+
+	highestVersion := versions[len(versions)-1]
+
+	if *compare != "" {
+		comp := g2.CompareVersions(*compare, highestVersion)
+		if comp < 0 {
+			if *downgrades {
+				fmt.Println("-")
+			} else {
+				log.Printf("Version %s is a downgrade from %s. Ignoring.", *compare, highestVersion)
+			}
+		} else if comp == 0 {
+			fmt.Println("=")
+		} else {
+			fmt.Println("+")
+		}
+		return nil
+	}
+
+	// Output incremented version if asked
+	if *bumpPatch || *bumpMinor || *bumpMajor {
+		gv := g2.ParseGentooVersion(highestVersion)
+		if !gv.IsValid {
+			return fmt.Errorf("could not parse version %s for incrementing", highestVersion)
+		}
+
+		if *bumpMajor {
+			gv.IncrementPart("major")
+		} else if *bumpMinor {
+			gv.IncrementPart("minor")
+		} else if *bumpPatch {
+			gv.IncrementPart("patch")
+		}
+
+		fmt.Println(gv.String())
+		return nil
+	}
+
+	fmt.Println(highestVersion)
+	return nil
+}

--- a/cmd/g2/ebuild_tag.go
+++ b/cmd/g2/ebuild_tag.go
@@ -16,6 +16,7 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string) error {
 	dir := fs.String("dir", ".", "Directory to search for ebuilds")
 	compare := fs.String("compare", "", "Compare a version to the highest tag (outputs -, =, or +)")
 	downgrades := fs.Bool("downgrades", false, "Include downgrades in comparison")
+	bumpRevision := fs.Bool("revision", false, "Bump the revision version")
 	bumpPatch := fs.Bool("patch", false, "Bump the patch version")
 	bumpMinor := fs.Bool("minor", false, "Bump the minor version")
 	bumpMajor := fs.Bool("major", false, "Bump the major version")
@@ -79,13 +80,15 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string) error {
 	}
 
 	// Output incremented version if asked
-	if *bumpPatch || *bumpMinor || *bumpMajor {
+	if *bumpRevision || *bumpPatch || *bumpMinor || *bumpMajor {
 		gv := g2.ParseGentooVersion(highestVersion)
 		if !gv.IsValid {
 			return fmt.Errorf("could not parse version %s for incrementing", highestVersion)
 		}
 
-		if *bumpMajor {
+		if *bumpRevision {
+			gv.IncrementPart("revision")
+		} else if *bumpMajor {
 			gv.IncrementPart("major")
 		} else if *bumpMinor {
 			gv.IncrementPart("minor")

--- a/cmd/g2/ebuild_tag_test.go
+++ b/cmd/g2/ebuild_tag_test.go
@@ -129,4 +129,20 @@ func TestEbuildTag(t *testing.T) {
 	if output != "2.0.1" { // 2.0.0-r1 -> micro increment drops suffix and goes to next number
 		t.Errorf("Expected '2.0.1' output for patch bump, got %s", output)
 	}
+
+	// Test revision bump
+	r7, w7, _ := os.Pipe()
+	os.Stdout = w7
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-revision"})
+	if err != nil {
+		t.Fatalf("cmdEbuildTag failed: %v", err)
+	}
+	_ = w7.Close()
+	os.Stdout = oldStdout
+	buf.Reset()
+	_, _ = buf.ReadFrom(r7)
+	output = strings.TrimSpace(buf.String())
+	if output != "2.0.0-r2" {
+		t.Errorf("Expected '2.0.0-r2' output for revision bump, got %s", output)
+	}
 }

--- a/cmd/g2/ebuild_tag_test.go
+++ b/cmd/g2/ebuild_tag_test.go
@@ -14,7 +14,7 @@ func TestEbuildTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Create some fake ebuilds
 	versions := []string{"1.0.0", "1.1.0", "1.1.1", "2.0.0-r1", "2.0.0"}
@@ -39,11 +39,11 @@ func TestEbuildTag(t *testing.T) {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 	output := strings.TrimSpace(buf.String())
 
 	if output != "2.0.0-r1" {
@@ -57,10 +57,10 @@ func TestEbuildTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	w2.Close()
+	_ = w2.Close()
 	os.Stdout = oldStdout
 	buf.Reset()
-	buf.ReadFrom(r2)
+	_, _ = buf.ReadFrom(r2)
 	output = strings.TrimSpace(buf.String())
 	if output != "" {
 		t.Errorf("Expected empty output for downgrade without -downgrades flag, got %s", output)
@@ -73,10 +73,10 @@ func TestEbuildTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	w3.Close()
+	_ = w3.Close()
 	os.Stdout = oldStdout
 	buf.Reset()
-	buf.ReadFrom(r3)
+	_, _ = buf.ReadFrom(r3)
 	output = strings.TrimSpace(buf.String())
 	if output != "-" {
 		t.Errorf("Expected '-' output for downgrade with -downgrades flag, got %s", output)
@@ -89,10 +89,10 @@ func TestEbuildTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	w4.Close()
+	_ = w4.Close()
 	os.Stdout = oldStdout
 	buf.Reset()
-	buf.ReadFrom(r4)
+	_, _ = buf.ReadFrom(r4)
 	output = strings.TrimSpace(buf.String())
 	if output != "=" {
 		t.Errorf("Expected '=' output for equal version, got %s", output)
@@ -105,10 +105,10 @@ func TestEbuildTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	w5.Close()
+	_ = w5.Close()
 	os.Stdout = oldStdout
 	buf.Reset()
-	buf.ReadFrom(r5)
+	_, _ = buf.ReadFrom(r5)
 	output = strings.TrimSpace(buf.String())
 	if output != "+" {
 		t.Errorf("Expected '+' output for upgrade version, got %s", output)
@@ -121,10 +121,10 @@ func TestEbuildTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	w6.Close()
+	_ = w6.Close()
 	os.Stdout = oldStdout
 	buf.Reset()
-	buf.ReadFrom(r6)
+	_, _ = buf.ReadFrom(r6)
 	output = strings.TrimSpace(buf.String())
 	if output != "2.0.1" { // 2.0.0-r1 -> micro increment drops suffix and goes to next number
 		t.Errorf("Expected '2.0.1' output for patch bump, got %s", output)

--- a/cmd/g2/ebuild_tag_test.go
+++ b/cmd/g2/ebuild_tag_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEbuildTag(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir, err := os.MkdirTemp("", "ebuild-tag-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create some fake ebuilds
+	versions := []string{"1.0.0", "1.1.0", "1.1.1", "2.0.0-r1", "2.0.0"}
+	pn := "testpkg"
+
+	for _, v := range versions {
+		ebuildPath := filepath.Join(tmpDir, pn+"-"+v+".ebuild")
+		if err := os.WriteFile(ebuildPath, []byte("EAPI=8"), 0644); err != nil {
+			t.Fatalf("Failed to create fake ebuild %s: %v", ebuildPath, err)
+		}
+	}
+
+	cfg := &CmdEbuildArgConfig{}
+
+	// Test basic execution without compare (should return highest version)
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir})
+	if err != nil {
+		t.Fatalf("cmdEbuildTag failed: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := strings.TrimSpace(buf.String())
+
+	if output != "2.0.0-r1" {
+		t.Errorf("Expected highest version to be 2.0.0-r1, got %s", output)
+	}
+
+	// Test compare downgrade without flag
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w2
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "1.5.0"})
+	if err != nil {
+		t.Fatalf("cmdEbuildTag failed: %v", err)
+	}
+	w2.Close()
+	os.Stdout = oldStdout
+	buf.Reset()
+	buf.ReadFrom(r2)
+	output = strings.TrimSpace(buf.String())
+	if output != "" {
+		t.Errorf("Expected empty output for downgrade without -downgrades flag, got %s", output)
+	}
+
+	// Test compare downgrade with flag
+	r3, w3, _ := os.Pipe()
+	os.Stdout = w3
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "1.5.0", "-downgrades"})
+	if err != nil {
+		t.Fatalf("cmdEbuildTag failed: %v", err)
+	}
+	w3.Close()
+	os.Stdout = oldStdout
+	buf.Reset()
+	buf.ReadFrom(r3)
+	output = strings.TrimSpace(buf.String())
+	if output != "-" {
+		t.Errorf("Expected '-' output for downgrade with -downgrades flag, got %s", output)
+	}
+
+	// Test compare equal
+	r4, w4, _ := os.Pipe()
+	os.Stdout = w4
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "2.0.0-r1"})
+	if err != nil {
+		t.Fatalf("cmdEbuildTag failed: %v", err)
+	}
+	w4.Close()
+	os.Stdout = oldStdout
+	buf.Reset()
+	buf.ReadFrom(r4)
+	output = strings.TrimSpace(buf.String())
+	if output != "=" {
+		t.Errorf("Expected '=' output for equal version, got %s", output)
+	}
+
+	// Test compare upgrade
+	r5, w5, _ := os.Pipe()
+	os.Stdout = w5
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "2.1.0"})
+	if err != nil {
+		t.Fatalf("cmdEbuildTag failed: %v", err)
+	}
+	w5.Close()
+	os.Stdout = oldStdout
+	buf.Reset()
+	buf.ReadFrom(r5)
+	output = strings.TrimSpace(buf.String())
+	if output != "+" {
+		t.Errorf("Expected '+' output for upgrade version, got %s", output)
+	}
+
+	// Test patch bump
+	r6, w6, _ := os.Pipe()
+	os.Stdout = w6
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-patch"})
+	if err != nil {
+		t.Fatalf("cmdEbuildTag failed: %v", err)
+	}
+	w6.Close()
+	os.Stdout = oldStdout
+	buf.Reset()
+	buf.ReadFrom(r6)
+	output = strings.TrimSpace(buf.String())
+	if output != "2.0.1" { // 2.0.0-r1 -> micro increment drops suffix and goes to next number
+		t.Errorf("Expected '2.0.1' output for patch bump, got %s", output)
+	}
+}


### PR DESCRIPTION
Added `ebuild tag` and `ebuild bump-version` to simplify Gentoo ebuild version automation and Manifest updates.

---
*PR created automatically by Jules for task [4916231353097863721](https://jules.google.com/task/4916231353097863721) started by @arran4*