### PR TITLE
🧹 [Code Health] Migrate AggProfileRepo model to root

### DIFF
--- a/cmd/g2/models_page.go
+++ b/cmd/g2/models_page.go
@@ -26,7 +26,7 @@ type GenericPageContext struct {
 	Projects             []*AggProject
 	Eclass               *AggEclass
 	Eclasses             []*AggEclass
-	Profiles             interface{} // Can be []*AggProfile or []ProfileData
+	Profiles             interface{} // Can be []*g2.AggProfile or []g2.ProfileData
 	Arches               []*AggArch
 	RecentDurationString string
 	RecentNews           interface{} // Can be []AggNewsItem or []g2.NewsItem
@@ -41,7 +41,7 @@ type GenericPageContext struct {
 	MovedToName          string
 	MovedToURL           string
 	ProfilePath          string
-	ProfileList          interface{} // Can be []AggProfileRepo
+	ProfileList          interface{} // Can be []g2.AggProfileRepo
 	Profile              interface{}
 	FileName             string
 	FileContent          string

--- a/cmd/g2/profile.go
+++ b/cmd/g2/profile.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"text/tabwriter"
+
+	"github.com/arran4/g2"
 )
 
 func ProfileCommand(args []string) error {
@@ -81,7 +83,7 @@ func profileDescribeCommand(args []string) error {
 		return fmt.Errorf("failed to parse profiles: %w", err)
 	}
 
-	var targetProfile *ProfileData
+	var targetProfile *g2.ProfileData
 	for i, p := range profilesData {
 		if p.Path == profilePath {
 			targetProfile = &profilesData[i]

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -52,15 +52,7 @@ type ProfileDescEntry struct {
 
 type SourceURL string
 
-type ProfileData struct {
-	Path     string
-	IsDesc   bool
-	DescArch string
-	DescStat string
-	Parents  []string
-	Children []string
-	Files    map[string]string // Maps filename to its content
-}
+
 
 type EclassData struct {
 	Name string
@@ -74,7 +66,7 @@ type SiteData struct {
 	EAPI              string
 	Projects          *g2.Projects
 	Categories        []CategoryData
-	Profiles          []ProfileData
+	Profiles          []g2.ProfileData
 	DefinedEclasses   []EclassData
 	AggEclasses       []*AggEclass
 	Authors           []g2.Author
@@ -1570,11 +1562,11 @@ func buildManifestData(manifest *g2.Manifest, versions []VersionData, thirdParty
 	return manifestData
 }
 
-func parseProfilesDir(repoDir string, entries []ProfileDescEntry) ([]ProfileData, error) {
+func parseProfilesDir(repoDir string, entries []ProfileDescEntry) ([]g2.ProfileData, error) {
 	return parseProfilesDirFS(os.DirFS(repoDir), ".", entries)
 }
 
-func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry) ([]ProfileData, error) {
+func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry) ([]g2.ProfileData, error) {
 	profilesDir := path2.Join(repoDir, "profiles")
 
 	if info, err := fs.Stat(sysFS, profilesDir); err != nil || !info.IsDir() {
@@ -1586,7 +1578,7 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 		descMap[e.Path] = e
 	}
 
-	profilesMap := make(map[string]*ProfileData)
+	profilesMap := make(map[string]*g2.ProfileData)
 
 	err := fs.WalkDir(sysFS, profilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -1602,7 +1594,7 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 			return nil
 		}
 
-		pData := &ProfileData{
+		pData := &g2.ProfileData{
 			Path:  relPath,
 			Files: make(map[string]string),
 		}
@@ -1657,7 +1649,7 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 		}
 	}
 
-	var result []ProfileData
+	var result []g2.ProfileData
 	for _, pData := range profilesMap {
 		result = append(result, *pData)
 	}
@@ -1993,21 +1985,9 @@ func parseDuration(s string) (time.Duration, string, error) {
 	return d, s, nil
 }
 
-// TODO migrate to / if it hasn't been done already check for differences
 
-type AggProfileRepo struct {
-	RepoName string
-	Profile  ProfileData
-}
 
-type AggProfile struct {
-	Path     string
-	IsDesc   bool
-	DescArch string
-	DescStat string
-	Repos    []AggProfileRepo
-	Files    map[string]string // Maps filename to its content
-}
+
 
 type AggEclass struct {
 	Name     string
@@ -2042,7 +2022,7 @@ type AggregatedData struct {
 	Packages        []*AggPackage
 	Licenses        []*AggLicense
 	Projects        []*AggProject
-	Profiles        []*AggProfile
+	Profiles        []*g2.AggProfile
 	Arches          []*AggArch
 	Moves           map[string]*AggPackageMove
 	GlobalNews      []AggNewsItem
@@ -2111,16 +2091,16 @@ func aggregateProjects(sites []*SiteData) map[string]*AggProject {
 	return aggProjects
 }
 
-func aggregateProfiles(sites []*SiteData) map[string]*AggProfile {
-	aggProfiles := make(map[string]*AggProfile)
+func aggregateProfiles(sites []*SiteData) map[string]*g2.AggProfile {
+	aggProfiles := make(map[string]*g2.AggProfile)
 	for _, site := range sites {
 		for _, p := range site.Profiles {
 			if _, ok := aggProfiles[p.Path]; !ok {
-				aggProfiles[p.Path] = &AggProfile{
+				aggProfiles[p.Path] = &g2.AggProfile{
 					Path: p.Path,
 				}
 			}
-			aggProfiles[p.Path].Repos = append(aggProfiles[p.Path].Repos, AggProfileRepo{
+			aggProfiles[p.Path].Repos = append(aggProfiles[p.Path].Repos, g2.AggProfileRepo{
 				RepoName: site.RepoName,
 				Profile:  p,
 			})
@@ -2420,8 +2400,8 @@ func sortProjects(aggProjects map[string]*AggProject) []*AggProject {
 	return sortedProjects
 }
 
-func sortProfiles(aggProfiles map[string]*AggProfile) []*AggProfile {
-	var sortedProfiles []*AggProfile
+func sortProfiles(aggProfiles map[string]*g2.AggProfile) []*g2.AggProfile {
+	var sortedProfiles []*g2.AggProfile
 	for _, p := range aggProfiles {
 		sortedProfiles = append(sortedProfiles, p)
 	}

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/arran4/g2"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -987,7 +988,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							profilePath = remaining
 						}
 
-						var targetProfile *ProfileData
+						var targetProfile *g2.ProfileData
 						for _, p := range site.Profiles {
 							if p.Path == profilePath {
 								targetProfile = &p

--- a/site.go
+++ b/site.go
@@ -62,3 +62,27 @@ type VersionData struct {
 	// Masked
 	Masked *PackageMasked
 }
+
+type ProfileData struct {
+	Path     string
+	IsDesc   bool
+	DescArch string
+	DescStat string
+	Parents  []string
+	Children []string
+	Files    map[string]string // Maps filename to its content
+}
+
+type AggProfileRepo struct {
+	RepoName string
+	Profile  ProfileData
+}
+
+type AggProfile struct {
+	Path     string
+	IsDesc   bool
+	DescArch string
+	DescStat string
+	Repos    []AggProfileRepo
+	Files    map[string]string // Maps filename to its content
+}


### PR DESCRIPTION
🎯 **What:** Migrated `AggProfileRepo`, `AggProfile`, and `ProfileData` from `cmd/g2/site.go` to root `site.go`. Updated related models and usages throughout `cmd/g2`.
💡 **Why:** This resolves a code health issue where root package models were defined in the main package, which led to duplication and limited reusability across packages. It resolves the TODO comment indicating the needed migration.
✅ **Verification:** Verified via `go build ./...`, `go test ./...`, and `golangci-lint run`. Passed code review completely.
✨ **Result:** A cleaner codebase with improved dependency boundaries between the `g2` core package and its CLI implementation, ensuring no cyclic imports.

---
*PR created automatically by Jules for task [3438690396155327623](https://jules.google.com/task/3438690396155327623) started by @arran4*