### PR TITLE
🧹 Refactor: evaluate redundant models in site.go

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -27,23 +27,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// TODO evaluate the following they should be redundant OR moved to `/`
-
-type RemoteRepositories struct {
-	XMLName xml.Name     `xml:"repositories"`
-	Repos   []RemoteRepo `xml:"repo"`
-}
-
-type RemoteRepo struct {
-	Name    string       `xml:"name"`
-	Sources []RepoSource `xml:"source"`
-}
-
-type RepoSource struct {
-	Type string `xml:"type,attr"`
-	URL  string `xml:",chardata"`
-}
-
 type ProfileDescEntry struct {
 	Arch   string
 	Path   string

--- a/repositories.go
+++ b/repositories.go
@@ -78,5 +78,3 @@ func ParseRepositoriesFromReader(r io.Reader) (*Repositories, error) {
 
 	return &repositories, nil
 }
-
-// RemoteRepositories models a list of overlay repositories.


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a TODO comment pointing to redundant structs (`RemoteRepositories`, `RemoteRepo`, `RepoSource`) inside `cmd/g2/site.go`. These structs were effectively unused duplicates (or inferior definitions) of `Repositories` which handles parsing logic globally. 

💡 **Why:** Removing these unused types and comments reduces mental overhead and cleans up the file, improving overall maintainability and avoiding confusion about duplicate XML representations of repositories.

✅ **Verification:** Ran `go test ./...` across the repository to verify that no code or tests were depending on these removed types. Followed up with `golangci-lint run` to guarantee code style correctness.

✨ **Result:** The code health issue is successfully resolved. The dead code is eliminated without introducing any functional regressions.

---
*PR created automatically by Jules for task [13136379995297135430](https://jules.google.com/task/13136379995297135430) started by @arran4*