### PR TITLE
🧪 test: Add unit test for ParseArchList

### DIFF
--- a/arches_test.go
+++ b/arches_test.go
@@ -1,0 +1,19 @@
+package g2
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseArchList(t *testing.T) {
+	r := strings.NewReader("amd64\n# a comment\n\n  x86  \narm64")
+	al, err := ParseArchList(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []string{"amd64", "x86", "arm64"}
+	if !reflect.DeepEqual(al.Arches, expected) {
+		t.Errorf("expected %v, got %v", expected, al.Arches)
+	}
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for `ParseArchList` in `arches.go`.
📊 **Coverage:** The scenarios now tested include a typical multiline arch list, whitespace handling, comment skipping, and empty lines.
✨ **Result:** Test coverage for `arches.go` is increased, ensuring confidence against regressions for architecture parsing.

---
*PR created automatically by Jules for task [15385970996972176062](https://jules.google.com/task/15385970996972176062) started by @arran4*