### PR TITLE
Refactor: migrate site aggregated models to root package

### DIFF
--- a/agg_use_flag.go
+++ b/agg_use_flag.go
@@ -1,4 +1,5 @@
-package main
+package g2
+
 
 func (a *AggUseFlag) Desc() string {
 	if a.GlobalDesc != "" {

--- a/cmd/g2/models_page.go
+++ b/cmd/g2/models_page.go
@@ -9,28 +9,28 @@ import (
 type GenericPageContext struct {
 	Title       string
 	BaseURL     string
-	Breadcrumbs []Breadcrumb
+	Breadcrumbs []g2.Breadcrumb
 	Version     string
 	GenInfo     GenerationInfo
 	Content     template.HTML
 
 	// Additional data fields used by various templates
-	Repos                []*SiteData
-	GroupedRepos         []RepoGroup
-	Categories           interface{} // Can be []*AggCategory or []CategoryData
-	Packages             interface{} // Can be []*AggPackage or []PackageData
-	Licenses             []*AggLicense
-	UseFlags             []*AggUseFlag
+	Repos                []*g2.SiteData
+	GroupedRepos         []g2.RepoGroup
+	Categories           interface{} // Can be []*g2.AggCategory or []g2.CategoryData
+	Packages             interface{} // Can be []*g2.AggPackage or []g2.PackageData
+	Licenses             []*g2.AggLicense
+	UseFlags             []*g2.AggUseFlag
 	UseExpandDescs        map[string]*g2.UseExpandDesc
 	UseExpandDesc         *g2.UseExpandDesc
-	Projects             []*AggProject
-	Eclass               *AggEclass
-	Eclasses             []*AggEclass
-	Profiles             interface{} // Can be []*AggProfile or []ProfileData
-	Arches               []*AggArch
+	Projects             []*g2.AggProject
+	Eclass               *g2.AggEclass
+	Eclasses             []*g2.AggEclass
+	Profiles             interface{} // Can be []*g2.AggProfile or []g2.ProfileData
+	Arches               []*g2.AggArch
 	RecentDurationString string
-	RecentNews           interface{} // Can be []AggNewsItem or []g2.NewsItem
-	GlobalNews           []AggNewsItem
+	RecentNews           interface{} // Can be []g2.AggNewsItem or []g2.NewsItem
+	GlobalNews           []g2.AggNewsItem
 	News                 []g2.NewsItem
 	NewsItem             interface{}
 	Category             map[string]interface{}
@@ -41,15 +41,15 @@ type GenericPageContext struct {
 	MovedToName          string
 	MovedToURL           string
 	ProfilePath          string
-	ProfileList          interface{} // Can be []AggProfileRepo
+	ProfileList          interface{} // Can be []g2.AggProfileRepo
 	Profile              interface{}
 	FileName             string
 	FileContent          string
-	Arch                 *AggArch
+	Arch                 *g2.AggArch
 	UseFlag              interface{}
 	License              map[string]interface{}
-	Project              *AggProject
-	Repo                 *SiteData
+	Project              *g2.AggProject
+	Repo                 *g2.SiteData
 	PackageCount         int
 	GlobalCategoriesCount int
 	GlobalPackagesCount   int
@@ -59,7 +59,7 @@ type GenericPageContext struct {
 	ValidLicenses        map[string]bool
 	RepoName             string
 	Group                interface{}
-	VersionData          interface{}
-	FilteredManifest     []ManifestEntryData
+	VersionData interface{}
+	FilteredManifest     []g2.ManifestEntryData
 	Manifest             interface{}
 }

--- a/cmd/g2/package.go
+++ b/cmd/g2/package.go
@@ -383,7 +383,7 @@ func (cfg *CmdPackageArgConfig) cmdIndexOverlay(args []string) error {
 		return fmt.Errorf("failed to parse repo: %w", err)
 	}
 
-	sites := []*SiteData{repo}
+	sites := []*g2.SiteData{repo}
 
 	if err := generateSearchData(*outDir, *outZip, sites); err != nil {
 		return fmt.Errorf("generating search data: %w", err)
@@ -443,7 +443,7 @@ func (cfg *CmdPackageArgConfig) cmdIndexRepositories(args []string) error {
 	}
 	repos = reposObj.Repositories
 
-	var sites []*SiteData
+	var sites []*g2.SiteData
 
 	for _, rep := range repos {
 		if allowRepos != nil && !allowRepos[rep.Name] {
@@ -521,7 +521,7 @@ func (cfg *CmdPackageArgConfig) cmdIndex(args []string) error {
 		overlayPaths = append(overlayPaths, fmt.Sprintf("%s/%s", reposDir, repoName))
 	}
 
-	var sites []*SiteData
+	var sites []*g2.SiteData
 	for _, overlayPath := range overlayPaths {
 		sysFS := os.DirFS(overlayPath)
 		repo, err := parseRepo(sysFS, overlayPath, "local", false, nil)

--- a/cmd/g2/page_node.go
+++ b/cmd/g2/page_node.go
@@ -1,5 +1,9 @@
 package main
 
+import (
+	"github.com/arran4/g2"
+)
+
 import "strings"
 
 type PageNode struct {
@@ -33,8 +37,8 @@ func (n *PageNode) BaseURL() string {
 	return res
 }
 
-func (n *PageNode) Breadcrumbs() []Breadcrumb {
-	var crumbs []Breadcrumb
+func (n *PageNode) Breadcrumbs() []g2.Breadcrumb {
+	var crumbs []g2.Breadcrumb
 	curr := n
 
 	for curr != nil {
@@ -58,7 +62,7 @@ func (n *PageNode) Breadcrumbs() []Breadcrumb {
 			}
 		}
 
-		crumbs = append([]Breadcrumb{{Name: curr.Name, URL: url}}, crumbs...)
+		crumbs = append([]g2.Breadcrumb{{Name: curr.Name, URL: url}}, crumbs...)
 		curr = curr.Parent
 	}
 

--- a/cmd/g2/parse_pkg_uses.go
+++ b/cmd/g2/parse_pkg_uses.go
@@ -1,18 +1,20 @@
 package main
 
 import (
+	"github.com/arran4/g2"
+
 	"fmt"
 	"sort"
 	"strings"
 )
 
-// AggregateUseFlags processes a list of SiteData and updates an aggregate map of UseFlags,
-// and returns the sorted global UseFlags list. It also aggregates per-repo USE flags inside SiteData.
-func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([]*AggUseFlag, map[string]*AggUseFlag) {
-	globalAggUseFlags := make(map[string]*AggUseFlag)
+// AggregateUseFlags processes a list of g2.SiteData and updates an aggregate map of UseFlags,
+// and returns the sorted global UseFlags list. It also aggregates per-repo USE flags inside g2.SiteData.
+func AggregateUseFlags(sites []*g2.SiteData, aggPackages map[string]*g2.AggPackage) ([]*g2.AggUseFlag, map[string]*g2.AggUseFlag) {
+	globalAggUseFlags := make(map[string]*g2.AggUseFlag)
 
 	for _, site := range sites {
-		repoAggUseFlags := make(map[string]*AggUseFlag)
+		repoAggUseFlags := make(map[string]*g2.AggUseFlag)
 
 		for _, pkg := range site.Categories {
 			for _, p := range pkg.Packages {
@@ -25,7 +27,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 							for _, flag := range useBlock.Flags {
 								// Global
 								if _, ok := globalAggUseFlags[flag.Name]; !ok {
-									globalAggUseFlags[flag.Name] = &AggUseFlag{
+									globalAggUseFlags[flag.Name] = &g2.AggUseFlag{
 										Name:          flag.Name,
 										LocalDescs:    make(map[string]string),
 										MetadataDescs: make(map[string]string),
@@ -52,7 +54,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 
 								// Repo
 								if _, ok := repoAggUseFlags[flag.Name]; !ok {
-									repoAggUseFlags[flag.Name] = &AggUseFlag{
+									repoAggUseFlags[flag.Name] = &g2.AggUseFlag{
 										Name:          flag.Name,
 										LocalDescs:    make(map[string]string),
 										MetadataDescs: make(map[string]string),
@@ -92,7 +94,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 								flag := flagObj.Name
 								// Global
 								if _, ok := globalAggUseFlags[flag]; !ok {
-									globalAggUseFlags[flag] = &AggUseFlag{
+									globalAggUseFlags[flag] = &g2.AggUseFlag{
 										Name:          flag,
 										LocalDescs:    make(map[string]string),
 										MetadataDescs: make(map[string]string),
@@ -100,7 +102,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 								}
 								// Repo
 								if _, ok := repoAggUseFlags[flag]; !ok {
-									repoAggUseFlags[flag] = &AggUseFlag{
+									repoAggUseFlags[flag] = &g2.AggUseFlag{
 										Name:          flag,
 										LocalDescs:    make(map[string]string),
 										MetadataDescs: make(map[string]string),
@@ -152,7 +154,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 
 								// Global
 								if _, ok := globalAggUseFlags[flag]; !ok {
-									globalAggUseFlags[flag] = &AggUseFlag{
+									globalAggUseFlags[flag] = &g2.AggUseFlag{
 										Name:          flag,
 										LocalDescs:    make(map[string]string),
 										MetadataDescs: make(map[string]string),
@@ -160,7 +162,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 								}
 								// Repo
 								if _, ok := repoAggUseFlags[flag]; !ok {
-									repoAggUseFlags[flag] = &AggUseFlag{
+									repoAggUseFlags[flag] = &g2.AggUseFlag{
 										Name:          flag,
 										LocalDescs:    make(map[string]string),
 										MetadataDescs: make(map[string]string),
@@ -207,7 +209,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 			for flag, desc := range site.UseDesc.Flags {
 				// Global
 				if _, ok := globalAggUseFlags[flag]; !ok {
-					globalAggUseFlags[flag] = &AggUseFlag{
+					globalAggUseFlags[flag] = &g2.AggUseFlag{
 						Name:          flag,
 						LocalDescs:    make(map[string]string),
 						MetadataDescs: make(map[string]string),
@@ -217,7 +219,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 
 				// Repo
 				if _, ok := repoAggUseFlags[flag]; !ok {
-					repoAggUseFlags[flag] = &AggUseFlag{
+					repoAggUseFlags[flag] = &g2.AggUseFlag{
 						Name:          flag,
 						LocalDescs:    make(map[string]string),
 						MetadataDescs: make(map[string]string),
@@ -259,7 +261,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 			}
 		}
 
-		var sortedRepoUseFlags []*AggUseFlag
+		var sortedRepoUseFlags []*g2.AggUseFlag
 		for _, flag := range repoAggUseFlags {
 			if flag.GlobalDesc == "" && len(flag.Packages) > 0 {
 				flag.Warnings = append(flag.Warnings, fmt.Sprintf("Warning: USE flag '%s' is used in ebuilds/metadata but is not defined in profiles/use.desc", flag.Name))
@@ -285,7 +287,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 		site.AggUseFlags = sortedRepoUseFlags
 	}
 
-	var sortedUseFlags []*AggUseFlag
+	var sortedUseFlags []*g2.AggUseFlag
 	for _, flag := range globalAggUseFlags {
 		if flag.GlobalDesc == "" && len(flag.Packages) > 0 {
 			flag.Warnings = append(flag.Warnings, fmt.Sprintf("Warning: USE flag '%s' is used in ebuilds/metadata but is not defined in profiles/use.desc", flag.Name))
@@ -313,7 +315,7 @@ func AggregateUseFlags(sites []*SiteData, aggPackages map[string]*AggPackage) ([
 	return sortedUseFlags, globalAggUseFlags
 }
 
-func populatePkgUseFlags(site *SiteData) {
+func populatePkgUseFlags(site *g2.SiteData) {
 	globalDescs := make(map[string]string)
 	if site.UseDesc != nil {
 		globalDescs = site.UseDesc.Flags
@@ -401,7 +403,7 @@ func populatePkgUseFlags(site *SiteData) {
 			pkg := &site.Categories[i].Packages[j]
 			pkgKey := pkg.Category + "/" + pkg.Name
 
-			flagsMap := make(map[string]*PkgUseFlag)
+			flagsMap := make(map[string]*g2.PkgUseFlag)
 
 			for _, ver := range pkg.Versions {
 				vName := ver.Version
@@ -415,7 +417,7 @@ func populatePkgUseFlags(site *SiteData) {
 						parsed := parseIUSEFlagsFunc(iuse)
 						for _, f := range parsed {
 							if _, ok := flagsMap[f.Name]; !ok {
-								flagsMap[f.Name] = &PkgUseFlag{
+								flagsMap[f.Name] = &g2.PkgUseFlag{
 									Name: f.Name,
 									Versions: make(map[string]string),
 								}
@@ -435,7 +437,7 @@ func populatePkgUseFlags(site *SiteData) {
 				}
 			}
 
-			var pkgFlags []PkgUseFlag
+			var pkgFlags []g2.PkgUseFlag
 			for name, flag := range flagsMap {
 				desc := ""
 				source := ""

--- a/cmd/g2/profile.go
+++ b/cmd/g2/profile.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/arran4/g2"
+
 	"flag"
 	"fmt"
 	"os"
@@ -32,7 +34,7 @@ func profileListCommand(args []string) error {
 	_ = fs.Parse(args)
 
 	profilesDescBytes, err := os.ReadFile(filepath.Join(*repoDir, "profiles", "profiles.desc"))
-	var profilesDescEntries []ProfileDescEntry
+	var profilesDescEntries []g2.ProfileDescEntry
 	if err == nil {
 		profilesDescEntries = parseProfilesDesc(string(profilesDescBytes))
 	}
@@ -71,7 +73,7 @@ func profileDescribeCommand(args []string) error {
 	profilePath := positionals[0]
 
 	profilesDescBytes, err := os.ReadFile(filepath.Join(*repoDir, "profiles", "profiles.desc"))
-	var profilesDescEntries []ProfileDescEntry
+	var profilesDescEntries []g2.ProfileDescEntry
 	if err == nil {
 		profilesDescEntries = parseProfilesDesc(string(profilesDescBytes))
 	}
@@ -81,7 +83,7 @@ func profileDescribeCommand(args []string) error {
 		return fmt.Errorf("failed to parse profiles: %w", err)
 	}
 
-	var targetProfile *ProfileData
+	var targetProfile *g2.ProfileData
 	for i, p := range profilesData {
 		if p.Path == profilePath {
 			targetProfile = &profilesData[i]

--- a/cmd/g2/search_index.go
+++ b/cmd/g2/search_index.go
@@ -55,7 +55,7 @@ type SearchManifest struct {
 	DataFiles     []string `json:"data_files"`
 }
 
-func generateSearchData(outDir, outZip string, sites []*SiteData, maxChunkSizeOverride ...int) error {
+func generateSearchData(outDir, outZip string, sites []*g2.SiteData, maxChunkSizeOverride ...int) error {
 	var documents []SearchDocument
 	docID := 0
 
@@ -387,7 +387,7 @@ func generateSearchData(outDir, outZip string, sites []*SiteData, maxChunkSizeOv
 	return nil
 }
 
-func generateSearchIndex(outDir string, sites []*SiteData) error {
+func generateSearchIndex(outDir string, sites []*g2.SiteData) error {
 	searchDir := filepath.Join(outDir, "search")
 	dataDir := filepath.Join(searchDir, "data")
 

--- a/cmd/g2/search_index_test.go
+++ b/cmd/g2/search_index_test.go
@@ -16,20 +16,20 @@ func TestGenerateSearchIndex(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	sites := []*SiteData{
+	sites := []*g2.SiteData{
 		{
 			Title:    "Test Repo",
 			RepoName: "test-repo",
 			LicenseMapping: map[string][]string{
 				"MIT": {"FREE", "OSI-APPROVED"},
 			},
-			Categories: []CategoryData{
+			Categories: []g2.CategoryData{
 				{
 					Name: "app-test",
-					Packages: []PackageData{
+					Packages: []g2.PackageData{
 						{
 							Name: "test-pkg",
-							Versions: []VersionData{
+							Versions: []g2.VersionData{
 								{
 									Version: "1.0",
 									Ebuild: &g2.Ebuild{
@@ -44,7 +44,7 @@ func TestGenerateSearchIndex(t *testing.T) {
 									},
 								},
 							},
-							PkgUseFlags: []PkgUseFlag{
+							PkgUseFlags: []g2.PkgUseFlag{
 								{
 									Name: "test-flag",
 									Desc: "Enables testing",

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -27,181 +27,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// TODO evaluate the following they should be redundant OR moved to `/`
-
-type RemoteRepositories struct {
-	XMLName xml.Name     `xml:"repositories"`
-	Repos   []RemoteRepo `xml:"repo"`
-}
-
-type RemoteRepo struct {
-	Name    string       `xml:"name"`
-	Sources []RepoSource `xml:"source"`
-}
-
-type RepoSource struct {
-	Type string `xml:"type,attr"`
-	URL  string `xml:",chardata"`
-}
-
-type ProfileDescEntry struct {
-	Arch   string
-	Path   string
-	Status string
-}
-
-type SourceURL string
-
-type ProfileData struct {
-	Path     string
-	IsDesc   bool
-	DescArch string
-	DescStat string
-	Parents  []string
-	Children []string
-	Files    map[string]string // Maps filename to its content
-}
-
-type EclassData struct {
-	Name string
-}
-
-type SiteData struct {
-	Title             string
-	RepoName          string
-	RemoteURL         string
-	Repository        *g2.Repository
-	EAPI              string
-	Projects          *g2.Projects
-	Categories        []CategoryData
-	Profiles          []ProfileData
-	DefinedEclasses   []EclassData
-	AggEclasses       []*AggEclass
-	Authors           []g2.Author
-	AuthorsURL        string
-	Moves             []g2.PackageMove
-	SlotMoves         []g2.PackageSlotMove
-	News              []g2.NewsItem
-	LayoutConf        *g2.LayoutConf
-	LicenseMapping    map[string][]string
-	QAPolicy          *g2.QAPolicy
-	UseDesc           *g2.UseDesc
-	UseLocalDesc      *g2.UseLocalDesc
-	UseExpandDescs    map[string]*g2.UseExpandDesc
-	ValidUseExpands   map[string]bool
-	ArchList          *g2.ArchList
-	ArchesDesc        *g2.ArchesDesc
-	InfoPkgs          []g2.InfoPkg
-	Masked            []g2.PackageMasked
-	Deprecated        []g2.PackageDeprecated
-	ParsedEclasses    []*g2.Ebuild
-	Eclasses          []*g2.Ebuild
-	PackageCount      int
-	AggUseFlags       []*AggUseFlag
-	ThirdPartyMirrors map[string][]string
-	InfoVars          []string
-	GitSize           string
-	CheckoutTime      string
-	ProcessTime       string
-	SourceURL         string
-}
-
-type LicenseData struct {
-	Name     string
-	Count    int
-	Packages []PackageData
-}
-
-type Breadcrumb struct {
-	Name string
-	URL  string
-}
-
-type CategoryData struct {
-	Name     string
-	Packages []PackageData
-}
-
-type FileData struct {
-	Name   string
-	Path   string
-	RawURL string
-}
-
-type ManifestEntryData struct {
-	Entry        *g2.ManifestEntry
-	Versions     []string
-	URLs         []string
-	ResolvedURLs []string
-}
-
-type PackageData struct {
-	Name                  string
-	Category              string
-	Versions              []VersionData
-	Metadata              *g2.PkgMetadata
-	MetadataError         error
-	Manifest              *g2.Manifest
-	ManifestData          []ManifestEntryData
-	Files                 []FileData
-	HighestStableVersion  template.HTML
-	HighestTestingVersion template.HTML
-	EbuildCount           int
-	DominantDescription   string
-	DominantHomepage      string
-	DominantLicense       string
-
-	// Git info
-	MetadataRawURL string
-	ModTime        time.Time
-
-	// Processed Uses (per package)
-	PkgUseFlags []PkgUseFlag
-
-	// Lint Info
-	LintWarnings []string
-
-	// Deprecation
-	Masked     *g2.PackageMasked
-	Deprecated *g2.PackageDeprecated
-
-	// InfoPkg matching
-	IsInfoPkg bool
-
-	ReverseVirtuals []string
-	Equivalents     []string
-	VirtualDeps     []string
-}
-
-type PkgUseFlag struct {
-	Name     string
-	Desc     string
-	Source   string
-	Versions map[string]string // Version -> Unicode symbol representing state
-}
-
-type VersionData struct {
-	Version string
-	Ebuild  *g2.Ebuild
-
-	// Git info
-	EbuildRawURL string
-	ModTime      time.Time
-
-	// Deprecation
-	Deprecated *g2.PackageDeprecated
-	Masked     *g2.PackageMasked
-
-	// Moves
-	MovedToSlot string
-
-	ResolvedDepsJSON string
-	// Mirrors
-	ApplicableMirrors map[string][]string
-}
-
-// End model TODO check
-
 func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	ebuild.SkipForSiteGen = true
 	if len(args) < 1 {
@@ -279,7 +104,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 		tasks = append(tasks, repoTask{Name: "guru", Location: "https://github.com/gentoo-mirror/guru.git"})
 	}
 
-	var allSites []*SiteData
+	var allSites []*g2.SiteData
 	var allSitesMu sync.Mutex
 
 	g, _ := errgroup.WithContext(context.Background())
@@ -290,7 +115,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 			isRemote := strings.HasPrefix(task.Location, "http://") || strings.HasPrefix(task.Location, "https://") || strings.HasPrefix(task.Location, "git://")
 			var parseLocation string
 			var cleanup func()
-			var siteData *SiteData
+			var siteData *g2.SiteData
 
 			if isRemote {
 				var tmpDir string
@@ -330,7 +155,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 				}
 
 				t1 := time.Now()
-				siteData, err = parseRepo(os.DirFS(parseLocation), ".", task.Name, *fastGit, nil, SourceURL(task.Location))
+				siteData, err = parseRepo(os.DirFS(parseLocation), ".", task.Name, *fastGit, nil, g2.SourceURL(task.Location))
 				if err != nil {
 					return fmt.Errorf("parsing repo %s: %w", task.Name, err)
 				}
@@ -352,7 +177,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 				}
 
 				t1 := time.Now()
-				siteData, err = parseRepo(os.DirFS(parseLocation), ".", task.Name, *fastGit, nil, SourceURL(task.Location))
+				siteData, err = parseRepo(os.DirFS(parseLocation), ".", task.Name, *fastGit, nil, g2.SourceURL(task.Location))
 				if err != nil {
 					return fmt.Errorf("parsing repo %s: %w", task.Name, err)
 				}
@@ -465,7 +290,7 @@ func parseManifestFromFS(sysFS fs.FS, path string) (*g2.Manifest, error) {
 	return g2.ParseManifestFromReader(file)
 }
 
-func getHighestVersionsAndCount(versions []VersionData, site *SiteData) (template.HTML, template.HTML, int) {
+func getHighestVersionsAndCount(versions []g2.VersionData, site *g2.SiteData) (template.HTML, template.HTML, int) {
 	// Parse KEYWORDS and group versions
 
 	stableMap := make(map[string]string)
@@ -558,7 +383,7 @@ type ResolvedDepNode struct {
 	Children  []ResolvedDepNode `json:"children,omitempty"`
 }
 
-func resolveDependencies(node g2.DepNode, site *SiteData) ResolvedDepNode {
+func resolveDependencies(node g2.DepNode, site *g2.SiteData) ResolvedDepNode {
 	switch n := node.(type) {
 	case g2.DepString:
 		raw := string(n)
@@ -646,14 +471,14 @@ func sanitizeFilename(s string) string {
 	return res
 }
 
-func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, repoInfo *g2.Repository, opts ...any) (*SiteData, error) {
+func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, repoInfo *g2.Repository, opts ...any) (*g2.SiteData, error) {
 	title := defaultTitle
 	var repoName string
 	var remoteURL string
 
 	for _, opt := range opts {
 		switch o := opt.(type) {
-		case SourceURL:
+		case g2.SourceURL:
 			remoteURL = string(o)
 		}
 	}
@@ -824,7 +649,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		log.Printf("Warning: failed to parse info_pkgs: %v", err)
 	}
 
-	site := &SiteData{
+	site := &g2.SiteData{
 		Title:             title,
 		RepoName:          repoName,
 		RemoteURL:         remoteURL,
@@ -907,7 +732,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		_ = authorsFile.Close()
 	}
 
-	var profilesDescEntries []ProfileDescEntry
+	var profilesDescEntries []g2.ProfileDescEntry
 	profilesDescBytes, err := fs.ReadFile(sysFS, filepath.ToSlash(filepath.Join(repoDir, "profiles", "profiles.desc")))
 	if err == nil {
 		profilesDescEntries = parseProfilesDesc(string(profilesDescBytes))
@@ -925,7 +750,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		for _, eclassEntry := range eclassEntries {
 			if !eclassEntry.IsDir() && strings.HasSuffix(eclassEntry.Name(), ".eclass") {
 				eclassName := strings.TrimSuffix(eclassEntry.Name(), ".eclass")
-				site.DefinedEclasses = append(site.DefinedEclasses, EclassData{
+				site.DefinedEclasses = append(site.DefinedEclasses, g2.EclassData{
 					Name: eclassName,
 				})
 			}
@@ -990,7 +815,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 			continue
 		}
 
-		catData := CategoryData{Name: name}
+		catData := g2.CategoryData{Name: name}
 		catPath := filepath.Join(repoDir, name)
 
 		inRepo := len(supportedCategories) == 0 || supportedCategories[name]
@@ -1013,7 +838,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 			}
 
 			pkgPath := filepath.Join(catPath, pkgName)
-			pkgData := PackageData{
+			pkgData := g2.PackageData{
 				Name:     pkgName,
 				Category: name,
 			}
@@ -1068,7 +893,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 					pkgData.ModTime = modTime
 				}
 
-				vd := VersionData{
+				vd := g2.VersionData{
 					Version:      version,
 					Ebuild:       ebuild,
 					EbuildRawURL: ebuildRawURL,
@@ -1210,7 +1035,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 				if err == nil {
 					for _, fe := range fileEntries {
 						if !fe.IsDir() {
-							fd := FileData{
+							fd := g2.FileData{
 								Name: fe.Name(),
 								Path: filepath.Join(filesDirPath, fe.Name()),
 							}
@@ -1396,7 +1221,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 	return site, nil
 }
 
-func extractVirtualDeps(site *SiteData) {
+func extractVirtualDeps(site *g2.SiteData) {
 	for i := range site.Categories {
 		if site.Categories[i].Name != "virtual" && !strings.HasPrefix(site.Categories[i].Name, "virtual-") {
 			continue
@@ -1499,10 +1324,10 @@ func extractDepNodes(nodes []g2.DepNode, depsMap map[string]bool) {
 	}
 }
 
-func buildManifestData(manifest *g2.Manifest, versions []VersionData, thirdPartyMirrors map[string][]string) []ManifestEntryData {
-	var manifestData []ManifestEntryData
+func buildManifestData(manifest *g2.Manifest, versions []g2.VersionData, thirdPartyMirrors map[string][]string) []g2.ManifestEntryData {
+	var manifestData []g2.ManifestEntryData
 	for _, entry := range manifest.Entries {
-		md := ManifestEntryData{
+		md := g2.ManifestEntryData{
 			Entry: entry,
 		}
 
@@ -1570,23 +1395,23 @@ func buildManifestData(manifest *g2.Manifest, versions []VersionData, thirdParty
 	return manifestData
 }
 
-func parseProfilesDir(repoDir string, entries []ProfileDescEntry) ([]ProfileData, error) {
+func parseProfilesDir(repoDir string, entries []g2.ProfileDescEntry) ([]g2.ProfileData, error) {
 	return parseProfilesDirFS(os.DirFS(repoDir), ".", entries)
 }
 
-func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry) ([]ProfileData, error) {
+func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []g2.ProfileDescEntry) ([]g2.ProfileData, error) {
 	profilesDir := path2.Join(repoDir, "profiles")
 
 	if info, err := fs.Stat(sysFS, profilesDir); err != nil || !info.IsDir() {
 		return nil, nil
 	}
 
-	descMap := make(map[string]ProfileDescEntry)
+	descMap := make(map[string]g2.ProfileDescEntry)
 	for _, e := range entries {
 		descMap[e.Path] = e
 	}
 
-	profilesMap := make(map[string]*ProfileData)
+	profilesMap := make(map[string]*g2.ProfileData)
 
 	err := fs.WalkDir(sysFS, profilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -1602,7 +1427,7 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 			return nil
 		}
 
-		pData := &ProfileData{
+		pData := &g2.ProfileData{
 			Path:  relPath,
 			Files: make(map[string]string),
 		}
@@ -1657,7 +1482,7 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 		}
 	}
 
-	var result []ProfileData
+	var result []g2.ProfileData
 	for _, pData := range profilesMap {
 		result = append(result, *pData)
 	}
@@ -1665,8 +1490,8 @@ func parseProfilesDirFS(sysFS fs.FS, repoDir string, entries []ProfileDescEntry)
 	return result, nil
 }
 
-func parseProfilesDesc(content string) []ProfileDescEntry {
-	var entries []ProfileDescEntry
+func parseProfilesDesc(content string) []g2.ProfileDescEntry {
+	var entries []g2.ProfileDescEntry
 	lines := strings.Split(content, "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -1675,7 +1500,7 @@ func parseProfilesDesc(content string) []ProfileDescEntry {
 		}
 		parts := strings.Fields(line)
 		if len(parts) >= 3 {
-			entries = append(entries, ProfileDescEntry{
+			entries = append(entries, g2.ProfileDescEntry{
 				Arch:   parts[0],
 				Path:   parts[1],
 				Status: parts[2],
@@ -1701,54 +1526,15 @@ func isIgnoredDir(name string) bool {
 	return ignored[name]
 }
 
-// TODO check model's should be redundant OR migrated to /
-
-type AggCategory struct {
-	Name     string
-	Packages map[string]*AggPackage
-}
-type AggPackage struct {
-	Name                string
-	Category            string
-	Repos               map[string]*SiteData
-	DominantDescription string
-	DominantHomepage    string
-	DominantLicense     string
-	ReverseVirtuals     []string
-	VirtualDeps         []string
-}
-type AggProject struct {
-	Project  *g2.Project
-	Packages []*AggPackage
-}
-
-type AggLicense struct {
-	Name     string
-	Count    int
-	Packages []*AggPackage
-	Text     string
-	Aliases  []string
-}
-
-type AggUseFlag struct {
-	Name          string
-	Count         int
-	GlobalDesc    string
-	LocalDescs    map[string]string
-	MetadataDescs map[string]string
-	Packages      []*AggPackage
-	Warnings      []string
-}
-
-func getRepoEclasses(site *SiteData, aggPackages map[string]*AggPackage) []*AggEclass {
-	eclassMap := make(map[string]*AggEclass)
+func getRepoEclasses(site *g2.SiteData, aggPackages map[string]*g2.AggPackage) []*g2.AggEclass {
+	eclassMap := make(map[string]*g2.AggEclass)
 	seenPackages := make(map[string]map[string]bool)
 
 	for _, eclass := range site.DefinedEclasses {
 		if _, ok := eclassMap[eclass.Name]; !ok {
-			eclassMap[eclass.Name] = &AggEclass{
+			eclassMap[eclass.Name] = &g2.AggEclass{
 				Name:  eclass.Name,
-				Repos: make(map[string]*SiteData),
+				Repos: make(map[string]*g2.SiteData),
 			}
 			seenPackages[eclass.Name] = make(map[string]bool)
 		}
@@ -1766,9 +1552,9 @@ func getRepoEclasses(site *SiteData, aggPackages map[string]*AggPackage) []*AggE
 						eclasses := strings.Fields(inherited)
 						for _, ec := range eclasses {
 							if _, ok := eclassMap[ec]; !ok {
-								eclassMap[ec] = &AggEclass{
+								eclassMap[ec] = &g2.AggEclass{
 									Name:  ec,
-									Repos: make(map[string]*SiteData),
+									Repos: make(map[string]*g2.SiteData),
 								}
 								eclassMap[ec].Repos[site.RepoName] = site
 								seenPackages[ec] = make(map[string]bool)
@@ -1785,7 +1571,7 @@ func getRepoEclasses(site *SiteData, aggPackages map[string]*AggPackage) []*AggE
 		}
 	}
 
-	var sortedEclasses []*AggEclass
+	var sortedEclasses []*g2.AggEclass
 	for _, ec := range eclassMap {
 		sort.Slice(ec.Packages, func(i, j int) bool {
 			if ec.Packages[i].Category == ec.Packages[j].Category {
@@ -1800,8 +1586,8 @@ func getRepoEclasses(site *SiteData, aggPackages map[string]*AggPackage) []*AggE
 	return sortedEclasses
 }
 
-func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggUseFlag {
-	aggUseFlags := make(map[string]*AggUseFlag)
+func getRepoUseFlags(site *g2.SiteData, aggPackages map[string]*g2.AggPackage) []*g2.AggUseFlag {
+	aggUseFlags := make(map[string]*g2.AggUseFlag)
 
 	for _, cat := range site.Categories {
 		for _, pkg := range cat.Packages {
@@ -1815,7 +1601,7 @@ func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggU
 						for _, flagObj := range parsedFlags {
 							flag := flagObj.Name
 							if _, ok := aggUseFlags[flag]; !ok {
-								aggUseFlags[flag] = &AggUseFlag{
+								aggUseFlags[flag] = &g2.AggUseFlag{
 									Name:          flag,
 									LocalDescs:    make(map[string]string),
 									MetadataDescs: make(map[string]string),
@@ -1847,7 +1633,7 @@ func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggU
 							flag = strings.TrimPrefix(flag, "!") // remove negations
 
 							if _, ok := aggUseFlags[flag]; !ok {
-								aggUseFlags[flag] = &AggUseFlag{
+								aggUseFlags[flag] = &g2.AggUseFlag{
 									Name:          flag,
 									LocalDescs:    make(map[string]string),
 									MetadataDescs: make(map[string]string),
@@ -1874,7 +1660,7 @@ func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggU
 				for _, useBlock := range pkg.Metadata.Use {
 					for _, flag := range useBlock.Flags {
 						if _, ok := aggUseFlags[flag.Name]; !ok {
-							aggUseFlags[flag.Name] = &AggUseFlag{
+							aggUseFlags[flag.Name] = &g2.AggUseFlag{
 								Name:          flag.Name,
 								LocalDescs:    make(map[string]string),
 								MetadataDescs: make(map[string]string),
@@ -1905,7 +1691,7 @@ func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggU
 	if site.UseDesc != nil {
 		for flag, desc := range site.UseDesc.Flags {
 			if _, ok := aggUseFlags[flag]; !ok {
-				aggUseFlags[flag] = &AggUseFlag{
+				aggUseFlags[flag] = &g2.AggUseFlag{
 					Name:          flag,
 					LocalDescs:    make(map[string]string),
 					MetadataDescs: make(map[string]string),
@@ -1938,7 +1724,7 @@ func getRepoUseFlags(site *SiteData, aggPackages map[string]*AggPackage) []*AggU
 		}
 	}
 
-	var sortedUseFlags []*AggUseFlag
+	var sortedUseFlags []*g2.AggUseFlag
 	for _, flag := range aggUseFlags {
 		for _, pkg := range flag.Packages {
 			if pkg == nil {
@@ -1993,71 +1779,8 @@ func parseDuration(s string) (time.Duration, string, error) {
 	return d, s, nil
 }
 
-// TODO migrate to / if it hasn't been done already check for differences
-
-type AggProfileRepo struct {
-	RepoName string
-	Profile  ProfileData
-}
-
-type AggProfile struct {
-	Path     string
-	IsDesc   bool
-	DescArch string
-	DescStat string
-	Repos    []AggProfileRepo
-	Files    map[string]string // Maps filename to its content
-}
-
-type AggEclass struct {
-	Name     string
-	Repos    map[string]*SiteData
-	Packages []*AggPackage
-}
-
-type AggPackageMove struct {
-	Old string
-	New string
-}
-
-type AggNewsItem struct {
-	g2.NewsItem
-	RepoName string
-}
-
-type AggArch struct {
-	Name   string
-	Status string
-	Repos  []*SiteData
-}
-
-type RepoGroup struct {
-	Quality string
-	Status  string
-	Repos   []*SiteData
-}
-
-type AggregatedData struct {
-	Categories      []*AggCategory
-	Packages        []*AggPackage
-	Licenses        []*AggLicense
-	Projects        []*AggProject
-	Profiles        []*AggProfile
-	Arches          []*AggArch
-	Moves           map[string]*AggPackageMove
-	GlobalNews      []AggNewsItem
-	RecentNews      []AggNewsItem
-	TotalPackages   int
-	UseFlags        []*AggUseFlag
-	Eclasses        []*AggEclass
-	UseExpandDescs  map[string]*g2.UseExpandDesc
-	ValidLicenses   map[string]bool
-	ValidUseExpands map[string]bool
-	GroupedRepos    []RepoGroup
-}
-
-func aggregateGroupedRepos(sites []*SiteData) map[string]*RepoGroup {
-	groupedReposMap := make(map[string]*RepoGroup)
+func aggregateGroupedRepos(sites []*g2.SiteData) map[string]*g2.RepoGroup {
+	groupedReposMap := make(map[string]*g2.RepoGroup)
 	for _, site := range sites {
 		quality := "experimental"
 		status := "unofficial"
@@ -2072,7 +1795,7 @@ func aggregateGroupedRepos(sites []*SiteData) map[string]*RepoGroup {
 
 		groupKey := quality + "|" + status
 		if _, ok := groupedReposMap[groupKey]; !ok {
-			groupedReposMap[groupKey] = &RepoGroup{
+			groupedReposMap[groupKey] = &g2.RepoGroup{
 				Quality: quality,
 				Status:  status,
 			}
@@ -2082,7 +1805,7 @@ func aggregateGroupedRepos(sites []*SiteData) map[string]*RepoGroup {
 	return groupedReposMap
 }
 
-func aggregateUseExpandDescs(sites []*SiteData) map[string]*g2.UseExpandDesc {
+func aggregateUseExpandDescs(sites []*g2.SiteData) map[string]*g2.UseExpandDesc {
 	aggUseExpandDescs := make(map[string]*g2.UseExpandDesc)
 	for _, site := range sites {
 		if site.UseExpandDescs != nil {
@@ -2096,14 +1819,14 @@ func aggregateUseExpandDescs(sites []*SiteData) map[string]*g2.UseExpandDesc {
 	return aggUseExpandDescs
 }
 
-func aggregateProjects(sites []*SiteData) map[string]*AggProject {
-	aggProjects := make(map[string]*AggProject)
+func aggregateProjects(sites []*g2.SiteData) map[string]*g2.AggProject {
+	aggProjects := make(map[string]*g2.AggProject)
 	for _, site := range sites {
 		if site.Projects != nil {
 			for i := range site.Projects.Projects {
 				proj := &site.Projects.Projects[i]
 				if _, ok := aggProjects[proj.Email]; !ok {
-					aggProjects[proj.Email] = &AggProject{Project: proj}
+					aggProjects[proj.Email] = &g2.AggProject{Project: proj}
 				}
 			}
 		}
@@ -2111,16 +1834,16 @@ func aggregateProjects(sites []*SiteData) map[string]*AggProject {
 	return aggProjects
 }
 
-func aggregateProfiles(sites []*SiteData) map[string]*AggProfile {
-	aggProfiles := make(map[string]*AggProfile)
+func aggregateProfiles(sites []*g2.SiteData) map[string]*g2.AggProfile {
+	aggProfiles := make(map[string]*g2.AggProfile)
 	for _, site := range sites {
 		for _, p := range site.Profiles {
 			if _, ok := aggProfiles[p.Path]; !ok {
-				aggProfiles[p.Path] = &AggProfile{
+				aggProfiles[p.Path] = &g2.AggProfile{
 					Path: p.Path,
 				}
 			}
-			aggProfiles[p.Path].Repos = append(aggProfiles[p.Path].Repos, AggProfileRepo{
+			aggProfiles[p.Path].Repos = append(aggProfiles[p.Path].Repos, g2.AggProfileRepo{
 				RepoName: site.RepoName,
 				Profile:  p,
 			})
@@ -2134,11 +1857,11 @@ func aggregateProfiles(sites []*SiteData) map[string]*AggProfile {
 	return aggProfiles
 }
 
-func aggregateGlobalNews(sites []*SiteData) []AggNewsItem {
-	var globalNews []AggNewsItem
+func aggregateGlobalNews(sites []*g2.SiteData) []g2.AggNewsItem {
+	var globalNews []g2.AggNewsItem
 	for _, site := range sites {
 		for _, news := range site.News {
-			globalNews = append(globalNews, AggNewsItem{
+			globalNews = append(globalNews, g2.AggNewsItem{
 				NewsItem: news,
 				RepoName: site.RepoName,
 			})
@@ -2147,13 +1870,13 @@ func aggregateGlobalNews(sites []*SiteData) []AggNewsItem {
 	return globalNews
 }
 
-func aggregateArches(sites []*SiteData) map[string]*AggArch {
-	aggArches := make(map[string]*AggArch)
+func aggregateArches(sites []*g2.SiteData) map[string]*g2.AggArch {
+	aggArches := make(map[string]*g2.AggArch)
 	for _, site := range sites {
 		if site.ArchList != nil {
 			for _, arch := range site.ArchList.Arches {
 				if _, ok := aggArches[arch]; !ok {
-					aggArches[arch] = &AggArch{Name: arch}
+					aggArches[arch] = &g2.AggArch{Name: arch}
 				}
 				aggArches[arch].Repos = append(aggArches[arch].Repos, site)
 			}
@@ -2161,7 +1884,7 @@ func aggregateArches(sites []*SiteData) map[string]*AggArch {
 		if site.ArchesDesc != nil {
 			for arch, status := range site.ArchesDesc.Arches {
 				if _, ok := aggArches[arch]; !ok {
-					aggArches[arch] = &AggArch{Name: arch}
+					aggArches[arch] = &g2.AggArch{Name: arch}
 				}
 				if aggArches[arch].Status == "" {
 					aggArches[arch].Status = status
@@ -2183,26 +1906,26 @@ func aggregateArches(sites []*SiteData) map[string]*AggArch {
 	return aggArches
 }
 
-func aggregateMoves(sites []*SiteData) map[string]*AggPackageMove {
-	aggMoves := make(map[string]*AggPackageMove)
+func aggregateMoves(sites []*g2.SiteData) map[string]*g2.AggPackageMove {
+	aggMoves := make(map[string]*g2.AggPackageMove)
 	for _, site := range sites {
 		for _, move := range site.Moves {
 			if _, ok := aggMoves[move.Old]; !ok {
-				aggMoves[move.Old] = &AggPackageMove{Old: move.Old, New: move.New}
+				aggMoves[move.Old] = &g2.AggPackageMove{Old: move.Old, New: move.New}
 			}
 		}
 	}
 	return aggMoves
 }
 
-func aggregateEclasses(sites []*SiteData) map[string]*AggEclass {
-	aggEclasses := make(map[string]*AggEclass)
+func aggregateEclasses(sites []*g2.SiteData) map[string]*g2.AggEclass {
+	aggEclasses := make(map[string]*g2.AggEclass)
 	for _, site := range sites {
 		for _, eclass := range site.AggEclasses {
 			if _, ok := aggEclasses[eclass.Name]; !ok {
-				aggEclasses[eclass.Name] = &AggEclass{
+				aggEclasses[eclass.Name] = &g2.AggEclass{
 					Name:  eclass.Name,
-					Repos: make(map[string]*SiteData),
+					Repos: make(map[string]*g2.SiteData),
 				}
 			}
 			for rName, rData := range eclass.Repos {
@@ -2212,7 +1935,7 @@ func aggregateEclasses(sites []*SiteData) map[string]*AggEclass {
 				foundPkg := false
 				for _, existingPkg := range aggEclasses[eclass.Name].Packages {
 					if existingPkg.Name == pkg.Name && existingPkg.Category == pkg.Category {
-						newRepos := make(map[string]*SiteData)
+						newRepos := make(map[string]*g2.SiteData)
 						for k, v := range existingPkg.Repos {
 							newRepos[k] = v
 						}
@@ -2226,7 +1949,7 @@ func aggregateEclasses(sites []*SiteData) map[string]*AggEclass {
 				}
 				if !foundPkg {
 					newPkg := *pkg
-					newRepos := make(map[string]*SiteData)
+					newRepos := make(map[string]*g2.SiteData)
 					for k, v := range pkg.Repos {
 						newRepos[k] = v
 					}
@@ -2239,21 +1962,21 @@ func aggregateEclasses(sites []*SiteData) map[string]*AggEclass {
 	return aggEclasses
 }
 
-func aggregatePackagesAndCategories(sites []*SiteData, aggProjects map[string]*AggProject) (map[string]*AggCategory, map[string]*AggPackage, map[string]*AggLicense, int) {
-	aggCategories := make(map[string]*AggCategory)
-	aggPackages := make(map[string]*AggPackage)
-	aggLicenses := make(map[string]*AggLicense)
+func aggregatePackagesAndCategories(sites []*g2.SiteData, aggProjects map[string]*g2.AggProject) (map[string]*g2.AggCategory, map[string]*g2.AggPackage, map[string]*g2.AggLicense, int) {
+	aggCategories := make(map[string]*g2.AggCategory)
+	aggPackages := make(map[string]*g2.AggPackage)
+	aggLicenses := make(map[string]*g2.AggLicense)
 	totalPackages := 0
 
 	for _, site := range sites {
 		for _, cat := range site.Categories {
 			if _, ok := aggCategories[cat.Name]; !ok {
-				aggCategories[cat.Name] = &AggCategory{Name: cat.Name, Packages: make(map[string]*AggPackage)}
+				aggCategories[cat.Name] = &g2.AggCategory{Name: cat.Name, Packages: make(map[string]*g2.AggPackage)}
 			}
 			for _, pkg := range cat.Packages {
 				pkgKey := cat.Name + "/" + pkg.Name
 				if _, ok := aggPackages[pkgKey]; !ok {
-					aggPackages[pkgKey] = &AggPackage{Name: pkg.Name, Category: cat.Name, Repos: make(map[string]*SiteData)}
+					aggPackages[pkgKey] = &g2.AggPackage{Name: pkg.Name, Category: cat.Name, Repos: make(map[string]*g2.SiteData)}
 					totalPackages++
 				}
 				aggPackages[pkgKey].Repos[site.RepoName] = site
@@ -2324,7 +2047,7 @@ func aggregatePackagesAndCategories(sites []*SiteData, aggProjects map[string]*A
 									continue
 								}
 								if _, ok := aggLicenses[lic]; !ok {
-									aggLicenses[lic] = &AggLicense{Name: lic}
+									aggLicenses[lic] = &g2.AggLicense{Name: lic}
 								}
 
 								found := false
@@ -2366,8 +2089,8 @@ func aggregatePackagesAndCategories(sites []*SiteData, aggProjects map[string]*A
 	return aggCategories, aggPackages, aggLicenses, totalPackages
 }
 
-func sortCategories(aggCategories map[string]*AggCategory) []*AggCategory {
-	var sortedCategories []*AggCategory
+func sortCategories(aggCategories map[string]*g2.AggCategory) []*g2.AggCategory {
+	var sortedCategories []*g2.AggCategory
 	for _, c := range aggCategories {
 		sortedCategories = append(sortedCategories, c)
 	}
@@ -2375,8 +2098,8 @@ func sortCategories(aggCategories map[string]*AggCategory) []*AggCategory {
 	return sortedCategories
 }
 
-func sortPackages(aggPackages map[string]*AggPackage) []*AggPackage {
-	var sortedPackages []*AggPackage
+func sortPackages(aggPackages map[string]*g2.AggPackage) []*g2.AggPackage {
+	var sortedPackages []*g2.AggPackage
 	for _, p := range aggPackages {
 		sortedPackages = append(sortedPackages, p)
 	}
@@ -2389,7 +2112,7 @@ func sortPackages(aggPackages map[string]*AggPackage) []*AggPackage {
 	return sortedPackages
 }
 
-func aggregateValidUseExpands(sites []*SiteData) map[string]bool {
+func aggregateValidUseExpands(sites []*g2.SiteData) map[string]bool {
 	validUseExpands := make(map[string]bool)
 	for _, site := range sites {
 		for prefix := range site.ValidUseExpands {
@@ -2399,9 +2122,9 @@ func aggregateValidUseExpands(sites []*SiteData) map[string]bool {
 	return validUseExpands
 }
 
-func sortLicenses(aggLicenses map[string]*AggLicense) ([]*AggLicense, map[string]bool) {
+func sortLicenses(aggLicenses map[string]*g2.AggLicense) ([]*g2.AggLicense, map[string]bool) {
 	validLicenses := make(map[string]bool)
-	var sortedLicenses []*AggLicense
+	var sortedLicenses []*g2.AggLicense
 	for _, l := range aggLicenses {
 		sort.Strings(l.Aliases)
 		sortedLicenses = append(sortedLicenses, l)
@@ -2411,8 +2134,8 @@ func sortLicenses(aggLicenses map[string]*AggLicense) ([]*AggLicense, map[string
 	return sortedLicenses, validLicenses
 }
 
-func sortProjects(aggProjects map[string]*AggProject) []*AggProject {
-	var sortedProjects []*AggProject
+func sortProjects(aggProjects map[string]*g2.AggProject) []*g2.AggProject {
+	var sortedProjects []*g2.AggProject
 	for _, p := range aggProjects {
 		sortedProjects = append(sortedProjects, p)
 	}
@@ -2420,8 +2143,8 @@ func sortProjects(aggProjects map[string]*AggProject) []*AggProject {
 	return sortedProjects
 }
 
-func sortProfiles(aggProfiles map[string]*AggProfile) []*AggProfile {
-	var sortedProfiles []*AggProfile
+func sortProfiles(aggProfiles map[string]*g2.AggProfile) []*g2.AggProfile {
+	var sortedProfiles []*g2.AggProfile
 	for _, p := range aggProfiles {
 		sortedProfiles = append(sortedProfiles, p)
 	}
@@ -2429,8 +2152,8 @@ func sortProfiles(aggProfiles map[string]*AggProfile) []*AggProfile {
 	return sortedProfiles
 }
 
-func sortArches(aggArches map[string]*AggArch) []*AggArch {
-	var sortedArches []*AggArch
+func sortArches(aggArches map[string]*g2.AggArch) []*g2.AggArch {
+	var sortedArches []*g2.AggArch
 	for _, a := range aggArches {
 		sortedArches = append(sortedArches, a)
 	}
@@ -2438,8 +2161,8 @@ func sortArches(aggArches map[string]*AggArch) []*AggArch {
 	return sortedArches
 }
 
-func sortEclasses(aggEclasses map[string]*AggEclass) []*AggEclass {
-	var sortedEclasses []*AggEclass
+func sortEclasses(aggEclasses map[string]*g2.AggEclass) []*g2.AggEclass {
+	var sortedEclasses []*g2.AggEclass
 	for _, ec := range aggEclasses {
 		sort.Slice(ec.Packages, func(i, j int) bool {
 			if ec.Packages[i].Category == ec.Packages[j].Category {
@@ -2453,12 +2176,12 @@ func sortEclasses(aggEclasses map[string]*AggEclass) []*AggEclass {
 	return sortedEclasses
 }
 
-func extractRecentNews(globalNews []AggNewsItem) []AggNewsItem {
+func extractRecentNews(globalNews []g2.AggNewsItem) []g2.AggNewsItem {
 	sort.Slice(globalNews, func(i, j int) bool {
 		return globalNews[i].Posted.After(globalNews[j].Posted)
 	})
 
-	var recentNews []AggNewsItem
+	var recentNews []g2.AggNewsItem
 	cutoffDate := time.Now().AddDate(0, -3, 0)
 	for _, n := range globalNews {
 		if n.Posted.After(cutoffDate) {
@@ -2476,8 +2199,8 @@ func extractRecentNews(globalNews []AggNewsItem) []AggNewsItem {
 	return recentNews
 }
 
-func sortGroupedRepos(groupedReposMap map[string]*RepoGroup) []RepoGroup {
-	var sortedGroupedRepos []RepoGroup
+func sortGroupedRepos(groupedReposMap map[string]*g2.RepoGroup) []g2.RepoGroup {
+	var sortedGroupedRepos []g2.RepoGroup
 	for _, group := range groupedReposMap {
 		sortedGroupedRepos = append(sortedGroupedRepos, *group)
 	}
@@ -2490,7 +2213,7 @@ func sortGroupedRepos(groupedReposMap map[string]*RepoGroup) []RepoGroup {
 	return sortedGroupedRepos
 }
 
-func prepareAggregatedData(sites []*SiteData) *AggregatedData {
+func prepareAggregatedData(sites []*g2.SiteData) *g2.AggregatedData {
 	groupedReposMap := aggregateGroupedRepos(sites)
 	aggUseExpandDescs := aggregateUseExpandDescs(sites)
 	aggProjects := aggregateProjects(sites)
@@ -2514,7 +2237,7 @@ func prepareAggregatedData(sites []*SiteData) *AggregatedData {
 
 	sortedUseFlags, _ := AggregateUseFlags(sites, aggPackages)
 
-	return &AggregatedData{
+	return &g2.AggregatedData{
 		Categories:      sortedCategories,
 		Packages:        sortedPackages,
 		Licenses:        sortedLicenses,
@@ -2534,7 +2257,7 @@ func prepareAggregatedData(sites []*SiteData) *AggregatedData {
 	}
 }
 
-func generateGlobalPages(outDir string, tmpl *template.Template, sites []*SiteData, data *AggregatedData, title, version, recentDurationStr string, genInfo GenerationInfo) error {
+func generateGlobalPages(outDir string, tmpl *template.Template, sites []*g2.SiteData, data *g2.AggregatedData, title, version, recentDurationStr string, genInfo GenerationInfo) error {
 	// Generate Help Page
 	if err := os.MkdirAll(filepath.Join(outDir, "help"), 0755); err != nil {
 		return err
@@ -2597,7 +2320,7 @@ func generateGlobalPages(outDir string, tmpl *template.Template, sites []*SiteDa
 		if err := renderPage(filepath.Join(outDir, "news", "index.html"), tmpl, "news_dashboard.html", GenericPageContext{
 			Title:       "News Dashboard",
 			BaseURL:     "../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "News"}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "News"}},
 			RecentNews:  data.RecentNews,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -2612,7 +2335,7 @@ func generateGlobalPages(outDir string, tmpl *template.Template, sites []*SiteDa
 		if err := renderPage(filepath.Join(outDir, "news", "archive", "index.html"), tmpl, "news_archive.html", GenericPageContext{
 			Title:       "News Archive",
 			BaseURL:     "../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "News", URL: "../"}, {Name: "Archive"}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "News", URL: "../"}, {Name: "Archive"}},
 			GlobalNews:  data.GlobalNews,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -2629,7 +2352,7 @@ func generateGlobalPages(outDir string, tmpl *template.Template, sites []*SiteDa
 			if err := renderPage(filepath.Join(newsDir, "index.html"), tmpl, "news_article.html", GenericPageContext{
 				Title:       n.Title,
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: "News", URL: "../../"}, {Name: "Archive", URL: "../"}, {Name: n.Title}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: "News", URL: "../../"}, {Name: "Archive", URL: "../"}, {Name: n.Title}},
 				NewsItem:    n,
 				Version:     version,
 				GenInfo:     genInfo,
@@ -2647,7 +2370,7 @@ func generateGlobalPages(outDir string, tmpl *template.Template, sites []*SiteDa
 	if err := renderPage(filepath.Join(outDir, "overlays", "index.html"), tmpl, "overlays.html", GenericPageContext{
 		Title:       "Overlays",
 		BaseURL:     "../",
-		Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Overlays"}},
+		Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "Overlays"}},
 		Repos:       sites,
 		Version:     version,
 		GenInfo:     genInfo,
@@ -2658,7 +2381,7 @@ func generateGlobalPages(outDir string, tmpl *template.Template, sites []*SiteDa
 	return nil
 }
 
-func generateCategoryPages(outDir string, tmpl *template.Template, data *AggregatedData, title, version string, genInfo GenerationInfo) error {
+func generateCategoryPages(outDir string, tmpl *template.Template, data *g2.AggregatedData, title, version string, genInfo GenerationInfo) error {
 	// 3. Global Categories
 	if err := os.MkdirAll(filepath.Join(outDir, "categories"), 0755); err != nil {
 		return fmt.Errorf("creating directory: %w", err)
@@ -2666,7 +2389,7 @@ func generateCategoryPages(outDir string, tmpl *template.Template, data *Aggrega
 	if err := renderPage(filepath.Join(outDir, "categories", "index.html"), tmpl, "categories.html", GenericPageContext{
 		Title:       "Categories",
 		BaseURL:     "../",
-		Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Categories"}},
+		Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "Categories"}},
 		Categories:  data.Categories,
 		Version:     version,
 		GenInfo:     genInfo,
@@ -2686,7 +2409,7 @@ func generateCategoryPages(outDir string, tmpl *template.Template, data *Aggrega
 			return fmt.Errorf("creating directory %s: %w", catDir, err)
 		}
 
-		var catPkgs []*AggPackage
+		var catPkgs []*g2.AggPackage
 		for _, p := range cat.Packages {
 			catPkgs = append(catPkgs, p)
 		}
@@ -2694,7 +2417,7 @@ func generateCategoryPages(outDir string, tmpl *template.Template, data *Aggrega
 
 		type TmplPkg struct {
 			Name                  string
-			ReposList             []*SiteData
+			ReposList             []*g2.SiteData
 			EbuildCount           int
 			HighestStableVersion  template.HTML
 			HighestTestingVersion template.HTML
@@ -2705,7 +2428,7 @@ func generateCategoryPages(outDir string, tmpl *template.Template, data *Aggrega
 		}
 		var tmplPkgs []TmplPkg
 		for _, p := range catPkgs {
-			var allVersions []VersionData
+			var allVersions []g2.VersionData
 			for _, r := range p.Repos {
 				for _, c := range r.Categories {
 					if c.Name == cat.Name {
@@ -2724,7 +2447,7 @@ func generateCategoryPages(outDir string, tmpl *template.Template, data *Aggrega
 		if err := renderPage(filepath.Join(catDir, "index.html"), tmpl, "category.html", GenericPageContext{
 			Title:       "Category: " + cat.Name,
 			BaseURL:     "../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "Categories", URL: "../"}, {Name: cat.Name}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "Categories", URL: "../"}, {Name: cat.Name}},
 			Category:    map[string]interface{}{"Name": cat.Name, "Packages": tmplPkgs},
 			Version:     version,
 			GenInfo:     genInfo,
@@ -2735,7 +2458,7 @@ func generateCategoryPages(outDir string, tmpl *template.Template, data *Aggrega
 	return nil
 }
 
-func generatePackagePages(outDir string, tmpl *template.Template, data *AggregatedData, title, version string, genInfo GenerationInfo) error {
+func generatePackagePages(outDir string, tmpl *template.Template, data *g2.AggregatedData, title, version string, genInfo GenerationInfo) error {
 	// Global Moved Packages Pages
 	for oldPath, move := range data.Moves {
 		parts := strings.Split(oldPath, "/")
@@ -2768,7 +2491,7 @@ func generatePackagePages(outDir string, tmpl *template.Template, data *Aggregat
 		if err := renderPage(filepath.Join(pkgDir, "index.html"), tmpl, "moved_package.html", GenericPageContext{
 			Title:       "Package Moved: " + oldCat + "/" + oldName,
 			BaseURL:     "../../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Packages", URL: "../../"}, {Name: oldCat, URL: "../../../categories/" + oldCat + "/"}, {Name: oldName}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Packages", URL: "../../"}, {Name: oldCat, URL: "../../../categories/" + oldCat + "/"}, {Name: oldName}},
 			OldName:     oldCat + "/" + oldName,
 			NewName:     move.New,
 			NewURL:      "../../" + newParts[0] + "/" + newParts[1] + "/",
@@ -2786,7 +2509,7 @@ func generatePackagePages(outDir string, tmpl *template.Template, data *Aggregat
 	if err := renderPage(filepath.Join(outDir, "packages", "index.html"), tmpl, "packages.html", GenericPageContext{
 		Title:       "Packages",
 		BaseURL:     "../",
-		Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Packages"}},
+		Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "Packages"}},
 		Packages:    data.Packages,
 		Version:     version,
 		GenInfo:     genInfo,
@@ -2821,7 +2544,7 @@ func generatePackagePages(outDir string, tmpl *template.Template, data *Aggregat
 			if err := renderPage(filepath.Join(pkgDir, "index.html"), tmpl, "package_picker.html", GenericPageContext{
 				Title:       "Package: " + pkg.Category + "/" + pkg.Name,
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Packages", URL: "../../"}, {Name: pkg.Category, URL: "../../../categories/" + pkg.Category + "/"}, {Name: pkg.Name}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Packages", URL: "../../"}, {Name: pkg.Category, URL: "../../../categories/" + pkg.Category + "/"}, {Name: pkg.Name}},
 				Package:     map[string]interface{}{"Category": pkg.Category, "Name": pkg.Name, "ReposList": reposList},
 				MovedToName: movedToName,
 				MovedToURL:  movedToURL,
@@ -2836,7 +2559,7 @@ func generatePackagePages(outDir string, tmpl *template.Template, data *Aggregat
 	return nil
 }
 
-func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *AggregatedData, title, version string, genInfo GenerationInfo) error {
+func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *g2.AggregatedData, title, version string, genInfo GenerationInfo) error {
 	// Arches
 	if err := os.MkdirAll(filepath.Join(outDir, "arches"), 0755); err != nil {
 		return fmt.Errorf("creating directory: %w", err)
@@ -2844,7 +2567,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 	if err := renderPage(filepath.Join(outDir, "arches", "index.html"), tmpl, "arches.html", GenericPageContext{
 		Title:       "Architectures",
 		BaseURL:     "../",
-		Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Architectures"}},
+		Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "Architectures"}},
 		Arches:      data.Arches,
 		Version:     version,
 		GenInfo:     genInfo,
@@ -2861,7 +2584,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		if err := renderPage(filepath.Join(archDir, "index.html"), tmpl, "arch.html", GenericPageContext{
 			Title:       "Architecture: " + a.Name,
 			BaseURL:     "../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "Architectures", URL: "../../arches/"}, {Name: a.Name}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "Architectures", URL: "../../arches/"}, {Name: a.Name}},
 			Arch:        a,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -2878,7 +2601,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		if err := renderPage(filepath.Join(outDir, "profiles", "index.html"), tmpl, "profiles.html", GenericPageContext{
 			Title:       "Profiles",
 			BaseURL:     "../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Profiles"}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "Profiles"}},
 			Profiles:    data.Profiles,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -2897,7 +2620,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 			if err := renderPage(filepath.Join(profDir, "index.html"), tmpl, "profile.html", GenericPageContext{
 				Title:       "Profile: " + p.Path,
 				BaseURL:     relToRoot,
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: relToRoot}, {Name: "Profiles", URL: relToRoot + "profiles/"}, {Name: p.Path}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: relToRoot}, {Name: "Profiles", URL: relToRoot + "profiles/"}, {Name: p.Path}},
 				ProfilePath: p.Path,
 				ProfileList: p.Repos,
 				Version:     version,
@@ -2919,7 +2642,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 	if err := renderPage(filepath.Join(outDir, "uses", "index.html"), tmpl, "uses.html", GenericPageContext{
 		Title:       "USE Flags",
 		BaseURL:     "../",
-		Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "USE Flags"}},
+		Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "USE Flags"}},
 		UseFlags:    data.UseFlags,
 		Version:     version,
 		GenInfo:     genInfo,
@@ -2937,7 +2660,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		if err := renderPage(filepath.Join(useDir, "index.html"), tmpl, "use.html", GenericPageContext{
 			Title:       "USE Flag: " + f.Name,
 			BaseURL:     "../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "USE Flags", URL: "../"}, {Name: f.Name}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "USE Flags", URL: "../"}, {Name: f.Name}},
 			UseFlag:     f,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -2953,7 +2676,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		if err := renderPage(filepath.Join(outDir, "uses_expand", "index.html"), tmpl, "use_expands.html", GenericPageContext{
 			Title:          "USE_EXPAND Flags",
 			BaseURL:        "../",
-			Breadcrumbs:    []Breadcrumb{{Name: title, URL: "../"}, {Name: "USE_EXPAND Flags"}},
+			Breadcrumbs:    []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "USE_EXPAND Flags"}},
 			UseExpandDescs: data.UseExpandDescs,
 			Version:        version,
 			GenInfo:        genInfo,
@@ -2968,7 +2691,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 			if err := renderPage(filepath.Join(useExpandDir, "index.html"), tmpl, "use_expand.html", GenericPageContext{
 				Title:         "USE_EXPAND: " + prefix,
 				BaseURL:       "../../",
-				Breadcrumbs:   []Breadcrumb{{Name: title, URL: "../../"}, {Name: "USE_EXPAND Flags", URL: "../"}, {Name: prefix}},
+				Breadcrumbs:   []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "USE_EXPAND Flags", URL: "../"}, {Name: prefix}},
 				UseExpandDesc: desc,
 				Version:       version,
 				GenInfo:       genInfo,
@@ -2980,7 +2703,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 	if err := renderPage(filepath.Join(outDir, "licenses", "index.html"), tmpl, "licenses.html", GenericPageContext{
 		Title:       "Licenses",
 		BaseURL:     "../",
-		Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Licenses"}},
+		Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "Licenses"}},
 		Licenses:    data.Licenses,
 		Version:     version,
 		GenInfo:     genInfo,
@@ -3001,7 +2724,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		type TmplPkg struct {
 			Name      string
 			Category  string
-			ReposList []*SiteData
+			ReposList []*g2.SiteData
 		}
 		var tmplPkgs []TmplPkg
 		for _, p := range lic.Packages {
@@ -3011,7 +2734,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		if err := renderPage(filepath.Join(licDir, "index.html"), tmpl, "license.html", GenericPageContext{
 			Title:       "License: " + lic.Name,
 			BaseURL:     "../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "Licenses", URL: "../"}, {Name: lic.Name}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "Licenses", URL: "../"}, {Name: lic.Name}},
 			License:     map[string]interface{}{"Name": lic.Name, "Packages": tmplPkgs, "Text": lic.Text, "Aliases": lic.Aliases},
 			Version:     version,
 			GenInfo:     genInfo,
@@ -3028,7 +2751,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		if err := renderPage(filepath.Join(outDir, "projects", "index.html"), tmpl, "projects.html", GenericPageContext{
 			Title:       "Projects",
 			BaseURL:     "../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../"}, {Name: "Projects"}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "Projects"}},
 			Projects:    data.Projects,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -3049,7 +2772,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 			type TmplPkg struct {
 				Name      string
 				Category  string
-				ReposList []*SiteData
+				ReposList []*g2.SiteData
 			}
 			var tmplPkgs []TmplPkg
 			for _, p := range proj.Packages {
@@ -3059,7 +2782,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 			if err := renderPage(filepath.Join(projDir, "index.html"), tmpl, "project.html", GenericPageContext{
 				Title:       "Project: " + proj.Project.Name,
 				BaseURL:     "../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "Projects", URL: "../"}, {Name: proj.Project.Name}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "Projects", URL: "../"}, {Name: proj.Project.Name}},
 				Project:     proj,
 				Packages:    tmplPkgs,
 				Version:     version,
@@ -3074,7 +2797,7 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 	return nil
 }
 
-func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData, data *AggregatedData, title, version, recentDurationStr string, genInfo GenerationInfo) error {
+func generateRepoPages(outDir string, tmpl *template.Template, sites []*g2.SiteData, data *g2.AggregatedData, title, version, recentDurationStr string, genInfo GenerationInfo) error {
 	// 6. Repo-Specific Pages
 
 	if err := os.MkdirAll(filepath.Join(outDir, "repos"), 0755); err != nil {
@@ -3087,7 +2810,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 	if err := renderPage(filepath.Join(outDir, "repos", "all", "index.html"), tmpl, "overlays.html", GenericPageContext{
 		Title:       "All Overlays",
 		BaseURL:     "../../",
-		Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "All Overlays"}},
+		Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "All Overlays"}},
 		Repos:       sites,
 		Version:     version,
 		GenInfo:     genInfo,
@@ -3104,7 +2827,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 		if err := renderPage(filepath.Join(groupDir, "index.html"), tmpl, "repo_group.html", GenericPageContext{
 			Title:       "Overlays: " + group.Quality + " - " + group.Status,
 			BaseURL:     "../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../"}, {Name: "Overlays: " + group.Quality + " - " + group.Status}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "Overlays: " + group.Quality + " - " + group.Status}},
 			Group:       group,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -3126,7 +2849,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "uses", "index.html"), tmpl, "uses.html", GenericPageContext{
 				Title:       site.RepoName + " - USE Flags",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "USE Flags"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "USE Flags"}},
 				UseFlags:    site.AggUseFlags,
 				Version:     version,
 				GenInfo:     genInfo,
@@ -3144,7 +2867,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 				if err := renderPage(filepath.Join(useDir, "index.html"), tmpl, "use.html", GenericPageContext{
 					Title:       "USE Flag: " + f.Name,
 					BaseURL:     "../../../../",
-					Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "USE Flags", URL: "../"}, {Name: f.Name}},
+					Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "USE Flags", URL: "../"}, {Name: f.Name}},
 					UseFlag:     f,
 					Version:     version,
 					GenInfo:     genInfo,
@@ -3161,7 +2884,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "uses_expand", "index.html"), tmpl, "repo_use_expands.html", GenericPageContext{
 				Title:       site.RepoName + " - USE_EXPAND Flags",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "USE_EXPAND Flags"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "USE_EXPAND Flags"}},
 				Repo:        site,
 				Version:     version,
 				GenInfo:     genInfo,
@@ -3176,7 +2899,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 				if err := renderPage(filepath.Join(useExpandDir, "index.html"), tmpl, "repo_use_expand.html", GenericPageContext{
 					Title:         site.RepoName + " - USE_EXPAND: " + prefix,
 					BaseURL:       "../../../../",
-					Breadcrumbs:   []Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "USE_EXPAND Flags", URL: "../"}, {Name: prefix}},
+					Breadcrumbs:   []g2.Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "USE_EXPAND Flags", URL: "../"}, {Name: prefix}},
 					Repo:          site,
 					UseExpandDesc: desc,
 					Version:       version,
@@ -3193,7 +2916,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "deprecated", "index.html"), tmpl, "repo_deprecated.html", GenericPageContext{
 				Title:       site.RepoName + " - Deprecated",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Deprecated Packages"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Deprecated Packages"}},
 				Repo:        site,
 			}); err != nil {
 				return fmt.Errorf("rendering page: %w", err)
@@ -3207,7 +2930,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "masked", "index.html"), tmpl, "repo_masked.html", GenericPageContext{
 				Title:       site.RepoName + " - Masked",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Masked Packages"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Masked Packages"}},
 				Repo:        site,
 			}); err != nil {
 				return fmt.Errorf("rendering page: %w", err)
@@ -3221,7 +2944,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "info_vars", "index.html"), tmpl, "repo_info_vars.html", GenericPageContext{
 				Title:       site.RepoName + " - Info Vars",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Info Vars"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Info Vars"}},
 				Repo:        site,
 			}); err != nil {
 				return fmt.Errorf("rendering page: %w", err)
@@ -3234,7 +2957,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "info_pkgs", "index.html"), tmpl, "repo_info_pkgs.html", GenericPageContext{
 				Title:       site.RepoName + " - Info Packages",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Info Packages"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Info Packages"}},
 				Repo:        site,
 			}); err != nil {
 				return fmt.Errorf("rendering page: %w", err)
@@ -3281,7 +3004,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(pkgDir, "index.html"), tmpl, "moved_package.html", GenericPageContext{
 				Title:       fmt.Sprintf("%s - %s/%s (Moved)", site.RepoName, oldCat, oldName),
 				BaseURL:     "../../../../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../../../"}, {Name: site.RepoName, URL: "../../../../"}, {Name: "Categories", URL: "../../../"}, {Name: oldCat, URL: "../../"}, {Name: oldName}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../../../"}, {Name: site.RepoName, URL: "../../../../"}, {Name: "Categories", URL: "../../../"}, {Name: oldCat, URL: "../../"}, {Name: oldName}},
 				Repo:        site,
 				OldName:     oldCat + "/" + oldName,
 				NewName:     move.New,
@@ -3311,7 +3034,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 		if err := renderPage(filepath.Join(repoDir, "index.html"), tmpl, "repo_index.html", GenericPageContext{
 			Title:                 site.RepoName,
 			BaseURL:               "../../",
-			Breadcrumbs:           []Breadcrumb{{Name: title, URL: "../../"}, {Name: "Overlays", URL: "../../overlays/"}, {Name: site.RepoName}},
+			Breadcrumbs:           []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "Overlays", URL: "../../overlays/"}, {Name: site.RepoName}},
 			Repo:                  site,
 			PackageCount:          site.PackageCount,
 			Version:               version,
@@ -3332,7 +3055,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 		if err := renderPage(filepath.Join(repoDir, "stats", "index.html"), tmpl, "repo_stats.html", GenericPageContext{
 			Title:       site.RepoName + " - Statistics",
 			BaseURL:     "../../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Overlays", URL: "../../../overlays/"}, {Name: site.RepoName, URL: "../"}, {Name: "Statistics"}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Overlays", URL: "../../../overlays/"}, {Name: site.RepoName, URL: "../"}, {Name: "Statistics"}},
 			Repo:        site,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -3347,7 +3070,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "profiles", "index.html"), tmpl, "repo_profiles.html", GenericPageContext{
 				Title:       site.RepoName + " - Profiles",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Profiles"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Profiles"}},
 				Repo:        site,
 				Version:     version,
 				GenInfo:     genInfo,
@@ -3366,7 +3089,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 				if err := renderPage(filepath.Join(profDir, "index.html"), tmpl, "repo_profile.html", GenericPageContext{
 					Title:       site.RepoName + " - Profile: " + p.Path,
 					BaseURL:     relToRoot,
-					Breadcrumbs: []Breadcrumb{{Name: title, URL: relToRoot}, {Name: site.RepoName, URL: relToRoot + "repos/" + site.RepoName + "/"}, {Name: "Profiles", URL: relToRoot + "repos/" + site.RepoName + "/profiles/"}, {Name: p.Path}},
+					Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: relToRoot}, {Name: site.RepoName, URL: relToRoot + "repos/" + site.RepoName + "/"}, {Name: "Profiles", URL: relToRoot + "repos/" + site.RepoName + "/profiles/"}, {Name: p.Path}},
 					RepoName:    site.RepoName,
 					ProfilePath: p.Path,
 					Profile:     p,
@@ -3380,7 +3103,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 					if err := renderPage(filepath.Join(profDir, fName+".html"), tmpl, "repo_profile_file.html", GenericPageContext{
 						Title:       site.RepoName + " - Profile File: " + fName,
 						BaseURL:     relToRoot,
-						Breadcrumbs: []Breadcrumb{{Name: title, URL: relToRoot}, {Name: site.RepoName, URL: relToRoot + "repos/" + site.RepoName + "/"}, {Name: "Profiles", URL: relToRoot + "repos/" + site.RepoName + "/profiles/"}, {Name: p.Path, URL: "index.html"}, {Name: fName}},
+						Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: relToRoot}, {Name: site.RepoName, URL: relToRoot + "repos/" + site.RepoName + "/"}, {Name: "Profiles", URL: relToRoot + "repos/" + site.RepoName + "/profiles/"}, {Name: p.Path, URL: "index.html"}, {Name: fName}},
 						RepoName:    site.RepoName,
 						ProfilePath: p.Path,
 						Profile:     p,
@@ -3403,7 +3126,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "news", "index.html"), tmpl, "news_dashboard.html", GenericPageContext{
 				Title:       site.RepoName + " - News Dashboard",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Overlays", URL: "../../../overlays/"}, {Name: site.RepoName, URL: "../"}, {Name: "News"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Overlays", URL: "../../../overlays/"}, {Name: site.RepoName, URL: "../"}, {Name: "News"}},
 				RecentNews:  repoRecentNews,
 				Version:     version,
 				GenInfo:     genInfo,
@@ -3418,7 +3141,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "news", "archive", "index.html"), tmpl, "news_archive.html", GenericPageContext{
 				Title:       site.RepoName + " - News Archive",
 				BaseURL:     "../../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../"}, {Name: "Overlays", URL: "../../../../overlays/"}, {Name: site.RepoName, URL: "../../"}, {Name: "News", URL: "../"}, {Name: "Archive"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../"}, {Name: "Overlays", URL: "../../../../overlays/"}, {Name: site.RepoName, URL: "../../"}, {Name: "News", URL: "../"}, {Name: "Archive"}},
 				News:        site.News,
 				Version:     version,
 				GenInfo:     genInfo,
@@ -3435,7 +3158,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 				if err := renderPage(filepath.Join(newsDir, "index.html"), tmpl, "news_article.html", GenericPageContext{
 					Title:       n.Title,
 					BaseURL:     "../../../../../",
-					Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../../"}, {Name: "Overlays", URL: "../../../../../overlays/"}, {Name: site.RepoName, URL: "../../../"}, {Name: "News", URL: "../../"}, {Name: "Archive", URL: "../"}, {Name: n.Title}},
+					Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../../"}, {Name: "Overlays", URL: "../../../../../overlays/"}, {Name: site.RepoName, URL: "../../../"}, {Name: "News", URL: "../../"}, {Name: "Archive", URL: "../"}, {Name: n.Title}},
 					NewsItem:    n,
 					Version:     version,
 					GenInfo:     genInfo,
@@ -3451,7 +3174,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 		if err := renderPage(filepath.Join(repoDir, "categories", "index.html"), tmpl, "categories.html", GenericPageContext{
 			Title:       site.RepoName + " - Categories",
 			BaseURL:     "../../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Categories"}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Categories"}},
 			Categories:  site.Categories,
 			Version:     version,
 			GenInfo:     genInfo,
@@ -3466,7 +3189,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "authors", "index.html"), tmpl, "authors.html", GenericPageContext{
 				Title:       site.RepoName + " - Authors",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Authors"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Authors"}},
 				Authors:     site.Authors,
 				Repo:        site,
 				Version:     version,
@@ -3487,7 +3210,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 
 			type TmplPkg struct {
 				Name                  string
-				ReposList             []*SiteData
+				ReposList             []*g2.SiteData
 				EbuildCount           int
 				HighestStableVersion  template.HTML
 				HighestTestingVersion template.HTML
@@ -3498,13 +3221,13 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			}
 			var tmplPkgs []TmplPkg
 			for _, p := range cat.Packages {
-				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
+				tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*g2.SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
 			}
 
 			if err := renderPage(filepath.Join(catDir, "index.html"), tmpl, "category.html", GenericPageContext{
 				Title:       "Category: " + cat.Name,
 				BaseURL:     "../../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "Categories", URL: "../"}, {Name: cat.Name}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "Categories", URL: "../"}, {Name: cat.Name}},
 				Category:    map[string]interface{}{"Name": cat.Name, "Packages": tmplPkgs},
 				Version:     version,
 				GenInfo:     genInfo,
@@ -3516,7 +3239,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 		if err := os.MkdirAll(filepath.Join(repoDir, "packages"), 0755); err != nil {
 			return fmt.Errorf("creating directory: %w", err)
 		}
-		var repoPkgs []PackageData
+		var repoPkgs []g2.PackageData
 		for _, c := range site.Categories {
 			repoPkgs = append(repoPkgs, c.Packages...)
 		}
@@ -3530,7 +3253,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 		if err := renderPage(filepath.Join(repoDir, "packages", "index.html"), tmpl, "repo_packages.html", GenericPageContext{
 			Title:       site.RepoName + " - Packages",
 			BaseURL:     "../../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Packages"}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Packages"}},
 			Packages:    repoPkgs,
 			Repo:        site,
 			Version:     version,
@@ -3539,7 +3262,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			return fmt.Errorf("rendering page: %w", err)
 		}
 
-		aggPackagesMap := make(map[string]*AggPackage)
+		aggPackagesMap := make(map[string]*g2.AggPackage)
 		for _, p := range data.Packages {
 			aggPackagesMap[p.Category+"/"+p.Name] = p
 		}
@@ -3552,7 +3275,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(repoDir, "eclasses", "index.html"), tmpl, "repo_eclasses.html", GenericPageContext{
 				Title:       site.RepoName + " - Eclasses",
 				BaseURL:     "../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Eclasses"}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Eclasses"}},
 				Eclasses:    site.AggEclasses,
 				Repo:        site,
 				Version:     version,
@@ -3574,7 +3297,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 				if err := renderPage(filepath.Join(ecDir, "index.html"), tmpl, "repo_eclass.html", GenericPageContext{
 					Title:       site.RepoName + " - Eclass: " + ec.Name,
 					BaseURL:     "../../../../",
-					Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "Eclasses", URL: "../"}, {Name: ec.Name}},
+					Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "Eclasses", URL: "../"}, {Name: ec.Name}},
 					Eclass:      ec,
 					Repo:        site,
 					Version:     version,
@@ -3591,7 +3314,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 		if err := renderPage(filepath.Join(repoDir, "uses", "index.html"), tmpl, "repo_uses.html", GenericPageContext{
 			Title:       site.RepoName + " - USE Flags",
 			BaseURL:     "../../../",
-			Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "USE Flags"}},
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "USE Flags"}},
 			UseFlags:    repoUseFlags,
 			Repo:        site,
 			Version:     version,
@@ -3610,7 +3333,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(useDir, "index.html"), tmpl, "repo_use.html", GenericPageContext{
 				Title:       site.RepoName + " - USE Flag: " + f.Name,
 				BaseURL:     "../../../../",
-				Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "USE Flags", URL: "../"}, {Name: f.Name}},
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "USE Flags", URL: "../"}, {Name: f.Name}},
 				UseFlag:     f,
 				Repo:        site,
 				Version:     version,
@@ -3641,7 +3364,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 			if err := renderPage(filepath.Join(pkgDir, "index.html"), tmpl, "repo_package.html", GenericPageContext{
 				Title:         fmt.Sprintf("%s - %s/%s", site.RepoName, pkg.Category, pkg.Name),
 				BaseURL:       "../../../../../../",
-				Breadcrumbs:   []Breadcrumb{{Name: title, URL: "../../../../../../"}, {Name: site.RepoName, URL: "../../../../"}, {Name: "Categories", URL: "../../../"}, {Name: pkg.Category, URL: "../../"}, {Name: pkg.Name}},
+				Breadcrumbs:   []g2.Breadcrumb{{Name: title, URL: "../../../../../../"}, {Name: site.RepoName, URL: "../../../../"}, {Name: "Categories", URL: "../../../"}, {Name: pkg.Category, URL: "../../"}, {Name: pkg.Name}},
 				Repo:          site,
 				Package:       pkg,
 				MovedToName:   movedToName,
@@ -3663,7 +3386,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 					if err := renderPage(filepath.Join(mdDir, "index.html"), tmpl, "repo_package_manifest.html", GenericPageContext{
 						Title:       fmt.Sprintf("%s - %s/%s - Manifest: %s", site.RepoName, pkg.Category, pkg.Name, md.Entry.Filename),
 						BaseURL:     "../../../../../../../../",
-						Breadcrumbs: []Breadcrumb{{Name: title, URL: "../../../../../../../../"}, {Name: site.RepoName, URL: "../../../../../../"}, {Name: "Categories", URL: "../../../../../"}, {Name: pkg.Category, URL: "../../../../"}, {Name: pkg.Name, URL: "../../"}, {Name: "Manifest"}, {Name: md.Entry.Filename}},
+						Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../../../../../"}, {Name: site.RepoName, URL: "../../../../../../"}, {Name: "Categories", URL: "../../../../../"}, {Name: pkg.Category, URL: "../../../../"}, {Name: pkg.Name, URL: "../../"}, {Name: "Manifest"}, {Name: md.Entry.Filename}},
 						Repo:        site,
 						Package:     pkg,
 						Manifest:    md,
@@ -3685,7 +3408,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 					return fmt.Errorf("creating directory %s: %w", ebuildDir, err)
 				}
 
-				var filteredManifest []ManifestEntryData
+				var filteredManifest []g2.ManifestEntryData
 				if pkg.Manifest != nil {
 					for _, md := range pkg.ManifestData {
 						for _, mv := range md.Versions {
@@ -3700,7 +3423,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 				if err := renderPage(filepath.Join(ebuildDir, "index.html"), tmpl, "ebuild_details.html", GenericPageContext{
 					Title:            fmt.Sprintf("%s - %s/%s-%s", site.RepoName, pkg.Category, pkg.Name, versionStr),
 					BaseURL:          "../../../../../../../../",
-					Breadcrumbs:      []Breadcrumb{{Name: title, URL: "../../../../../../../../"}, {Name: site.RepoName, URL: "../../../../../../"}, {Name: "Categories", URL: "../../../../../"}, {Name: pkg.Category, URL: "../../../../"}, {Name: "Packages", URL: "../../../"}, {Name: pkg.Name, URL: "../../"}, {Name: "Ebuild", URL: "../"}, {Name: versionStr}},
+					Breadcrumbs:      []g2.Breadcrumb{{Name: title, URL: "../../../../../../../../"}, {Name: site.RepoName, URL: "../../../../../../"}, {Name: "Categories", URL: "../../../../../"}, {Name: pkg.Category, URL: "../../../../"}, {Name: "Packages", URL: "../../../"}, {Name: pkg.Name, URL: "../../"}, {Name: "Ebuild", URL: "../"}, {Name: versionStr}},
 					Repo:             site,
 					Package:          pkg,
 					VersionData:      v,
@@ -3718,7 +3441,7 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*SiteData
 	return nil
 }
 
-func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration, recentDurationStr string, genInfo GenerationInfo) error {
+func generateSite(outDir string, sites []*g2.SiteData, recentDuration time.Duration, recentDurationStr string, genInfo GenerationInfo) error {
 	log.Printf("Starting site generation (v%s) with %d repos to %s", version, len(sites), outDir)
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		return err
@@ -3739,14 +3462,14 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 	}
 
 	for _, site := range sites {
-		aggPackagesMap := make(map[string]*AggPackage)
+		aggPackagesMap := make(map[string]*g2.AggPackage)
 		for _, cat := range site.Categories {
 			for _, pkg := range cat.Packages {
 				pkgKey := cat.Name + "/" + pkg.Name
-				aggPackagesMap[pkgKey] = &AggPackage{
+				aggPackagesMap[pkgKey] = &g2.AggPackage{
 					Name:                pkg.Name,
 					Category:            cat.Name,
-					Repos:               map[string]*SiteData{site.RepoName: site},
+					Repos:               map[string]*g2.SiteData{site.RepoName: site},
 					DominantDescription: pkg.DominantDescription,
 					DominantHomepage:    pkg.DominantHomepage,
 					DominantLicense:     pkg.DominantLicense,
@@ -3878,7 +3601,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	}
 	defer cleanup()
 
-	var allSites []*SiteData
+	var allSites []*g2.SiteData
 	var allSitesMu sync.Mutex
 
 	g, _ := errgroup.WithContext(context.Background())
@@ -3943,7 +3666,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			repoCopy := repo
 
 			t1 := time.Now()
-			siteData, err := parseRepo(os.DirFS(repoPath), ".", repo.Name, fastGit, &repoCopy, SourceURL(gitUrl))
+			siteData, err := parseRepo(os.DirFS(repoPath), ".", repo.Name, fastGit, &repoCopy, g2.SourceURL(gitUrl))
 			if err != nil {
 				log.Printf("Failed to parse repo %s: %v", repo.Name, err)
 				return nil
@@ -3986,8 +3709,8 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	return nil
 }
 
-func mapToList(m map[string]*SiteData) []*SiteData {
-	var l []*SiteData
+func mapToList(m map[string]*g2.SiteData) []*g2.SiteData {
+	var l []*g2.SiteData
 	for _, v := range m {
 		l = append(l, v)
 	}

--- a/cmd/g2/site_extra_test.go
+++ b/cmd/g2/site_extra_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 func TestResolveDependencies(t *testing.T) {
-	site := &SiteData{
-		Categories: []CategoryData{
+	site := &g2.SiteData{
+		Categories: []g2.CategoryData{
 			{
 				Name: "app-misc",
-				Packages: []PackageData{
+				Packages: []g2.PackageData{
 					{
 						Category: "app-misc",
 						Name:     "bar",

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/arran4/g2"
+
 	"bytes"
 	"context"
 	"flag"
@@ -46,7 +48,7 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 	}
 
 	// Determine if location is a single overlay or we need to fall back to /var/db/repos
-	var sites []*SiteData
+	var sites []*g2.SiteData
 
 	if isOverlayDir(location) {
 		log.Printf("Parsing local overlay at %s", location)
@@ -142,20 +144,20 @@ type SiteServer struct {
 	GenInfo       GenerationInfo
 	tmpl          *template.Template
 	Title         string
-	Sites         []*SiteData
-	AggCategories []*AggCategory
-	AggPackages   []*AggPackage
-	AggLicenses   []*AggLicense
-	AggProjects   []*AggProject
+	Sites         []*g2.SiteData
+	AggCategories []*g2.AggCategory
+	AggPackages   []*g2.AggPackage
+	AggLicenses   []*g2.AggLicense
+	AggProjects   []*g2.AggProject
 
 	// Mappings for faster lookup
-	CatMap      map[string]*AggCategory
-	PkgMap      map[string]*AggPackage
-	LicMap      map[string]*AggLicense
-	UseMap      map[string]*AggUseFlag
-	AggUseFlags []*AggUseFlag
-	ProjMap     map[string]*AggProject
-	RepoMap     map[string]*SiteData
+	CatMap      map[string]*g2.AggCategory
+	PkgMap      map[string]*g2.AggPackage
+	LicMap      map[string]*g2.AggLicense
+	UseMap      map[string]*g2.AggUseFlag
+	AggUseFlags []*g2.AggUseFlag
+	ProjMap     map[string]*g2.AggProject
+	RepoMap     map[string]*g2.SiteData
 }
 
 type ParsedIUSEFlag struct {
@@ -188,7 +190,7 @@ func parseIUSEFlagsFunc(iuse string) []ParsedIUSEFlag {
 	return flags
 }
 
-func newSiteServer(sites []*SiteData, genInfo GenerationInfo) (*SiteServer, error) {
+func newSiteServer(sites []*g2.SiteData, genInfo GenerationInfo) (*SiteServer, error) {
 	for _, site := range sites {
 		populatePkgUseFlags(site)
 	}
@@ -201,38 +203,38 @@ func newSiteServer(sites []*SiteData, genInfo GenerationInfo) (*SiteServer, erro
 	server := &SiteServer{
 		tmpl:    tmpl,
 		Sites:   sites,
-		CatMap:  make(map[string]*AggCategory),
-		PkgMap:  make(map[string]*AggPackage),
-		LicMap:  make(map[string]*AggLicense),
-		ProjMap: make(map[string]*AggProject),
-		RepoMap: make(map[string]*SiteData),
+		CatMap:  make(map[string]*g2.AggCategory),
+		PkgMap:  make(map[string]*g2.AggPackage),
+		LicMap:  make(map[string]*g2.AggLicense),
+		ProjMap: make(map[string]*g2.AggProject),
+		RepoMap: make(map[string]*g2.SiteData),
 		GenInfo: genInfo,
 	}
 
 	// Similar aggregation logic to generateSite
-	aggCategories := make(map[string]*AggCategory)
-	aggPackages := make(map[string]*AggPackage)
-	aggLicenses := make(map[string]*AggLicense)
-	aggProjects := make(map[string]*AggProject)
+	aggCategories := make(map[string]*g2.AggCategory)
+	aggPackages := make(map[string]*g2.AggPackage)
+	aggLicenses := make(map[string]*g2.AggLicense)
+	aggProjects := make(map[string]*g2.AggProject)
 
 	for _, site := range sites {
 		if site.Projects != nil {
 			for i := range site.Projects.Projects {
 				proj := &site.Projects.Projects[i]
 				if _, ok := aggProjects[proj.Email]; !ok {
-					aggProjects[proj.Email] = &AggProject{Project: proj}
+					aggProjects[proj.Email] = &g2.AggProject{Project: proj}
 				}
 			}
 		}
 		server.RepoMap[site.RepoName] = site
 		for _, cat := range site.Categories {
 			if _, ok := aggCategories[cat.Name]; !ok {
-				aggCategories[cat.Name] = &AggCategory{Name: cat.Name, Packages: make(map[string]*AggPackage)}
+				aggCategories[cat.Name] = &g2.AggCategory{Name: cat.Name, Packages: make(map[string]*g2.AggPackage)}
 			}
 			for _, pkg := range cat.Packages {
 				pkgKey := cat.Name + "/" + pkg.Name
 				if _, ok := aggPackages[pkgKey]; !ok {
-					aggPackages[pkgKey] = &AggPackage{Name: pkg.Name, Category: cat.Name, Repos: make(map[string]*SiteData)}
+					aggPackages[pkgKey] = &g2.AggPackage{Name: pkg.Name, Category: cat.Name, Repos: make(map[string]*g2.SiteData)}
 				}
 				aggPackages[pkgKey].Repos[site.RepoName] = site
 				if aggPackages[pkgKey].DominantDescription == "" {
@@ -272,7 +274,7 @@ func newSiteServer(sites []*SiteData, genInfo GenerationInfo) (*SiteServer, erro
 								continue
 							}
 							if _, ok := aggLicenses[lic]; !ok {
-								aggLicenses[lic] = &AggLicense{Name: lic}
+								aggLicenses[lic] = &g2.AggLicense{Name: lic}
 							}
 
 							found := false
@@ -410,7 +412,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "overlays.html", map[string]interface{}{
 				"Title":       "Overlays",
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Overlays"}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Overlays"}},
 				"Repos":       s.Sites,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -423,7 +425,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "categories.html", map[string]interface{}{
 				"Title":       "Categories",
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Categories"}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Categories"}},
 				"Categories":  s.AggCategories,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -437,7 +439,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			var catPkgs []*AggPackage
+			var catPkgs []*g2.AggPackage
 			for _, p := range cat.Packages {
 				catPkgs = append(catPkgs, p)
 			}
@@ -445,7 +447,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			type TmplPkg struct {
 				Name                  string
-				ReposList             []*SiteData
+				ReposList             []*g2.SiteData
 				EbuildCount           int
 				HighestStableVersion  template.HTML
 				HighestTestingVersion template.HTML
@@ -456,7 +458,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			var tmplPkgs []TmplPkg
 			for _, p := range catPkgs {
-				var allVersions []VersionData
+				var allVersions []g2.VersionData
 				for _, r := range p.Repos {
 					for _, c := range r.Categories {
 						if c.Name == catName {
@@ -475,7 +477,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "category.html", map[string]interface{}{
 				"Title":       "Category: " + cat.Name,
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Categories", URL: "../"}, {Name: cat.Name}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Categories", URL: "../"}, {Name: cat.Name}},
 				"Category":    map[string]interface{}{"Name": cat.Name, "Packages": tmplPkgs},
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -488,7 +490,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "packages.html", map[string]interface{}{
 				"Title":       "Packages",
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Packages"}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Packages"}},
 				"Packages":    s.AggPackages,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -515,7 +517,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				s.renderPageHTTP(w, "package_picker.html", map[string]interface{}{
 					"Title":       "Package: " + pkg.Category + "/" + pkg.Name,
 					"BaseURL":     baseURL,
-					"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Packages", URL: "../../"}, {Name: pkg.Category, URL: "../../../categories/" + pkg.Category + "/"}, {Name: pkg.Name}},
+					"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Packages", URL: "../../"}, {Name: pkg.Category, URL: "../../../categories/" + pkg.Category + "/"}, {Name: pkg.Name}},
 					"Package":     map[string]interface{}{"Category": pkg.Category, "Name": pkg.Name, "ReposList": reposList},
 					"Version":     version,
 					"GenInfo":     s.GenInfo,
@@ -529,7 +531,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "uses.html", map[string]interface{}{
 				"Title":       "USE Flags",
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "USE Flags"}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "USE Flags"}},
 				"UseFlags":    s.AggUseFlags,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -545,7 +547,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "use.html", map[string]interface{}{
 				"Title":       "USE Flag: " + flag.Name,
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "USE Flags", URL: "../"}, {Name: flag.Name}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "USE Flags", URL: "../"}, {Name: flag.Name}},
 				"UseFlag":     flag,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -558,7 +560,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "licenses.html", map[string]interface{}{
 				"Title":       "Licenses",
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Licenses"}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Licenses"}},
 				"Licenses":    s.AggLicenses,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -566,7 +568,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		} else if len(parts) == 2 {
 			licNameSlug := parts[1]
-			var lic *AggLicense
+			var lic *g2.AggLicense
 			for _, l := range s.AggLicenses {
 				if sanitizeFilename(l.Name) == licNameSlug {
 					lic = l
@@ -581,7 +583,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			type TmplPkg struct {
 				Name      string
 				Category  string
-				ReposList []*SiteData
+				ReposList []*g2.SiteData
 			}
 			var tmplPkgs []TmplPkg
 			for _, p := range lic.Packages {
@@ -591,7 +593,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "license.html", map[string]interface{}{
 				"Title":       "License: " + lic.Name,
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Licenses", URL: "../"}, {Name: lic.Name}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Licenses", URL: "../"}, {Name: lic.Name}},
 				"License":     map[string]interface{}{"Name": lic.Name, "Packages": tmplPkgs, "Text": lic.Text, "Aliases": lic.Aliases},
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -604,7 +606,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "projects.html", map[string]interface{}{
 				"Title":       "Projects",
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Projects"}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Projects"}},
 				"Projects":    s.AggProjects,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
@@ -621,7 +623,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			type TmplPkg struct {
 				Name      string
 				Category  string
-				ReposList []*SiteData
+				ReposList []*g2.SiteData
 			}
 			var tmplPkgs []TmplPkg
 			for _, p := range proj.Packages {
@@ -631,7 +633,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "project.html", map[string]interface{}{
 				"Title":       "Project: " + proj.Project.Name,
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Projects", URL: "../"}, {Name: proj.Project.Name}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Projects", URL: "../"}, {Name: proj.Project.Name}},
 				"Project":     proj,
 				"Packages":    tmplPkgs,
 				"Version":     version,
@@ -645,7 +647,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "stats.html", map[string]interface{}{
 				"Title":       "Generation Statistics",
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Statistics"}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Statistics"}},
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
 			})
@@ -657,7 +659,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.renderPageHTTP(w, "help.html", map[string]interface{}{
 				"Title":       "Help & Legend",
 				"BaseURL":     baseURL,
-				"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Help"}},
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Help"}},
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
 			})
@@ -682,7 +684,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				s.renderPageHTTP(w, "repo_index.html", map[string]interface{}{
 					"Title":                 site.RepoName,
 					"BaseURL":               baseURL,
-					"Breadcrumbs":           []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Overlays", URL: baseURL + "overlays/"}, {Name: site.RepoName}},
+					"Breadcrumbs":           []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Overlays", URL: baseURL + "overlays/"}, {Name: site.RepoName}},
 					"Repo":                  site,
 					"PackageCount":          site.PackageCount,
 					"Version":               version,
@@ -702,7 +704,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "repo_stats.html", map[string]interface{}{
 							"Title":       site.RepoName + " - Statistics",
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Statistics"}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Statistics"}},
 							"Repo":        site,
 							"Version":     version,
 							"GenInfo":     s.GenInfo,
@@ -714,7 +716,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "repo_masked.html", map[string]interface{}{
 							"Title":       site.RepoName + " - Masked",
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Masked Packages"}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Masked Packages"}},
 							"Repo":        site,
 							"Version":     version,
 							"GenInfo":     s.GenInfo,
@@ -726,7 +728,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "repo_deprecated.html", map[string]interface{}{
 							"Title":       site.RepoName + " - Deprecated",
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Deprecated Packages"}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Deprecated Packages"}},
 							"Repo":        site,
 							"Version":     version,
 							"GenInfo":     s.GenInfo,
@@ -738,7 +740,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "repo_info_pkgs.html", map[string]interface{}{
 							"Title":       site.RepoName + " - Info Packages",
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Info Packages"}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Info Packages"}},
 							"Repo":        site,
 							"Version":     version,
 							"GenInfo":     s.GenInfo,
@@ -750,7 +752,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "categories.html", map[string]interface{}{
 							"Title":       site.RepoName + " - Categories",
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Categories"}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Categories"}},
 							"Categories":  site.Categories,
 							"Version":     version,
 							"GenInfo":     s.GenInfo,
@@ -758,7 +760,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					} else if len(parts) == 4 {
 						catName := parts[3]
-						var catData *CategoryData
+						var catData *g2.CategoryData
 						for _, c := range site.Categories {
 							if c.Name == catName {
 								catData = &c
@@ -772,7 +774,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 						type TmplPkg struct {
 							Name                  string
-							ReposList             []*SiteData
+							ReposList             []*g2.SiteData
 							EbuildCount           int
 							HighestStableVersion  template.HTML
 							HighestTestingVersion template.HTML
@@ -783,13 +785,13 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 						var tmplPkgs []TmplPkg
 						for _, p := range catData.Packages {
-							tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
+							tmplPkgs = append(tmplPkgs, TmplPkg{Name: p.Name, ReposList: []*g2.SiteData{site}, EbuildCount: p.EbuildCount, HighestStableVersion: p.HighestStableVersion, HighestTestingVersion: p.HighestTestingVersion, DominantDescription: p.DominantDescription, DominantHomepage: p.DominantHomepage, DominantLicense: p.DominantLicense, ReverseVirtuals: p.ReverseVirtuals})
 						}
 
 						s.renderPageHTTP(w, "category.html", map[string]interface{}{
 							"Title":       "Category: " + catData.Name,
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../../"}, {Name: "Categories", URL: "../"}, {Name: catData.Name}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../../"}, {Name: "Categories", URL: "../"}, {Name: catData.Name}},
 							"Category":    map[string]interface{}{"Name": catData.Name, "Packages": tmplPkgs},
 							"Version":     version,
 							"GenInfo":     s.GenInfo,
@@ -799,7 +801,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						catName := parts[3]
 						pkgName := parts[5]
 
-						var pkgData *PackageData
+						var pkgData *g2.PackageData
 						for _, c := range site.Categories {
 							if c.Name == catName {
 								for _, p := range c.Packages {
@@ -824,7 +826,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							s.renderPageHTTP(w, "repo_package.html", map[string]interface{}{
 								"Title":   fmt.Sprintf("%s - %s/%s", site.RepoName, pkgData.Category, pkgData.Name),
 								"BaseURL": baseURL,
-								"Breadcrumbs": []Breadcrumb{
+								"Breadcrumbs": []g2.Breadcrumb{
 									{Name: s.Title, URL: baseURL},
 									{Name: site.RepoName, URL: "../../../../"},
 									{Name: "Categories", URL: "../../../"},
@@ -841,7 +843,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						} else if len(parts) == 8 && parts[6] == "ebuild" {
 							versionName := strings.TrimSuffix(parts[7], ".html")
 
-							var versionData *VersionData
+							var versionData *g2.VersionData
 							for _, v := range pkgData.Versions {
 								if v.Version == versionName || (v.Ebuild != nil && v.Ebuild.Vars != nil && v.Ebuild.Vars["PV"] == versionName) {
 									versionData = &v
@@ -853,7 +855,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
-							var filteredManifest []ManifestEntryData
+							var filteredManifest []g2.ManifestEntryData
 							for _, md := range pkgData.ManifestData {
 								for _, v := range md.Versions {
 									if v == versionData.Version || (versionData.Ebuild != nil && versionData.Ebuild.Vars != nil && v == versionData.Ebuild.Vars["PV"]) {
@@ -866,7 +868,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							s.renderPageHTTP(w, "ebuild_details.html", map[string]interface{}{
 								"Title":   fmt.Sprintf("%s - %s/%s-%s", site.RepoName, pkgData.Category, pkgData.Name, versionName),
 								"BaseURL": baseURL,
-								"Breadcrumbs": []Breadcrumb{
+								"Breadcrumbs": []g2.Breadcrumb{
 									{Name: s.Title, URL: baseURL},
 									{Name: site.RepoName, URL: "../../../../../../"},
 									{Name: "Categories", URL: "../../../../../"},
@@ -888,7 +890,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						} else if len(parts) == 8 && parts[6] == "manifest" {
 							manifestName := strings.TrimSuffix(parts[7], ".html")
 
-							var targetMD *ManifestEntryData
+							var targetMD *g2.ManifestEntryData
 							for _, md := range pkgData.ManifestData {
 								if md.Entry.Filename == manifestName {
 									targetMD = &md
@@ -903,7 +905,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							s.renderPageHTTP(w, "repo_package_manifest.html", map[string]interface{}{
 								"Title":   fmt.Sprintf("%s - %s/%s-Manifest-%s", site.RepoName, pkgData.Category, pkgData.Name, manifestName),
 								"BaseURL": baseURL,
-								"Breadcrumbs": []Breadcrumb{
+								"Breadcrumbs": []g2.Breadcrumb{
 									{Name: s.Title, URL: baseURL},
 									{Name: site.RepoName, URL: "../../../../../../"},
 									{Name: "Categories", URL: "../../../../../"},
@@ -926,7 +928,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 				case "packages":
 					if len(parts) == 3 {
-						var repoPkgs []PackageData
+						var repoPkgs []g2.PackageData
 						for _, c := range site.Categories {
 							repoPkgs = append(repoPkgs, c.Packages...)
 						}
@@ -940,7 +942,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "repo_packages.html", map[string]interface{}{
 							"Title":       site.RepoName + " - Packages",
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Packages"}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Packages"}},
 							"Packages":    repoPkgs,
 							"Repo":        site,
 							"Version":     version,
@@ -954,7 +956,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "repo_profiles.html", map[string]interface{}{
 							"Title":       site.RepoName + " - Profiles",
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Profiles"}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Profiles"}},
 							"Repo":        site,
 							"Version":     version,
 							"GenInfo":     s.GenInfo,
@@ -987,7 +989,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							profilePath = remaining
 						}
 
-						var targetProfile *ProfileData
+						var targetProfile *g2.ProfileData
 						for _, p := range site.Profiles {
 							if p.Path == profilePath {
 								targetProfile = &p
@@ -1010,7 +1012,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							s.renderPageHTTP(w, "repo_profile_file.html", map[string]interface{}{
 								"Title":       site.RepoName + " - Profile File: " + requestedFile,
 								"BaseURL":     baseURL,
-								"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: baseURL + "repos/" + site.RepoName + "/"}, {Name: "Profiles", URL: baseURL + "repos/" + site.RepoName + "/profiles/"}, {Name: targetProfile.Path, URL: "index.html"}, {Name: requestedFile}},
+								"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: baseURL + "repos/" + site.RepoName + "/"}, {Name: "Profiles", URL: baseURL + "repos/" + site.RepoName + "/profiles/"}, {Name: targetProfile.Path, URL: "index.html"}, {Name: requestedFile}},
 								"RepoName":    site.RepoName,
 								"ProfilePath": targetProfile.Path,
 								"Profile":     targetProfile,
@@ -1024,7 +1026,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							s.renderPageHTTP(w, "repo_profile.html", map[string]interface{}{
 								"Title":       site.RepoName + " - Profile: " + targetProfile.Path,
 								"BaseURL":     baseURL,
-								"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: baseURL + "repos/" + site.RepoName + "/"}, {Name: "Profiles", URL: baseURL + "repos/" + site.RepoName + "/profiles/"}, {Name: targetProfile.Path}},
+								"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: baseURL + "repos/" + site.RepoName + "/"}, {Name: "Profiles", URL: baseURL + "repos/" + site.RepoName + "/profiles/"}, {Name: targetProfile.Path}},
 								"RepoName":    site.RepoName,
 								"ProfilePath": targetProfile.Path,
 								"Profile":     targetProfile,
@@ -1042,7 +1044,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "repo_uses.html", map[string]interface{}{
 							"Title":       site.RepoName + " - USE Flags",
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "USE Flags"}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "USE Flags"}},
 							"UseFlags":    repoUseFlags,
 							"Repo":        site,
 							"Version":     version,
@@ -1051,7 +1053,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					} else if len(parts) == 4 {
 						flagName := parts[3]
-						var flag *AggUseFlag
+						var flag *g2.AggUseFlag
 						for _, f := range repoUseFlags {
 							if f.Name == flagName {
 								flag = f
@@ -1066,7 +1068,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						s.renderPageHTTP(w, "repo_use.html", map[string]interface{}{
 							"Title":       site.RepoName + " - USE Flag: " + flag.Name,
 							"BaseURL":     baseURL,
-							"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../../"}, {Name: "USE Flags", URL: "../"}, {Name: flag.Name}},
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../../"}, {Name: "USE Flags", URL: "../"}, {Name: flag.Name}},
 							"UseFlag":     flag,
 							"Repo":        site,
 							"Version":     version,

--- a/cmd/g2/site_serve_uses_test.go
+++ b/cmd/g2/site_serve_uses_test.go
@@ -51,16 +51,16 @@ func TestParseIUSEFlagsFunc(t *testing.T) {
 }
 
 func TestGetRepoUseFlags(t *testing.T) {
-	site := &SiteData{
+	site := &g2.SiteData{
 		RepoName: "test-repo",
-		Categories: []CategoryData{
+		Categories: []g2.CategoryData{
 			{
 				Name: "app-misc",
-				Packages: []PackageData{
+				Packages: []g2.PackageData{
 					{
 						Category: "app-misc",
 						Name:     "foo",
-						Versions: []VersionData{
+						Versions: []g2.VersionData{
 							{
 								Version: "1.0",
 								Ebuild: &g2.Ebuild{
@@ -76,7 +76,7 @@ func TestGetRepoUseFlags(t *testing.T) {
 		},
 	}
 
-	aggPackages := map[string]*AggPackage{
+	aggPackages := map[string]*g2.AggPackage{
 		"app-misc/foo": {
 			Name: "foo",
 			Category: "app-misc",

--- a/cmd/g2/site_test.go
+++ b/cmd/g2/site_test.go
@@ -20,7 +20,7 @@ func TestBuildManifestData(t *testing.T) {
 		},
 	}
 
-	versions := []VersionData{
+	versions := []g2.VersionData{
 		{
 			Version: "1.0",
 			Ebuild: &g2.Ebuild{
@@ -57,7 +57,7 @@ func TestBuildManifestData(t *testing.T) {
 
 	got := buildManifestData(manifest, versions, nil)
 
-	expected := []ManifestEntryData{
+	expected := []g2.ManifestEntryData{
 		{
 			Entry:    manifest.Entries[0],
 			Versions: []string{"1.0"},
@@ -105,7 +105,7 @@ func TestGenerateSite(t *testing.T) {
 
 	outDir := t.TempDir()
 
-	err = generateSite(outDir, []*SiteData{siteData}, 90*24*time.Hour, "3 months", GenerationInfo{})
+	err = generateSite(outDir, []*g2.SiteData{siteData}, 90*24*time.Hour, "3 months", GenerationInfo{})
 	if err != nil {
 		t.Fatalf("generateSite failed: %v", err)
 	}
@@ -117,13 +117,13 @@ func TestGenerateSite_TemplateError(t *testing.T) {
 	// that will cause MkdirAll to fail, or just pass a package with a malformed template format.
 	// We will supply a category with a malformed name to trigger a file path error or a bad move.
 
-	siteData := &SiteData{
+	siteData := &g2.SiteData{
 		Title:    "Bad Template Site",
 		RepoName: "bad-repo",
-		Categories: []CategoryData{
+		Categories: []g2.CategoryData{
 			{
 				Name: "broken-category/\x00/invalid",
-				Packages: []PackageData{
+				Packages: []g2.PackageData{
 					{
 						Name:     "broken-package",
 						Category: "broken-category/\x00/invalid",
@@ -134,7 +134,7 @@ func TestGenerateSite_TemplateError(t *testing.T) {
 	}
 	outDir := t.TempDir()
 
-	err := generateSite(outDir, []*SiteData{siteData}, 90*24*time.Hour, "3 months", GenerationInfo{})
+	err := generateSite(outDir, []*g2.SiteData{siteData}, 90*24*time.Hour, "3 months", GenerationInfo{})
 
 	if err == nil {
 		t.Fatalf("generateSite unexpectedly succeeded with bad parameters, template/file errors are likely being swallowed")
@@ -143,8 +143,8 @@ func TestGenerateSite_TemplateError(t *testing.T) {
 }
 
 func TestDominantMetadataSelection(t *testing.T) {
-	pkgData := PackageData{
-		Versions: []VersionData{
+	pkgData := g2.PackageData{
+		Versions: []g2.VersionData{
 			{
 				Version: "1.0",
 				Ebuild: &g2.Ebuild{

--- a/cmd/g2/uses_serve_test.go
+++ b/cmd/g2/uses_serve_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/arran4/g2"
+
 	"os"
 	"testing"
 	"time"
@@ -14,7 +16,7 @@ func TestGenerateUsesPages(t *testing.T) {
 
 	outDir := t.TempDir()
 
-	err = generateSite(outDir, []*SiteData{siteData}, 90*24*time.Hour, "3 months", GenerationInfo{})
+	err = generateSite(outDir, []*g2.SiteData{siteData}, 90*24*time.Hour, "3 months", GenerationInfo{})
 	if err != nil {
 		t.Fatalf("generateSite failed: %v", err)
 	}

--- a/site.go
+++ b/site.go
@@ -1,11 +1,86 @@
 package g2
 
+import (
+	"encoding/xml"
+	"html/template"
+	"time"
+)
+
+type RemoteRepositories struct {
+	XMLName xml.Name     `xml:"repositories"`
+	Repos   []RemoteRepo `xml:"repo"`
+}
+
+type RemoteRepo struct {
+	Name    string       `xml:"name"`
+	Sources []RepoSource `xml:"source"`
+}
+
+type RepoSource struct {
+	Type string `xml:"type,attr"`
+	URL  string `xml:",chardata"`
+}
+
+type ProfileDescEntry struct {
+	Arch   string
+	Path   string
+	Status string
+}
+
+type SourceURL string
+
+type ProfileData struct {
+	Path     string
+	IsDesc   bool
+	DescArch string
+	DescStat string
+	Parents  []string
+	Children []string
+	Files    map[string]string // Maps filename to its content
+}
+
+type EclassData struct {
+	Name string
+}
+
 type SiteData struct {
-	Title          string
-	RepoName       string
-	RemoteURL      string
-	Categories     []CategoryData
-	LicenseMapping map[string][]string
+	Title             string
+	RepoName          string
+	RemoteURL         string
+	Repository        *Repository
+	EAPI              string
+	Projects          *Projects
+	Categories        []CategoryData
+	Profiles          []ProfileData
+	DefinedEclasses   []EclassData
+	AggEclasses       []*AggEclass
+	Authors           []Author
+	AuthorsURL        string
+	Moves             []PackageMove
+	SlotMoves         []PackageSlotMove
+	News              []NewsItem
+	LayoutConf        *LayoutConf
+	LicenseMapping    map[string][]string
+	QAPolicy          *QAPolicy
+	UseDesc           *UseDesc
+	UseLocalDesc      *UseLocalDesc
+	UseExpandDescs    map[string]*UseExpandDesc
+	ValidUseExpands   map[string]bool
+	ArchList          *ArchList
+	ArchesDesc        *ArchesDesc
+	InfoPkgs          []InfoPkg
+	Masked            []PackageMasked
+	Deprecated        []PackageDeprecated
+	ParsedEclasses    []*Ebuild
+	Eclasses          []*Ebuild
+	PackageCount      int
+	AggUseFlags       []*AggUseFlag
+	ThirdPartyMirrors map[string][]string
+	InfoVars          []string
+	GitSize           string
+	CheckoutTime      string
+	ProcessTime       string
+	SourceURL         string
 }
 
 type LicenseData struct {
@@ -30,23 +105,56 @@ type FileData struct {
 	RawURL string
 }
 
+type ManifestEntryData struct {
+	Entry        *ManifestEntry
+	Versions     []string
+	URLs         []string
+	ResolvedURLs []string
+}
+
 type PackageData struct {
-	Name          string
-	Category      string
-	Versions      []VersionData
-	Metadata      *PkgMetadata
-	MetadataError error
-	Manifest      *Manifest
-	Files         []FileData
+	Name                  string
+	Category              string
+	Versions              []VersionData
+	Metadata              *PkgMetadata
+	MetadataError         error
+	Manifest              *Manifest
+	ManifestData          []ManifestEntryData
+	Files                 []FileData
+	HighestStableVersion  template.HTML
+	HighestTestingVersion template.HTML
+	EbuildCount           int
+	DominantDescription   string
+	DominantHomepage      string
+	DominantLicense       string
 
 	// Git info
 	MetadataRawURL string
+	ModTime        time.Time
+
+	// Processed Uses (per package)
+	PkgUseFlags []PkgUseFlag
 
 	// Lint Info
 	LintWarnings []string
 
-	Masked *PackageMasked
+	// Deprecation
+	Masked     *PackageMasked
 	Deprecated *PackageDeprecated
+
+	// InfoPkg matching
+	IsInfoPkg bool
+
+	ReverseVirtuals []string
+	Equivalents     []string
+	VirtualDeps     []string
+}
+
+type PkgUseFlag struct {
+	Name     string
+	Desc     string
+	Source   string
+	Versions map[string]string // Version -> Unicode symbol representing state
 }
 
 type VersionData struct {
@@ -55,10 +163,114 @@ type VersionData struct {
 
 	// Git info
 	EbuildRawURL string
+	ModTime      time.Time
 
 	// Deprecation
 	Deprecated *PackageDeprecated
+	Masked     *PackageMasked
 
-	// Masked
-	Masked *PackageMasked
+	// Moves
+	MovedToSlot string
+
+	ResolvedDepsJSON string
+	// Mirrors
+	ApplicableMirrors map[string][]string
+}
+
+type AggCategory struct {
+	Name     string
+	Packages map[string]*AggPackage
+}
+type AggPackage struct {
+	Name                string
+	Category            string
+	Repos               map[string]*SiteData
+	DominantDescription string
+	DominantHomepage    string
+	DominantLicense     string
+	ReverseVirtuals     []string
+	VirtualDeps         []string
+}
+type AggProject struct {
+	Project  *Project
+	Packages []*AggPackage
+}
+
+type AggLicense struct {
+	Name     string
+	Count    int
+	Packages []*AggPackage
+	Text     string
+	Aliases  []string
+}
+
+type AggUseFlag struct {
+	Name          string
+	Count         int
+	GlobalDesc    string
+	LocalDescs    map[string]string
+	MetadataDescs map[string]string
+	Packages      []*AggPackage
+	Warnings      []string
+}
+
+type AggProfileRepo struct {
+	RepoName string
+	Profile  ProfileData
+}
+
+type AggProfile struct {
+	Path     string
+	IsDesc   bool
+	DescArch string
+	DescStat string
+	Repos    []AggProfileRepo
+	Files    map[string]string // Maps filename to its content
+}
+
+type AggEclass struct {
+	Name     string
+	Repos    map[string]*SiteData
+	Packages []*AggPackage
+}
+
+type AggPackageMove struct {
+	Old string
+	New string
+}
+
+type AggNewsItem struct {
+	NewsItem
+	RepoName string
+}
+
+type AggArch struct {
+	Name   string
+	Status string
+	Repos  []*SiteData
+}
+
+type RepoGroup struct {
+	Quality string
+	Status  string
+	Repos   []*SiteData
+}
+
+type AggregatedData struct {
+	Categories      []*AggCategory
+	Packages        []*AggPackage
+	Licenses        []*AggLicense
+	Projects        []*AggProject
+	Profiles        []*AggProfile
+	Arches          []*AggArch
+	Moves           map[string]*AggPackageMove
+	GlobalNews      []AggNewsItem
+	RecentNews      []AggNewsItem
+	TotalPackages   int
+	UseFlags        []*AggUseFlag
+	Eclasses        []*AggEclass
+	UseExpandDescs  map[string]*UseExpandDesc
+	ValidLicenses   map[string]bool
+	ValidUseExpands map[string]bool
+	GroupedRepos    []RepoGroup
 }


### PR DESCRIPTION
Moved the aggregated struct definitions (`AggCategory`, `AggPackage`, `SiteData`, etc.) from `cmd/g2/site.go` to the root `github.com/arran4/g2` package. Updates across the CLI (`cmd/g2/*`) point to these newly migrated types, removing redundancy and improving modularity as suggested by the TODO comments.

---
*PR created automatically by Jules for task [16013335521973477567](https://jules.google.com/task/16013335521973477567) started by @arran4*