### PR TITLE
perf: optimize ebuild parsing and generation memory loops

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -998,12 +998,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 				}
 
 				ebuildPath := filepath.Join(pkgPath, file.Name())
-				subFS, err := fs.Sub(sysFS, filepath.ToSlash(filepath.Dir(ebuildPath)))
-				if err != nil {
-					log.Printf("Warning: subfs ebuild %s: %v", ebuildPath, err)
-					continue
-				}
-				ebuild, err := g2.ParseEbuild(subFS, file.Name(), g2.ParseFull)
+				ebuild, err := g2.ParseEbuild(sysFS, filepath.ToSlash(ebuildPath), g2.ParseFull)
 				if err != nil {
 					log.Printf("Warning: parsing ebuild %s: %v", ebuildPath, err)
 					continue

--- a/ebuild.go
+++ b/ebuild.go
@@ -505,28 +505,38 @@ var varExpansionRegex = regexp.MustCompile(`\$\{([a-zA-Z0-9_]+)([^}]*)\}`)
 
 // ResolveVariables replaces ${VAR} and $VAR in the text with values from variables map.
 func ResolveVariables(text string, variables map[string]string) string {
+	if !strings.Contains(text, "$") {
+		return text
+	}
+
 	// Simple resolution: multiple passes until no change or limit reached
 	// To prevent memory exhaustion from self-referential or heavily nested variables,
 	// cap the maximum expanded length.
 	maxLen := 1024 * 1024 // 1MB limit for expanded strings
 
-	// 1. Sort keys by length descending to prevent $P from matching before $PN
 	var keys []string
-	for k := range variables {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return len(keys[i]) > len(keys[j])
-	})
+	var varRefs []string
 
 	for i := 0; i < 5; i++ { // Limit recursion depth
 		original := text
 
 		if strings.Contains(text, "$") {
 			// 1. Replace all simple $VAR substitutions
-			for _, key := range keys {
+			if keys == nil {
+				for k := range variables {
+					keys = append(keys, k)
+				}
+				sort.Slice(keys, func(i, j int) bool {
+					return len(keys[i]) > len(keys[j])
+				})
+				for _, k := range keys {
+					varRefs = append(varRefs, "$"+k)
+				}
+			}
+
+			for j, key := range keys {
 				value := variables[key]
-				varRef := fmt.Sprintf("$%s", key)
+				varRef := varRefs[j]
 				if strings.Contains(text, varRef) {
 					if strings.Contains(value, varRef) {
 						continue
@@ -1061,6 +1071,9 @@ func ParsePackageAtom(dep string) PackageAtom {
 // ExtractPackageNameFromDep strips version, slot, and USE flags from a package string
 // using the AST parser PackageAtom to satisfy architectural requirements.
 func ExtractPackageNameFromDep(dep string) string {
+	if !strings.ContainsAny(dep, "><=~![:") && !strings.Contains(dep, "/*") && !strings.ContainsAny(dep, "0123456789") {
+		return dep
+	}
 	atom := ParsePackageAtom(dep)
 	if atom.Category != "" {
 		return atom.Category + "/" + atom.Name

--- a/ebuild_bench_test.go
+++ b/ebuild_bench_test.go
@@ -1,0 +1,56 @@
+package g2
+
+import (
+	"os"
+	"testing"
+)
+
+func BenchmarkParseEbuildFull(b *testing.B) {
+	fsys := os.DirFS(".")
+
+	ebuildContent := []byte(`
+EAPI=8
+DESCRIPTION="Dummy package"
+HOMEPAGE="https://example.com"
+SRC_URI="https://example.com/file.tar.gz"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+
+DEPEND="
+	dev-libs/libxml2
+	test? ( dev-util/cppunit )
+"
+RDEPEND="${DEPEND}"
+`)
+	os.WriteFile("dummy-1.0.ebuild", ebuildContent, 0644)
+	defer os.Remove("dummy-1.0.ebuild")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseEbuild(fsys, "dummy-1.0.ebuild", ParseFull)
+	}
+}
+
+func BenchmarkResolveVariables(b *testing.B) {
+    vars := map[string]string{
+        "A": "B",
+        "C": "D",
+        "E": "F",
+        "P": "pkg-1.0",
+        "PN": "pkg",
+        "PV": "1.0",
+    }
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        ResolveVariables("This is a test with $P and ${PN} variables", vars)
+    }
+}
+
+func BenchmarkExtractPackageNameFromDep(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ExtractPackageNameFromDep("dev-lang/python")
+		ExtractPackageNameFromDep(">=dev-lang/python-3.10.4-r1:0/3.10[sqlite,xml]")
+	}
+}

--- a/ebuild_bench_test.go
+++ b/ebuild_bench_test.go
@@ -24,8 +24,8 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 `)
-	os.WriteFile("dummy-1.0.ebuild", ebuildContent, 0644)
-	defer os.Remove("dummy-1.0.ebuild")
+	_ = os.WriteFile("dummy-1.0.ebuild", ebuildContent, 0644)
+	defer func() { _ = os.Remove("dummy-1.0.ebuild") }()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/lints/md5cache/md5cache_missing.go
+++ b/lints/md5cache/md5cache_missing.go
@@ -3,6 +3,7 @@ package md5cache
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints"
@@ -51,9 +52,11 @@ func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 		if ver.Ebuild != nil {
 			cachePath := filepath.Join(repoDir, "metadata", "md5-cache", pkg.Category, pkg.Name+"-"+ver.Version)
 			if _, err := os.Stat(cachePath); os.IsNotExist(err) {
+				sevStr := string(severity)
+				sevTitle := strings.ToUpper(sevStr[:1]) + sevStr[1:]
 				res := lints.LintResult{
 					RuleMetadata: ruleMD5CacheMissing,
-					Message:      "[" + string(severity) + "] Missing md5-cache for ebuild " + pkg.Name + "-" + ver.Version,
+					Message:      "[" + sevTitle + "] Missing md5-cache for ebuild " + pkg.Name + "-" + ver.Version,
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = severity

--- a/lints/md5cache/md5cache_missing.go
+++ b/lints/md5cache/md5cache_missing.go
@@ -1,14 +1,11 @@
 package md5cache
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 var ruleMD5CacheMissing = lints.RuleMetadata{
@@ -56,7 +53,7 @@ func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 			if _, err := os.Stat(cachePath); os.IsNotExist(err) {
 				res := lints.LintResult{
 					RuleMetadata: ruleMD5CacheMissing,
-					Message:      fmt.Sprintf("[%s] Missing md5-cache for ebuild %s-%s", cases.Title(language.English).String(string(severity)), pkg.Name, ver.Version),
+					Message:      "[" + string(severity) + "] Missing md5-cache for ebuild " + pkg.Name + "-" + ver.Version,
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = severity

--- a/package_mask.go
+++ b/package_mask.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"regexp"
+
 	"strings"
 )
 
@@ -31,9 +31,6 @@ func parsePackageMaskedReader(r io.Reader) ([]PackageMasked, error) {
 	var currentReason []string
 	var currentAuthor, currentEmail, currentDate string
 	var currentEntries []PackageMaskedEntry
-
-	// Match: # Michał Górny <mgorny@gentoo.org> (2025-11-25)
-	authorLineRegex := regexp.MustCompile(`^#\s*(.*?)\s*<(.*?)>\s*\((.*?)\)$`)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())


### PR DESCRIPTION
Optimized `ResolveVariables` array allocation and variable regex replacement.
Added fast-paths in `ExtractPackageNameFromDep`.
Removed intermediate `fs.Sub` inside loop iterators in `parseRepo`.
Removed formatting string reflection allocations in `md5cache_missing.go`.
Removed repeated regexp compilation in `package_mask.go`.

---
*PR created automatically by Jules for task [12764747445767676737](https://jules.google.com/task/12764747445767676737) started by @arran4*