### PR TITLE
feat: log memory usage and node count during site generation

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	path2 "path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -3934,10 +3935,12 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			}
 			checkoutTime := time.Since(t0)
 			freeSpace, err := getFreeSpace(repoPath)
+			var memStats runtime.MemStats
+			runtime.ReadMemStats(&memStats)
 			if err == nil {
-				log.Printf("[DONE] Finished fetching repository %s in %s. Free space: %.2f MB", repo.Name, checkoutTime, float64(freeSpace)/(1024*1024))
+				log.Printf("[DONE] Finished fetching repository %s in %s. Free space: %.2f MB, Total memory usage: %.2f MB", repo.Name, checkoutTime, float64(freeSpace)/(1024*1024), float64(memStats.Alloc)/(1024*1024))
 			} else {
-				log.Printf("[DONE] Finished fetching repository %s in %s", repo.Name, checkoutTime)
+				log.Printf("[DONE] Finished fetching repository %s in %s. Total memory usage: %.2f MB", repo.Name, checkoutTime, float64(memStats.Alloc)/(1024*1024))
 			}
 
 			log.Printf("[START] Parsing repository: %s", repo.Name)
@@ -3958,10 +3961,21 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			}
 			processTime := time.Since(t1)
 			freeSpaceAfter, err := getFreeSpace(repoPath)
+			var memStatsAfter runtime.MemStats
+			runtime.ReadMemStats(&memStatsAfter)
+			nodeCount := 0
+			if siteData != nil {
+				nodeCount = len(siteData.Categories) + siteData.PackageCount + len(siteData.Profiles) + len(siteData.News) + len(siteData.Moves) + len(siteData.DefinedEclasses)
+				for _, cat := range siteData.Categories {
+					for _, pkg := range cat.Packages {
+						nodeCount += len(pkg.Versions)
+					}
+				}
+			}
 			if err == nil {
-				log.Printf("[DONE] Finished parsing repository %s in %s. Free space: %.2f MB", repo.Name, processTime, float64(freeSpaceAfter)/(1024*1024))
+				log.Printf("[DONE] Finished parsing repository %s in %s. Free space: %.2f MB, Total memory usage: %.2f MB, Nodes: %d", repo.Name, processTime, float64(freeSpaceAfter)/(1024*1024), float64(memStatsAfter.Alloc)/(1024*1024), nodeCount)
 			} else {
-				log.Printf("[DONE] Finished parsing repository %s in %s", repo.Name, processTime)
+				log.Printf("[DONE] Finished parsing repository %s in %s. Total memory usage: %.2f MB, Nodes: %d", repo.Name, processTime, float64(memStatsAfter.Alloc)/(1024*1024), nodeCount)
 			}
 
 			siteData.CheckoutTime = checkoutTime.String()

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -249,32 +249,9 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 
 	var allSites []*SiteData
 	var allSitesMu sync.Mutex
+	var lastLogTime time.Time
 
 	g, _ := errgroup.WithContext(context.Background())
-
-	tickerCtx, tickerCancel := context.WithCancel(context.Background())
-	defer tickerCancel()
-	go func() {
-		ticker := time.NewTicker(10 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-tickerCtx.Done():
-				return
-			case <-ticker.C:
-				allSitesMu.Lock()
-				currentRepos := len(allSites)
-				var currentPackages int
-				for _, site := range allSites {
-					if site != nil {
-						currentPackages += site.PackageCount
-					}
-				}
-				allSitesMu.Unlock()
-				log.Printf("[PROGRESS] Currently processed %d repositories and %d total packages so far", currentRepos, currentPackages)
-			}
-		}
-	}()
 
 	for _, task := range tasks {
 		task := task
@@ -356,6 +333,18 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 
 			allSitesMu.Lock()
 			allSites = append(allSites, siteData)
+			now := time.Now()
+			if lastLogTime.IsZero() || now.Sub(lastLogTime) >= 10*time.Minute {
+				lastLogTime = now
+				currentRepos := len(allSites)
+				var currentPackages int
+				for _, site := range allSites {
+					if site != nil {
+						currentPackages += site.PackageCount
+					}
+				}
+				log.Printf("[PROGRESS] Currently processed %d repositories and %d total packages so far", currentRepos, currentPackages)
+			}
 			allSitesMu.Unlock()
 			return nil
 		})
@@ -364,7 +353,6 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("fetching and parsing repos: %w", err)
 	}
