### PR TITLE
Refactor testing stdout capture by injecting io.Writer to commands

### DIFF
--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -83,7 +83,7 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 	case "deps":
 		if err := config.cmdEbuildDeps(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild deps: %w", err)
-    }
+		}
 	case "query":
 		if err := config.cmdEbuildQuery(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild query: %w", err)
@@ -465,7 +465,15 @@ func convertDepNodeToJSON(node g2.DepNode) *DepNodeJSON {
 	return nil
 }
 
-func (cfg *CmdEbuildArgConfig) cmdEbuildDeps(args []string) error {
+func (cfg *CmdEbuildArgConfig) cmdEbuildDeps(args []string, opts ...any) error {
+	var out io.Writer = os.Stdout
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case io.Writer:
+			out = o
+		}
+	}
+
 	fs := flag.NewFlagSet("deps", flag.ExitOnError)
 	flatten := fs.Bool("flatten", false, "Flatten dependency trees into a list")
 	atomsOnly := fs.Bool("atoms-only", false, "Extract only package atoms without operators (e.g. dev-libs/foo instead of >=dev-libs/foo-1.2.3)")
@@ -527,13 +535,13 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildDeps(args []string) error {
 					fileDeps.Deps[field] = flatDeps
 				} else {
 					if *onePerLine {
-						fmt.Printf("### %s - %s\n", filename, field)
+						_, _ = fmt.Fprintf(out, "### %s - %s\n", filename, field)
 						for _, d := range flatDeps {
-							fmt.Println(d)
+							_, _ = fmt.Fprintln(out, d)
 						}
-						fmt.Println()
+						_, _ = fmt.Fprintln(out)
 					} else {
-						fmt.Printf("### %s - %s\n%s\n\n", filename, field, strings.Join(flatDeps, " "))
+						_, _ = fmt.Fprintf(out, "### %s - %s\n%s\n\n", filename, field, strings.Join(flatDeps, " "))
 					}
 				}
 			} else {
@@ -549,13 +557,13 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildDeps(args []string) error {
 						// For raw string output, splitting by space is a naive approach,
 						// but since users requested one-per-line for standard format,
 						// printing evaluated/flattened is better, or splitting the raw string.
-						fmt.Printf("### %s - %s\n", filename, field)
+						_, _ = fmt.Fprintf(out, "### %s - %s\n", filename, field)
 						for _, token := range strings.Fields(val) {
-							fmt.Println(token)
+							_, _ = fmt.Fprintln(out, token)
 						}
-						fmt.Println()
+						_, _ = fmt.Fprintln(out)
 					} else {
-						fmt.Printf("### %s - %s\n%s\n\n", filename, field, val)
+						_, _ = fmt.Fprintf(out, "### %s - %s\n%s\n\n", filename, field, val)
 					}
 				}
 			}
@@ -567,11 +575,11 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildDeps(args []string) error {
 	}
 
 	if *jsonOutput {
-		out, err := json.MarshalIndent(allFilesDeps, "", "\t")
+		outBytes, err := json.MarshalIndent(allFilesDeps, "", "\t")
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
-		fmt.Println(string(out))
+		_, _ = fmt.Fprintln(out, string(outBytes))
 	}
 
 	return nil

--- a/cmd/g2/ebuild_deps_test.go
+++ b/cmd/g2/ebuild_deps_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"embed"
 	"encoding/json"
-	"io"
 	"io/fs"
 	"os"
 	"path"
@@ -64,11 +63,7 @@ func TestEbuildDeps(t *testing.T) {
 				}
 			}
 
-			// run the command logic intercepting stdout
-			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
+			// run the command logic capturing output via io.Writer
 			// Because cmdEbuildDeps is a method on CmdEbuildArgConfig
 			// We can initialize it
 			cfg := &CmdEbuildArgConfig{
@@ -78,14 +73,9 @@ func TestEbuildDeps(t *testing.T) {
 			// append ebuilds to arguments
 			args := append(opts.Args, ebuildFiles...)
 
-			err = cfg.cmdEbuildDeps(args)
-
-			// restore stdout and read result
-			_ = w.Close()
-			os.Stdout = oldStdout
-
 			var outBuf bytes.Buffer
-			_, _ = io.Copy(&outBuf, r)
+			err = cfg.cmdEbuildDeps(args, &outBuf)
+
 			got := outBuf.String()
 
 			if err != nil {

--- a/cmd/g2/ebuild_tag.go
+++ b/cmd/g2/ebuild_tag.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sort"
@@ -11,7 +12,15 @@ import (
 	"github.com/arran4/g2"
 )
 
-func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string) error {
+func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string, opts ...any) error {
+	var out io.Writer = os.Stdout
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case io.Writer:
+			out = o
+		}
+	}
+
 	fs := flag.NewFlagSet("tag", flag.ExitOnError)
 	dir := fs.String("dir", ".", "Directory to search for ebuilds")
 	compare := fs.String("compare", "", "Compare a version to the highest tag (outputs -, =, or +)")
@@ -67,14 +76,14 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string) error {
 		comp := g2.CompareVersions(*compare, highestVersion)
 		if comp < 0 {
 			if *downgrades {
-				fmt.Println("-")
+				_, _ = fmt.Fprintln(out, "-")
 			} else {
 				log.Printf("Version %s is a downgrade from %s. Ignoring.", *compare, highestVersion)
 			}
 		} else if comp == 0 {
-			fmt.Println("=")
+			_, _ = fmt.Fprintln(out, "=")
 		} else {
-			fmt.Println("+")
+			_, _ = fmt.Fprintln(out, "+")
 		}
 		return nil
 	}
