### PR TITLE
Refactor: Migrate Profile models to root package

### DIFF
--- a/cmd/g2/models_page.go
+++ b/cmd/g2/models_page.go
@@ -26,7 +26,7 @@ type GenericPageContext struct {
 	Projects             []*AggProject
 	Eclass               *AggEclass
 	Eclasses             []*AggEclass
-	Profiles             interface{} // Can be []*AggProfile or []ProfileData
+	Profiles             interface{} // Can be []*g2.AggProfile or []g2.ProfileData
 	Arches               []*AggArch
 	RecentDurationString string
 	RecentNews           interface{} // Can be []AggNewsItem or []g2.NewsItem
@@ -41,7 +41,7 @@ type GenericPageContext struct {
 	MovedToName          string
 	MovedToURL           string
 	ProfilePath          string
-	ProfileList          interface{} // Can be []AggProfileRepo
+	ProfileList          interface{} // Can be []g2.AggProfileRepo
 	Profile              interface{}
 	FileName             string
 	FileContent          string

--- a/cmd/g2/profile.go
+++ b/cmd/g2/profile.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"text/tabwriter"
+
+	"github.com/arran4/g2"
 )
 
 func ProfileCommand(args []string) error {
@@ -32,7 +34,7 @@ func profileListCommand(args []string) error {
 	_ = fs.Parse(args)
 
 	profilesDescBytes, err := os.ReadFile(filepath.Join(*repoDir, "profiles", "profiles.desc"))
-	var profilesDescEntries []ProfileDescEntry
+	var profilesDescEntries []g2.ProfileDescEntry
 	if err == nil {
 		profilesDescEntries = parseProfilesDesc(string(profilesDescBytes))
 	}
@@ -71,7 +73,7 @@ func profileDescribeCommand(args []string) error {
 	profilePath := positionals[0]
 
 	profilesDescBytes, err := os.ReadFile(filepath.Join(*repoDir, "profiles", "profiles.desc"))
-	var profilesDescEntries []ProfileDescEntry
+	var profilesDescEntries []g2.ProfileDescEntry
 	if err == nil {
 		profilesDescEntries = parseProfilesDesc(string(profilesDescBytes))
 	}
@@ -81,7 +83,7 @@ func profileDescribeCommand(args []string) error {
 		return fmt.Errorf("failed to parse profiles: %w", err)
 	}
 
-	var targetProfile *ProfileData
+		var targetProfile *g2.ProfileData
 	for i, p := range profilesData {
 		if p.Path == profilePath {
 			targetProfile = &profilesData[i]

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -44,23 +44,7 @@ type RepoSource struct {
 	URL  string `xml:",chardata"`
 }
 
-type ProfileDescEntry struct {
-	Arch   string
-	Path   string
-	Status string
-}
-
 type SourceURL string
-
-type ProfileData struct {
-	Path     string
-	IsDesc   bool
-	DescArch string
-	DescStat string
-	Parents  []string
-	Children []string
-	Files    map[string]string // Maps filename to its content
-}
 
 type EclassData struct {
 	Name string
@@ -74,7 +58,7 @@ type SiteData struct {
 	EAPI              string
 	Projects          *g2.Projects
 	Categories        []CategoryData
-	Profiles          []ProfileData
+	Profiles          []g2.ProfileData
 	DefinedEclasses   []EclassData
 	AggEclasses       []*AggEclass
 	Authors           []g2.Author
@@ -907,7 +891,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		_ = authorsFile.Close()
 	}
 
-	var profilesDescEntries []ProfileDescEntry
+	var profilesDescEntries []g2.ProfileDescEntry
 	profilesDescBytes, err := fs.ReadFile(sysFS, filepath.ToSlash(filepath.Join(repoDir, "profiles", "profiles.desc")))
 	if err == nil {
 		profilesDescEntries = parseProfilesDesc(string(profilesDescBytes))
@@ -1570,23 +1554,23 @@ func buildManifestData(manifest *g2.Manifest, versions []VersionData, thirdParty
 	return manifestData
 }
 
-func parseProfilesDir(repoDir string, entries []ProfileDescEntry) ([]ProfileData, error) {
+func parseProfilesDir(repoDir string, entries []g2.ProfileDescEntry) ([]g2.ProfileData, error) {
 	return parseProfilesDirFS(os.DirFS(repoDir), ".", entries)
 }
 
-func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry) ([]ProfileData, error) {
+func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []g2.ProfileDescEntry) ([]g2.ProfileData, error) {
 	profilesDir := path2.Join(repoDir, "profiles")
 
 	if info, err := fs.Stat(sysFS, profilesDir); err != nil || !info.IsDir() {
 		return nil, nil
 	}
 
-	descMap := make(map[string]ProfileDescEntry)
+	descMap := make(map[string]g2.ProfileDescEntry)
 	for _, e := range entries {
 		descMap[e.Path] = e
 	}
 
-	profilesMap := make(map[string]*ProfileData)
+	profilesMap := make(map[string]*g2.ProfileData)
 
 	err := fs.WalkDir(sysFS, profilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -1602,7 +1586,7 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 			return nil
 		}
 
-		pData := &ProfileData{
+		pData := &g2.ProfileData{
 			Path:  relPath,
 			Files: make(map[string]string),
 		}
@@ -1657,7 +1641,7 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 		}
 	}
 
-	var result []ProfileData
+	var result []g2.ProfileData
 	for _, pData := range profilesMap {
 		result = append(result, *pData)
 	}
@@ -1665,8 +1649,8 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 	return result, nil
 }
 
-func parseProfilesDesc(content string) []ProfileDescEntry {
-	var entries []ProfileDescEntry
+func parseProfilesDesc(content string) []g2.ProfileDescEntry {
+	var entries []g2.ProfileDescEntry
 	lines := strings.Split(content, "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -1675,7 +1659,7 @@ func parseProfilesDesc(content string) []ProfileDescEntry {
 		}
 		parts := strings.Fields(line)
 		if len(parts) >= 3 {
-			entries = append(entries, ProfileDescEntry{
+			entries = append(entries, g2.ProfileDescEntry{
 				Arch:   parts[0],
 				Path:   parts[1],
 				Status: parts[2],
@@ -1993,22 +1977,6 @@ func parseDuration(s string) (time.Duration, string, error) {
 	return d, s, nil
 }
 
-// TODO migrate to / if it hasn't been done already check for differences
-
-type AggProfileRepo struct {
-	RepoName string
-	Profile  ProfileData
-}
-
-type AggProfile struct {
-	Path     string
-	IsDesc   bool
-	DescArch string
-	DescStat string
-	Repos    []AggProfileRepo
-	Files    map[string]string // Maps filename to its content
-}
-
 type AggEclass struct {
 	Name     string
 	Repos    map[string]*SiteData
@@ -2042,7 +2010,7 @@ type AggregatedData struct {
 	Packages        []*AggPackage
 	Licenses        []*AggLicense
 	Projects        []*AggProject
-	Profiles        []*AggProfile
+	Profiles        []*g2.AggProfile
 	Arches          []*AggArch
 	Moves           map[string]*AggPackageMove
 	GlobalNews      []AggNewsItem
@@ -2111,16 +2079,16 @@ func aggregateProjects(sites []*SiteData) map[string]*AggProject {
 	return aggProjects
 }
 
-func aggregateProfiles(sites []*SiteData) map[string]*AggProfile {
-	aggProfiles := make(map[string]*AggProfile)
+func aggregateProfiles(sites []*SiteData) map[string]*g2.AggProfile {
+	aggProfiles := make(map[string]*g2.AggProfile)
 	for _, site := range sites {
 		for _, p := range site.Profiles {
 			if _, ok := aggProfiles[p.Path]; !ok {
-				aggProfiles[p.Path] = &AggProfile{
+				aggProfiles[p.Path] = &g2.AggProfile{
 					Path: p.Path,
 				}
 			}
-			aggProfiles[p.Path].Repos = append(aggProfiles[p.Path].Repos, AggProfileRepo{
+			aggProfiles[p.Path].Repos = append(aggProfiles[p.Path].Repos, g2.AggProfileRepo{
 				RepoName: site.RepoName,
 				Profile:  p,
 			})
@@ -2420,8 +2388,8 @@ func sortProjects(aggProjects map[string]*AggProject) []*AggProject {
 	return sortedProjects
 }
 
-func sortProfiles(aggProfiles map[string]*AggProfile) []*AggProfile {
-	var sortedProfiles []*AggProfile
+func sortProfiles(aggProfiles map[string]*g2.AggProfile) []*g2.AggProfile {
+	var sortedProfiles []*g2.AggProfile
 	for _, p := range aggProfiles {
 		sortedProfiles = append(sortedProfiles, p)
 	}

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 
 	"golang.org/x/sync/errgroup"
+
+	"github.com/arran4/g2"
 )
 
 func (cfg *MainArgConfig) cmdSite(args []string) error {
@@ -987,10 +989,10 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							profilePath = remaining
 						}
 
-						var targetProfile *ProfileData
-						for _, p := range site.Profiles {
+						var targetProfile *g2.ProfileData
+						for i, p := range site.Profiles {
 							if p.Path == profilePath {
-								targetProfile = &p
+								targetProfile = &site.Profiles[i]
 								break
 							}
 						}

--- a/site.go
+++ b/site.go
@@ -19,6 +19,36 @@ type Breadcrumb struct {
 	URL  string
 }
 
+type ProfileDescEntry struct {
+	Arch   string
+	Path   string
+	Status string
+}
+
+type ProfileData struct {
+	Path     string
+	IsDesc   bool
+	DescArch string
+	DescStat string
+	Parents  []string
+	Children []string
+	Files    map[string]string // Maps filename to its content
+}
+
+type AggProfileRepo struct {
+	RepoName string
+	Profile  ProfileData
+}
+
+type AggProfile struct {
+	Path     string
+	IsDesc   bool
+	DescArch string
+	DescStat string
+	Repos    []AggProfileRepo
+	Files    map[string]string // Maps filename to its content
+}
+
 type CategoryData struct {
 	Name     string
 	Packages []PackageData


### PR DESCRIPTION
Migrated `ProfileData` and `AggProfile` models to the root `g2` package.

---
*PR created automatically by Jules for task [1433194913035858983](https://jules.google.com/task/1433194913035858983) started by @arran4*