-	tickerCancel()
 
 	sort.Slice(allSites, func(i, j int) bool {
 		return allSites[i].RepoName < allSites[j].RepoName
@@ -3931,6 +3919,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 
 	var allSites []*SiteData
 	var allSitesMu sync.Mutex
+	var lastLogTime time.Time
 
 	g, _ := errgroup.WithContext(context.Background())
 	if concurrency > 0 {
@@ -3939,30 +3928,6 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	} else {
 		log.Printf("Starting concurrent remote repository processing with unbounded concurrency")
 	}
-
-	tickerCtx, tickerCancel := context.WithCancel(context.Background())
-	defer tickerCancel()
-	go func() {
-		ticker := time.NewTicker(10 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-tickerCtx.Done():
-				return
-			case <-ticker.C:
-				allSitesMu.Lock()
-				currentRepos := len(allSites)
-				var currentPackages int
-				for _, site := range allSites {
-					if site != nil {
-						currentPackages += site.PackageCount
-					}
-				}
-				allSitesMu.Unlock()
-				log.Printf("[PROGRESS] Currently processed %d repositories and %d total packages so far", currentRepos, currentPackages)
-			}
-		}
-	}()
 
 	for _, repo := range repos.Repositories {
 		repo := repo // loop variable capture
@@ -4050,6 +4015,18 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 
 			allSitesMu.Lock()
 			allSites = append(allSites, siteData)
+			now := time.Now()
+			if lastLogTime.IsZero() || now.Sub(lastLogTime) >= 10*time.Minute {
+				lastLogTime = now
+				currentRepos := len(allSites)
+				var currentPackages int
+				for _, site := range allSites {
+					if site != nil {
+						currentPackages += site.PackageCount
+					}
+				}
+				log.Printf("[PROGRESS] Currently processed %d repositories and %d total packages so far", currentRepos, currentPackages)
+			}
 			allSitesMu.Unlock()
 			return nil
 		})
@@ -4060,7 +4037,6 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 		}
 		log.Printf("Warning: error during parallel repository fetching: %v", err)
 	}
-	tickerCancel()
 	// Sort the resulting sites alphabetically by RepoName for deterministic ordering
 	sort.Slice(allSites, func(i, j int) bool {
 		return allSites[i].RepoName < allSites[j].RepoName

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -252,6 +252,30 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 
 	g, _ := errgroup.WithContext(context.Background())
 
+	tickerCtx, tickerCancel := context.WithCancel(context.Background())
+	defer tickerCancel()
+	go func() {
+		ticker := time.NewTicker(10 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-tickerCtx.Done():
+				return
+			case <-ticker.C:
+				allSitesMu.Lock()
+				currentRepos := len(allSites)
+				var currentPackages int
+				for _, site := range allSites {
+					if site != nil {
+						currentPackages += site.PackageCount
+					}
+				}
+				allSitesMu.Unlock()
+				log.Printf("[PROGRESS] Currently processed %d repositories and %d total packages so far", currentRepos, currentPackages)
+			}
+		}
+	}()
+
 	for _, task := range tasks {
 		task := task
 		g.Go(func() error {
@@ -340,6 +364,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("fetching and parsing repos: %w", err)
 	}
+	tickerCancel()
 
 	sort.Slice(allSites, func(i, j int) bool {
 		return allSites[i].RepoName < allSites[j].RepoName
@@ -3807,6 +3832,23 @@ func generateSite(outDir string, sites []*SiteData, recentDuration time.Duration
 		return err
 	}
 
+	totalNodes := len(data.Categories) + data.TotalPackages + len(data.Profiles) + len(data.GlobalNews) + len(data.Moves) + len(data.Eclasses)
+	for _, pkg := range data.Packages {
+		for _, repoSite := range pkg.Repos {
+			for _, cat := range repoSite.Categories {
+				if cat.Name == pkg.Category {
+					for _, repoPkg := range cat.Packages {
+						if repoPkg.Name == pkg.Name {
+							totalNodes += len(repoPkg.Versions)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	log.Printf("[DONE] Site generation complete. Total nodes generated: %d", totalNodes)
+
 	return nil
 }
 
@@ -3897,6 +3939,30 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	} else {
 		log.Printf("Starting concurrent remote repository processing with unbounded concurrency")
 	}
+
+	tickerCtx, tickerCancel := context.WithCancel(context.Background())
+	defer tickerCancel()
+	go func() {
+		ticker := time.NewTicker(10 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-tickerCtx.Done():
+				return
+			case <-ticker.C:
+				allSitesMu.Lock()
+				currentRepos := len(allSites)
+				var currentPackages int
+				for _, site := range allSites {
+					if site != nil {
+						currentPackages += site.PackageCount
+					}
+				}
+				allSitesMu.Unlock()
+				log.Printf("[PROGRESS] Currently processed %d repositories and %d total packages so far", currentRepos, currentPackages)
+			}
+		}
+	}()
 
 	for _, repo := range repos.Repositories {
 		repo := repo // loop variable capture
@@ -3994,6 +4060,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 		}
 		log.Printf("Warning: error during parallel repository fetching: %v", err)
 	}
+	tickerCancel()
 	// Sort the resulting sites alphabetically by RepoName for deterministic ordering
 	sort.Slice(allSites, func(i, j int) bool {
 		return allSites[i].RepoName < allSites[j].RepoName


### PR DESCRIPTION
Added `runtime.ReadMemStats` to log the process's allocated memory (`MemStats.Alloc`) alongside free disk space during the repository fetching and parsing phases. Also added a calculation to determine the total number of nodes (categories, packages, versions, profiles, news, moves, eclasses) in a repository and included it in the parsing phase log output.

---
*PR created automatically by Jules for task [1781980407688594992](https://jules.google.com/task/1781980407688594992) started by @arran4*