@@ -96,10 +105,10 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string) error {
 			gv.IncrementPart("patch")
 		}
 
-		fmt.Println(gv.String())
+		_, _ = fmt.Fprintln(out, gv.String())
 		return nil
 	}
 
-	fmt.Println(highestVersion)
+	_, _ = fmt.Fprintln(out, highestVersion)
 	return nil
 }

--- a/cmd/g2/ebuild_tag_test.go
+++ b/cmd/g2/ebuild_tag_test.go
@@ -29,21 +29,14 @@ func TestEbuildTag(t *testing.T) {
 
 	cfg := &CmdEbuildArgConfig{}
 
-	// Test basic execution without compare (should return highest version)
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	var buf bytes.Buffer
 
-	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir})
+	// Test basic execution without compare (should return highest version)
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir}, &buf)
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
 
-	_ = w.Close()
-	os.Stdout = oldStdout
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
 	output := strings.TrimSpace(buf.String())
 
 	if output != "2.0.0-r1" {
@@ -51,96 +44,66 @@ func TestEbuildTag(t *testing.T) {
 	}
 
 	// Test compare downgrade without flag
-	r2, w2, _ := os.Pipe()
-	os.Stdout = w2
-	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "1.5.0"})
+	buf.Reset()
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "1.5.0"}, &buf)
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	_ = w2.Close()
-	os.Stdout = oldStdout
-	buf.Reset()
-	_, _ = buf.ReadFrom(r2)
 	output = strings.TrimSpace(buf.String())
 	if output != "" {
 		t.Errorf("Expected empty output for downgrade without -downgrades flag, got %s", output)
 	}
 
 	// Test compare downgrade with flag
-	r3, w3, _ := os.Pipe()
-	os.Stdout = w3
-	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "1.5.0", "-downgrades"})
+	buf.Reset()
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "1.5.0", "-downgrades"}, &buf)
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	_ = w3.Close()
-	os.Stdout = oldStdout
-	buf.Reset()
-	_, _ = buf.ReadFrom(r3)
 	output = strings.TrimSpace(buf.String())
 	if output != "-" {
 		t.Errorf("Expected '-' output for downgrade with -downgrades flag, got %s", output)
 	}
 
 	// Test compare equal
-	r4, w4, _ := os.Pipe()
-	os.Stdout = w4
-	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "2.0.0-r1"})
+	buf.Reset()
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "2.0.0-r1"}, &buf)
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	_ = w4.Close()
-	os.Stdout = oldStdout
-	buf.Reset()
-	_, _ = buf.ReadFrom(r4)
 	output = strings.TrimSpace(buf.String())
 	if output != "=" {
 		t.Errorf("Expected '=' output for equal version, got %s", output)
 	}
 
 	// Test compare upgrade
-	r5, w5, _ := os.Pipe()
-	os.Stdout = w5
-	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "2.1.0"})
+	buf.Reset()
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-compare", "2.1.0"}, &buf)
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	_ = w5.Close()
-	os.Stdout = oldStdout
-	buf.Reset()
-	_, _ = buf.ReadFrom(r5)
 	output = strings.TrimSpace(buf.String())
 	if output != "+" {
 		t.Errorf("Expected '+' output for upgrade version, got %s", output)
 	}
 
 	// Test patch bump
-	r6, w6, _ := os.Pipe()
-	os.Stdout = w6
-	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-patch"})
+	buf.Reset()
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-patch"}, &buf)
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	_ = w6.Close()
-	os.Stdout = oldStdout
-	buf.Reset()
-	_, _ = buf.ReadFrom(r6)
 	output = strings.TrimSpace(buf.String())
 	if output != "2.0.1" { // 2.0.0-r1 -> micro increment drops suffix and goes to next number
 		t.Errorf("Expected '2.0.1' output for patch bump, got %s", output)
 	}
 
 	// Test revision bump
-	r7, w7, _ := os.Pipe()
-	os.Stdout = w7
-	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-revision"})
+	buf.Reset()
+	err = cfg.cmdEbuildTag([]string{"-dir", tmpDir, "-revision"}, &buf)
 	if err != nil {
 		t.Fatalf("cmdEbuildTag failed: %v", err)
 	}
-	_ = w7.Close()
-	os.Stdout = oldStdout
-	buf.Reset()
-	_, _ = buf.ReadFrom(r7)
 	output = strings.TrimSpace(buf.String())
 	if output != "2.0.0-r2" {
 		t.Errorf("Expected '2.0.0-r2' output for revision bump, got %s", output)


### PR DESCRIPTION
Refactor `ebuild deps` and `ebuild tag` command execution testing to rely on `io.Writer` instead of intercepting `os.Stdout` with an `os.Pipe`, making testing robust and thread-safe.

---
*PR created automatically by Jules for task [16235730854875300738](https://jules.google.com/task/16235730854875300738) started by @arran4*