### PR TITLE
Log heap objects when concurrency is 1

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -4254,6 +4254,36 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			}
 
 			if concurrency == 1 {
+				numCategories := len(siteData.Categories)
+				numPackages := siteData.PackageCount
+				numVersions := 0
+				numLicenses := 0
+				uniqueLicenses := make(map[string]bool)
+				for _, cat := range siteData.Categories {
+					for _, pkg := range cat.Packages {
+						numVersions += len(pkg.Versions)
+						for _, v := range pkg.Versions {
+							if v.Ebuild != nil && v.Ebuild.Vars != nil {
+								licStr := v.Ebuild.Vars["LICENSE"]
+								if licStr != "" {
+									lics := g2.ParseLicense(licStr)
+									for _, l := range lics {
+										if l != "" {
+											uniqueLicenses[l] = true
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				numLicenses = len(uniqueLicenses)
+				numEclasses := len(siteData.DefinedEclasses)
+				numProfiles := len(siteData.Profiles)
+				numNews := len(siteData.News)
+
+				log.Printf("[STATS] Domain Objects - Repos: 1, Categories: %d, Packages: %d, Ebuilds: %d, Profiles: %d, Eclasses: %d, News: %d, Licenses: %d", numCategories, numPackages, numVersions, numProfiles, numEclasses, numNews, numLicenses)
+
 				log.Printf("[STATS] Heap Objects: %d, Alloc: %.2f MB, Total Alloc: %.2f MB, Sys: %.2f MB, NumGC: %d",
 					memStatsAfter.HeapObjects,
 					float64(memStatsAfter.Alloc)/(1024*1024),

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -4253,6 +4253,16 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 				)
 			}
 
+			if concurrency == 1 {
+				log.Printf("[STATS] Heap Objects: %d, Alloc: %.2f MB, Total Alloc: %.2f MB, Sys: %.2f MB, NumGC: %d",
+					memStatsAfter.HeapObjects,
+					float64(memStatsAfter.Alloc)/(1024*1024),
+					float64(memStatsAfter.TotalAlloc)/(1024*1024),
+					float64(memStatsAfter.Sys)/(1024*1024),
+					memStatsAfter.NumGC,
+				)
+			}
+
 			siteData.CheckoutTime = checkoutTime.String()
 			siteData.ProcessTime = processTime.String()
 			siteData.GitSize = gitSize

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -141,6 +142,18 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 					} else {
 						log.Printf("[DONE] Finished parsing repository %s", repoName)
 					}
+
+						if *concurrency == 1 {
+							var memStats runtime.MemStats
+							runtime.ReadMemStats(&memStats)
+							log.Printf("[STATS] Heap Objects: %d, Alloc: %.2f MB, Total Alloc: %.2f MB, Sys: %.2f MB, NumGC: %d",
+								memStats.HeapObjects,
+								float64(memStats.Alloc)/(1024*1024),
+								float64(memStats.TotalAlloc)/(1024*1024),
+								float64(memStats.Sys)/(1024*1024),
+								memStats.NumGC,
+							)
+						}
 
 					sitesMu.Lock()
 					sites = append(sites, siteData)

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -144,6 +144,36 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 					}
 
 						if *concurrency == 1 {
+							numCategories := len(siteData.Categories)
+							numPackages := siteData.PackageCount
+							numVersions := 0
+							numLicenses := 0
+							uniqueLicenses := make(map[string]bool)
+							for _, cat := range siteData.Categories {
+								for _, pkg := range cat.Packages {
+									numVersions += len(pkg.Versions)
+									for _, v := range pkg.Versions {
+										if v.Ebuild != nil && v.Ebuild.Vars != nil {
+											licStr := v.Ebuild.Vars["LICENSE"]
+											if licStr != "" {
+												lics := g2.ParseLicense(licStr)
+												for _, l := range lics {
+													if l != "" {
+														uniqueLicenses[l] = true
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+							numLicenses = len(uniqueLicenses)
+							numEclasses := len(siteData.DefinedEclasses)
+							numProfiles := len(siteData.Profiles)
+							numNews := len(siteData.News)
+
+							log.Printf("[STATS] Domain Objects - Repos: 1, Categories: %d, Packages: %d, Ebuilds: %d, Profiles: %d, Eclasses: %d, News: %d, Licenses: %d", numCategories, numPackages, numVersions, numProfiles, numEclasses, numNews, numLicenses)
+
 							var memStats runtime.MemStats
 							runtime.ReadMemStats(&memStats)
 							log.Printf("[STATS] Heap Objects: %d, Alloc: %.2f MB, Total Alloc: %.2f MB, Sys: %.2f MB, NumGC: %d",


### PR DESCRIPTION
Log object stats like `HeapObjects` and `Alloc` after every repository is successfully parsed when `-concurrency=1` is provided.

---
*PR created automatically by Jules for task [15036996173284028646](https://jules.google.com/task/15036996173284028646) started by @arran4*