### PR TITLE
feat: log application directory free space

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -4037,19 +4037,41 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			}
 			checkoutTime := time.Since(t0)
 			freeSpace, err := getFreeSpace(repoPath)
+			appFreeSpace, appErr := getFreeSpace(".")
 			freeMem, memErr := getFreeMemory()
 			procMem := getProcessMemUsage()
 
 			var memStats runtime.MemStats
 			runtime.ReadMemStats(&memStats)
 
-			if err == nil && memErr == nil {
+			if err == nil && appErr == nil && memErr == nil {
+				log.Printf(
+					"[DONE] Finished fetching repository %s in %s. Free space (Repo/App): %.2f/%.2f MB. Free memory: %.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB",
+					repo.Name,
+					checkoutTime,
+					float64(freeSpace)/(1024*1024),
+					float64(appFreeSpace)/(1024*1024),
+					float64(freeMem)/(1024*1024),
+					float64(procMem)/(1024*1024),
+					float64(memStats.Alloc)/(1024*1024),
+				)
+			} else if err == nil && memErr == nil {
 				log.Printf(
 					"[DONE] Finished fetching repository %s in %s. Free space: %.2f MB. Free memory: %.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB",
 					repo.Name,
 					checkoutTime,
 					float64(freeSpace)/(1024*1024),
 					float64(freeMem)/(1024*1024),
+					float64(procMem)/(1024*1024),
+					float64(memStats.Alloc)/(1024*1024),
+				)
+			} else if err == nil && appErr == nil {
+				log.Printf(
+					"[DONE] Finished fetching repository %s in %s. Free space (Repo/App): %.2f/%.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB",
+					repo.Name,
+					checkoutTime,
+					float64(freeSpace)/(1024*1024),
+					float64(appFreeSpace)/(1024*1024),
 					float64(procMem)/(1024*1024),
 					float64(memStats.Alloc)/(1024*1024),
 				)
@@ -4099,6 +4121,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			}
 			processTime := time.Since(t1)
 			freeSpaceAfter, err := getFreeSpace(repoPath)
+			appFreeSpaceAfter, appErrAfter := getFreeSpace(".")
 			freeMemAfter, memErrAfter := getFreeMemory()
 			procMemAfter := getProcessMemUsage()
 
@@ -4115,13 +4138,36 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				}
 			}
 
-			if err == nil && memErrAfter == nil {
+			if err == nil && appErrAfter == nil && memErrAfter == nil {
+				log.Printf(
+					"[DONE] Finished parsing repository %s in %s. Free space (Repo/App): %.2f/%.2f MB. Free memory: %.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB. Nodes: %d",
+					repo.Name,
+					processTime,
+					float64(freeSpaceAfter)/(1024*1024),
+					float64(appFreeSpaceAfter)/(1024*1024),
+					float64(freeMemAfter)/(1024*1024),
+					float64(procMemAfter)/(1024*1024),
+					float64(memStatsAfter.Alloc)/(1024*1024),
+					nodeCount,
+				)
+			} else if err == nil && memErrAfter == nil {
 				log.Printf(
 					"[DONE] Finished parsing repository %s in %s. Free space: %.2f MB. Free memory: %.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB. Nodes: %d",
 					repo.Name,
 					processTime,
 					float64(freeSpaceAfter)/(1024*1024),
 					float64(freeMemAfter)/(1024*1024),
+					float64(procMemAfter)/(1024*1024),
+					float64(memStatsAfter.Alloc)/(1024*1024),
+					nodeCount,
+				)
+			} else if err == nil && appErrAfter == nil {
+				log.Printf(
+					"[DONE] Finished parsing repository %s in %s. Free space (Repo/App): %.2f/%.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB. Nodes: %d",
+					repo.Name,
+					processTime,
+					float64(freeSpaceAfter)/(1024*1024),
+					float64(appFreeSpaceAfter)/(1024*1024),
 					float64(procMemAfter)/(1024*1024),
 					float64(memStatsAfter.Alloc)/(1024*1024),
 					nodeCount,
@@ -4217,6 +4263,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	})
 
 	finalMemUsage := getProcessMemUsage()
+	appFreeSpaceFinal, appErrFinal := getFreeSpace(".")
 	log.Printf("--------------------------------------------------")
 	log.Printf("[FINAL SUMMARY] Repository Processing Complete")
 	log.Printf("Total Repositories:      %d", len(allSites))
@@ -4224,6 +4271,9 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	log.Printf("Total Packages:          %d", totalPackages)
 	log.Printf("Total Package Versions:  %d", totalPackageVersions)
 	log.Printf("Final Memory Usage:      %.2f MB", float64(finalMemUsage)/(1024*1024))
+	if appErrFinal == nil {
+		log.Printf("Final App Free Space:    %.2f MB", float64(appFreeSpaceFinal)/(1024*1024))
+	}
 	log.Printf("--------------------------------------------------")
 
 	log.Printf("Generating integrated site (v%s) for %d repos", version, len(allSites))

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -4038,13 +4038,26 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			checkoutTime := time.Since(t0)
 			freeSpace, err := getFreeSpace(repoPath)
 			appFreeSpace, appErr := getFreeSpace(".")
+			tmpFreeSpace, tmpErr := getFreeSpace(os.TempDir())
 			freeMem, memErr := getFreeMemory()
 			procMem := getProcessMemUsage()
 
 			var memStats runtime.MemStats
 			runtime.ReadMemStats(&memStats)
 
-			if err == nil && appErr == nil && memErr == nil {
+			if err == nil && appErr == nil && tmpErr == nil && memErr == nil {
+				log.Printf(
+					"[DONE] Finished fetching repository %s in %s. Free space (Repo/App/Tmp): %.2f/%.2f/%.2f MB. Free memory: %.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB",
+					repo.Name,
+					checkoutTime,
+					float64(freeSpace)/(1024*1024),
+					float64(appFreeSpace)/(1024*1024),
+					float64(tmpFreeSpace)/(1024*1024),
+					float64(freeMem)/(1024*1024),
+					float64(procMem)/(1024*1024),
+					float64(memStats.Alloc)/(1024*1024),
+				)
+			} else if err == nil && appErr == nil && memErr == nil {
 				log.Printf(
 					"[DONE] Finished fetching repository %s in %s. Free space (Repo/App): %.2f/%.2f MB. Free memory: %.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB",
 					repo.Name,
@@ -4062,6 +4075,17 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 					checkoutTime,
 					float64(freeSpace)/(1024*1024),
 					float64(freeMem)/(1024*1024),
+					float64(procMem)/(1024*1024),
+					float64(memStats.Alloc)/(1024*1024),
+				)
+			} else if err == nil && appErr == nil && tmpErr == nil {
+				log.Printf(
+					"[DONE] Finished fetching repository %s in %s. Free space (Repo/App/Tmp): %.2f/%.2f/%.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB",
+					repo.Name,
+					checkoutTime,
+					float64(freeSpace)/(1024*1024),
+					float64(appFreeSpace)/(1024*1024),
+					float64(tmpFreeSpace)/(1024*1024),
 					float64(procMem)/(1024*1024),
 					float64(memStats.Alloc)/(1024*1024),
 				)
@@ -4122,6 +4146,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			processTime := time.Since(t1)
 			freeSpaceAfter, err := getFreeSpace(repoPath)
 			appFreeSpaceAfter, appErrAfter := getFreeSpace(".")
+			tmpFreeSpaceAfter, tmpErrAfter := getFreeSpace(os.TempDir())
 			freeMemAfter, memErrAfter := getFreeMemory()
 			procMemAfter := getProcessMemUsage()
 
@@ -4138,7 +4163,20 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				}
 			}
 
-			if err == nil && appErrAfter == nil && memErrAfter == nil {
+			if err == nil && appErrAfter == nil && tmpErrAfter == nil && memErrAfter == nil {
+				log.Printf(
+					"[DONE] Finished parsing repository %s in %s. Free space (Repo/App/Tmp): %.2f/%.2f/%.2f MB. Free memory: %.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB. Nodes: %d",
+					repo.Name,
+					processTime,
+					float64(freeSpaceAfter)/(1024*1024),
+					float64(appFreeSpaceAfter)/(1024*1024),
+					float64(tmpFreeSpaceAfter)/(1024*1024),
+					float64(freeMemAfter)/(1024*1024),
+					float64(procMemAfter)/(1024*1024),
+					float64(memStatsAfter.Alloc)/(1024*1024),
+					nodeCount,
+				)
+			} else if err == nil && appErrAfter == nil && memErrAfter == nil {
 				log.Printf(
 					"[DONE] Finished parsing repository %s in %s. Free space (Repo/App): %.2f/%.2f MB. Free memory: %.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB. Nodes: %d",
 					repo.Name,
@@ -4157,6 +4195,18 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 					processTime,
 					float64(freeSpaceAfter)/(1024*1024),
 					float64(freeMemAfter)/(1024*1024),
+					float64(procMemAfter)/(1024*1024),
+					float64(memStatsAfter.Alloc)/(1024*1024),
+					nodeCount,
+				)
+			} else if err == nil && appErrAfter == nil && tmpErrAfter == nil {
+				log.Printf(
+					"[DONE] Finished parsing repository %s in %s. Free space (Repo/App/Tmp): %.2f/%.2f/%.2f MB. Process Memory: %.2f MB. Go Alloc: %.2f MB. Nodes: %d",
+					repo.Name,
+					processTime,
+					float64(freeSpaceAfter)/(1024*1024),
+					float64(appFreeSpaceAfter)/(1024*1024),
+					float64(tmpFreeSpaceAfter)/(1024*1024),
 					float64(procMemAfter)/(1024*1024),
 					float64(memStatsAfter.Alloc)/(1024*1024),
 					nodeCount,
@@ -4264,6 +4314,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 
 	finalMemUsage := getProcessMemUsage()
 	appFreeSpaceFinal, appErrFinal := getFreeSpace(".")
+	tmpFreeSpaceFinal, tmpErrFinal := getFreeSpace(os.TempDir())
 	log.Printf("--------------------------------------------------")
 	log.Printf("[FINAL SUMMARY] Repository Processing Complete")
 	log.Printf("Total Repositories:      %d", len(allSites))
@@ -4273,6 +4324,9 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	log.Printf("Final Memory Usage:      %.2f MB", float64(finalMemUsage)/(1024*1024))
 	if appErrFinal == nil {
 		log.Printf("Final App Free Space:    %.2f MB", float64(appFreeSpaceFinal)/(1024*1024))
+	}
+	if tmpErrFinal == nil {
+		log.Printf("Final Tmp Free Space:    %.2f MB", float64(tmpFreeSpaceFinal)/(1024*1024))
 	}
 	log.Printf("--------------------------------------------------")
 

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -121,9 +121,14 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 					}
 
 					freeSpace, err := getFreeSpace(repoPath)
+					appFreeSpace, appErr := getFreeSpace(".")
 					freeMem, memErr := getFreeMemory()
-					if err == nil && memErr == nil {
+					if err == nil && appErr == nil && memErr == nil {
+						log.Printf("[DONE] Finished parsing repository %s. Free space (Repo/App): %.2f/%.2f MB. Free memory: %.2f MB", repoName, float64(freeSpace)/(1024*1024), float64(appFreeSpace)/(1024*1024), float64(freeMem)/(1024*1024))
+					} else if err == nil && memErr == nil {
 						log.Printf("[DONE] Finished parsing repository %s. Free space: %.2f MB. Free memory: %.2f MB", repoName, float64(freeSpace)/(1024*1024), float64(freeMem)/(1024*1024))
+					} else if err == nil && appErr == nil {
+						log.Printf("[DONE] Finished parsing repository %s. Free space (Repo/App): %.2f/%.2f MB", repoName, float64(freeSpace)/(1024*1024), float64(appFreeSpace)/(1024*1024))
 					} else if err == nil {
 						log.Printf("[DONE] Finished parsing repository %s. Free space: %.2f MB", repoName, float64(freeSpace)/(1024*1024))
 					} else if memErr == nil {

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -122,11 +122,16 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 
 					freeSpace, err := getFreeSpace(repoPath)
 					appFreeSpace, appErr := getFreeSpace(".")
+					tmpFreeSpace, tmpErr := getFreeSpace(os.TempDir())
 					freeMem, memErr := getFreeMemory()
-					if err == nil && appErr == nil && memErr == nil {
+					if err == nil && appErr == nil && tmpErr == nil && memErr == nil {
+						log.Printf("[DONE] Finished parsing repository %s. Free space (Repo/App/Tmp): %.2f/%.2f/%.2f MB. Free memory: %.2f MB", repoName, float64(freeSpace)/(1024*1024), float64(appFreeSpace)/(1024*1024), float64(tmpFreeSpace)/(1024*1024), float64(freeMem)/(1024*1024))
+					} else if err == nil && appErr == nil && memErr == nil {
 						log.Printf("[DONE] Finished parsing repository %s. Free space (Repo/App): %.2f/%.2f MB. Free memory: %.2f MB", repoName, float64(freeSpace)/(1024*1024), float64(appFreeSpace)/(1024*1024), float64(freeMem)/(1024*1024))
 					} else if err == nil && memErr == nil {
 						log.Printf("[DONE] Finished parsing repository %s. Free space: %.2f MB. Free memory: %.2f MB", repoName, float64(freeSpace)/(1024*1024), float64(freeMem)/(1024*1024))
+					} else if err == nil && appErr == nil && tmpErr == nil {
+						log.Printf("[DONE] Finished parsing repository %s. Free space (Repo/App/Tmp): %.2f/%.2f/%.2f MB", repoName, float64(freeSpace)/(1024*1024), float64(appFreeSpace)/(1024*1024), float64(tmpFreeSpace)/(1024*1024))
 					} else if err == nil && appErr == nil {
 						log.Printf("[DONE] Finished parsing repository %s. Free space (Repo/App): %.2f/%.2f MB", repoName, float64(freeSpace)/(1024*1024), float64(appFreeSpace)/(1024*1024))
 					} else if err == nil {


### PR DESCRIPTION
Modified `cmd/g2/site.go` and `cmd/g2/site_serve.go` to call `getFreeSpace(".")` and include the application directory's free space in the log output alongside the repository's free space during cloning and parsing. Also updated the final summary log to include the application directory's free space.

---
*PR created automatically by Jules for task [14072456659854350798](https://jules.google.com/task/14072456659854350798) started by @arran4*