### PR TITLE
feat: allow specifying custom temporary directory for site generation

### DIFF
--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -70,7 +70,7 @@ func giteaUrlConverter(gitUrl string) (string, error) {
 	return fmt.Sprintf("https://%s%s/archive/HEAD.zip", u.Host, path), nil
 }
 
-func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool, persistent bool, retries int) error {
+func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool, workMode string, retries int) error {
 	var err error
 	for i := 0; i <= retries; i++ {
 		if i > 0 {
@@ -78,7 +78,7 @@ func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool, 
 			_ = os.RemoveAll(destDir)
 			time.Sleep(1 * time.Second)
 		}
-		err = fetchRepoAttempt(ctx, gitUrl, destDir, useZip, persistent)
+		err = fetchRepoAttempt(ctx, gitUrl, destDir, useZip, workMode)
 		if err == nil {
 			return nil
 		}
@@ -126,8 +126,8 @@ type osWriteFS struct{}
 func (osWriteFS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
 func (osWriteFS) Create(name string) (io.WriteCloser, error)   { return os.Create(name) }
 
-func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip bool, persistent bool) error {
-	if persistent {
+func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip bool, workMode string) error {
+	if workMode == "persistent" {
 		gitDir := filepath.Join(destDir, ".git")
 		if info, err := os.Stat(gitDir); err == nil && info.IsDir() {
 			err := updatePersistentRepo(ctx, destDir)

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -220,7 +220,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	recentDurOpt := fs.String("recent-duration", "3mo", "Duration to consider an update 'recent' (e.g. 3mo, 14d, 72h)")
 	fastGit := fs.Bool("fast-git-modtime", false, "Use fast (O(1)) but potentially less reliable go-git file log lookup")
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
-	mode := fs.String("mode", "persistent", "Clone mode: 'persistent' or 'temp'")
+	workMode := fs.String("work-mode", "persistent", "Work mode: 'persistent' or 'temp'")
 	persistentDir := fs.String("persistent-dir", getDefaultCacheDir(), "Directory to persistently store checked out repositories instead of a temporary directory")
 	tempDir := fs.String("temp-dir", "", "Directory to use for temporary files instead of the default")
 	includeGentoo := fs.Bool("include-gentoo", false, "Include the base Gentoo repository")
@@ -303,7 +303,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 				var tmpDir string
 				var err error
 
-				if *mode == "persistent" {
+				if *workMode == "persistent" {
 					tmpDir = filepath.Join(*persistentDir, task.Name)
 					if err := os.MkdirAll(tmpDir, 0755); err != nil {
 						return fmt.Errorf("creating persistent dir for %s: %w", task.Name, err)
@@ -323,7 +323,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 				defer cancel()
 
 				t0 := time.Now()
-				if err := FetchRepo(ctx, task.Location, tmpDir, *useZip, *mode == "persistent", 0); err != nil {
+				if err := FetchRepo(ctx, task.Location, tmpDir, *useZip, *workMode == "persistent", 0); err != nil {
 					return fmt.Errorf("cloning repository %s: %w", task.Name, err)
 				}
 				checkoutTime := time.Since(t0)
@@ -432,7 +432,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	concurrency := fs.Int("concurrency", 4, "Maximum number of concurrent repository fetches/parses")
 	retries := fs.Int("retries", 3, "Number of times to retry fetching a repository")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue parsing other repositories even if fetching one fails")
-	mode := fs.String("mode", "persistent", "Clone mode: 'persistent' or 'temp'")
+	workMode := fs.String("work-mode", "persistent", "Work mode: 'persistent' or 'temp'")
 	persistentDir := fs.String("persistent-dir", getDefaultCacheDir(), "Directory to persistently store checked out repositories instead of a temporary directory")
 	tempDir := fs.String("temp-dir", "", "Directory to use for temporary files instead of the default")
 	reposConfOpt := fs.String("repos-conf", "", "Path to repos.conf file or directory")
@@ -461,7 +461,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	}
 
 	log.Printf("Generating site (v%s) from remote repositories: %s into %s", version, location, *outDir)
-	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError, *persistentDir, *reposConfOpt, *tempDir, *mode)
+	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError, *persistentDir, *reposConfOpt, *tempDir, *workMode)
 }
 
 func parseLayoutConfFromFS(sysFS fs.FS, path string) (*g2.LayoutConf, error) {
@@ -3907,7 +3907,7 @@ func renderPage(path string, tmpl *template.Template, name string, data interfac
 	return nil
 }
 
-func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool, persistentDir string, reposConfPath string, tempDir string, mode string) error {
+func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool, persistentDir string, reposConfPath string, tempDir string, workMode string) error {
 	var repos g2.Repositories
 
 	if reposConfPath != "" {
@@ -3979,7 +3979,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	var tmpDir string
 	var cleanup func()
 
-	if mode == "persistent" {
+	if workMode == "persistent" {
 		tmpDir = persistentDir
 		if err := os.MkdirAll(tmpDir, 0755); err != nil {
 			return fmt.Errorf("creating persistent dir: %w", err)
@@ -4040,7 +4040,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			defer cancel()
 
 			t0 := time.Now()
-			if err := FetchRepo(ctx, gitUrl, repoPath, useZip, mode == "persistent", retries); err != nil {
+			if err := FetchRepo(ctx, gitUrl, repoPath, useZip, workMode == "persistent", retries); err != nil {
 				log.Printf("Failed to fetch %s: %v", repo.Name, err)
 				if !continueOnError {
 					return fmt.Errorf("fetching %s: %w", repo.Name, err)

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -213,6 +213,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	fastGit := fs.Bool("fast-git-modtime", false, "Use fast (O(1)) but potentially less reliable go-git file log lookup")
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
 	persistentDir := fs.String("persistent-dir", "", "Directory to persistently store checked out repositories instead of a temporary directory")
+	tempDir := fs.String("temp-dir", "", "Directory to use for temporary files instead of the default")
 	includeGentoo := fs.Bool("include-gentoo", false, "Include the base Gentoo repository")
 	includeGuru := fs.Bool("include-guru", false, "Include the Guru repository")
 	reposConfOpt := fs.String("repos-conf", "", "Path to repos.conf file or directory")
@@ -300,7 +301,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 					}
 					cleanup = func() {}
 				} else {
-					tmpDir, err = os.MkdirTemp("", "g2-overlay-"+task.Name+"-*")
+					tmpDir, err = os.MkdirTemp(*tempDir, "g2-overlay-"+task.Name+"-*")
 					if err != nil {
 						return fmt.Errorf("creating temp dir for %s: %w", task.Name, err)
 					}
@@ -423,6 +424,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	retries := fs.Int("retries", 3, "Number of times to retry fetching a repository")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue parsing other repositories even if fetching one fails")
 	persistentDir := fs.String("persistent-dir", "", "Directory to persistently store checked out repositories instead of a temporary directory")
+	tempDir := fs.String("temp-dir", "", "Directory to use for temporary files instead of the default")
 	reposConfOpt := fs.String("repos-conf", "", "Path to repos.conf file or directory")
 
 	if err := fs.Parse(args[2:]); err != nil {
@@ -449,7 +451,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	}
 
 	log.Printf("Generating site (v%s) from remote repositories: %s into %s", version, location, *outDir)
-	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError, *persistentDir, *reposConfOpt)
+	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError, *persistentDir, *reposConfOpt, *tempDir)
 }
 
 func parseLayoutConfFromFS(sysFS fs.FS, path string) (*g2.LayoutConf, error) {
@@ -3895,7 +3897,7 @@ func renderPage(path string, tmpl *template.Template, name string, data interfac
 	return nil
 }
 
-func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool, persistentDir string, reposConfPath string) error {
+func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool, persistentDir string, reposConfPath string, tempDir string) error {
 	var repos g2.Repositories
 
 	if reposConfPath != "" {
@@ -3975,7 +3977,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 		cleanup = func() {}
 	} else {
 		var err error
-		tmpDir, err = os.MkdirTemp("", "g2-sitegen-*")
+		tmpDir, err = os.MkdirTemp(tempDir, "g2-sitegen-*")
 		if err != nil {
 			return fmt.Errorf("creating temp dir: %w", err)
 		}
@@ -4038,7 +4040,11 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			checkoutTime := time.Since(t0)
 			freeSpace, err := getFreeSpace(repoPath)
 			appFreeSpace, appErr := getFreeSpace(".")
-			tmpFreeSpace, tmpErr := getFreeSpace(os.TempDir())
+			actualTempDir := tempDir
+			if actualTempDir == "" {
+				actualTempDir = os.TempDir()
+			}
+			tmpFreeSpace, tmpErr := getFreeSpace(actualTempDir)
 			freeMem, memErr := getFreeMemory()
 			procMem := getProcessMemUsage()
 
@@ -4146,7 +4152,11 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			processTime := time.Since(t1)
 			freeSpaceAfter, err := getFreeSpace(repoPath)
 			appFreeSpaceAfter, appErrAfter := getFreeSpace(".")
-			tmpFreeSpaceAfter, tmpErrAfter := getFreeSpace(os.TempDir())
+			actualTempDirAfter := tempDir
+			if actualTempDirAfter == "" {
+				actualTempDirAfter = os.TempDir()
+			}
+			tmpFreeSpaceAfter, tmpErrAfter := getFreeSpace(actualTempDirAfter)
 			freeMemAfter, memErrAfter := getFreeMemory()
 			procMemAfter := getProcessMemUsage()
 
@@ -4314,7 +4324,11 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 
 	finalMemUsage := getProcessMemUsage()
 	appFreeSpaceFinal, appErrFinal := getFreeSpace(".")
-	tmpFreeSpaceFinal, tmpErrFinal := getFreeSpace(os.TempDir())
+	actualTempDirFinal := tempDir
+	if actualTempDirFinal == "" {
+		actualTempDirFinal = os.TempDir()
+	}
+	tmpFreeSpaceFinal, tmpErrFinal := getFreeSpace(actualTempDirFinal)
 	log.Printf("--------------------------------------------------")
 	log.Printf("[FINAL SUMMARY] Repository Processing Complete")
 	log.Printf("Total Repositories:      %d", len(allSites))

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -323,7 +323,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 				defer cancel()
 
 				t0 := time.Now()
-				if err := FetchRepo(ctx, task.Location, tmpDir, *useZip, *workMode == "persistent", 0); err != nil {
+				if err := FetchRepo(ctx, task.Location, tmpDir, *useZip, *workMode, 0); err != nil {
 					return fmt.Errorf("cloning repository %s: %w", task.Name, err)
 				}
 				checkoutTime := time.Since(t0)
@@ -4040,7 +4040,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			defer cancel()
 
 			t0 := time.Now()
-			if err := FetchRepo(ctx, gitUrl, repoPath, useZip, workMode == "persistent", retries); err != nil {
+			if err := FetchRepo(ctx, gitUrl, repoPath, useZip, workMode, retries); err != nil {
 				log.Printf("Failed to fetch %s: %v", repo.Name, err)
 				if !continueOnError {
 					return fmt.Errorf("fetching %s: %w", repo.Name, err)

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -176,6 +176,14 @@ type VersionData struct {
 
 // End model TODO check
 
+func getDefaultCacheDir() string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil || cacheDir == "" {
+		return filepath.Join(os.TempDir(), "g2-cache")
+	}
+	return filepath.Join(cacheDir, "g2")
+}
+
 func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	ebuild.SkipForSiteGen = true
 	if len(args) < 1 {
@@ -212,7 +220,8 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	recentDurOpt := fs.String("recent-duration", "3mo", "Duration to consider an update 'recent' (e.g. 3mo, 14d, 72h)")
 	fastGit := fs.Bool("fast-git-modtime", false, "Use fast (O(1)) but potentially less reliable go-git file log lookup")
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
-	persistentDir := fs.String("persistent-dir", "", "Directory to persistently store checked out repositories instead of a temporary directory")
+	mode := fs.String("mode", "persistent", "Clone mode: 'persistent' or 'temp'")
+	persistentDir := fs.String("persistent-dir", getDefaultCacheDir(), "Directory to persistently store checked out repositories instead of a temporary directory")
 	tempDir := fs.String("temp-dir", "", "Directory to use for temporary files instead of the default")
 	includeGentoo := fs.Bool("include-gentoo", false, "Include the base Gentoo repository")
 	includeGuru := fs.Bool("include-guru", false, "Include the Guru repository")
@@ -294,7 +303,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 				var tmpDir string
 				var err error
 
-				if *persistentDir != "" {
+				if *mode == "persistent" {
 					tmpDir = filepath.Join(*persistentDir, task.Name)
 					if err := os.MkdirAll(tmpDir, 0755); err != nil {
 						return fmt.Errorf("creating persistent dir for %s: %w", task.Name, err)
@@ -314,7 +323,7 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 				defer cancel()
 
 				t0 := time.Now()
-				if err := FetchRepo(ctx, task.Location, tmpDir, *useZip, *persistentDir != "", 0); err != nil {
+				if err := FetchRepo(ctx, task.Location, tmpDir, *useZip, *mode == "persistent", 0); err != nil {
 					return fmt.Errorf("cloning repository %s: %w", task.Name, err)
 				}
 				checkoutTime := time.Since(t0)
@@ -423,7 +432,8 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	concurrency := fs.Int("concurrency", 4, "Maximum number of concurrent repository fetches/parses")
 	retries := fs.Int("retries", 3, "Number of times to retry fetching a repository")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue parsing other repositories even if fetching one fails")
-	persistentDir := fs.String("persistent-dir", "", "Directory to persistently store checked out repositories instead of a temporary directory")
+	mode := fs.String("mode", "persistent", "Clone mode: 'persistent' or 'temp'")
+	persistentDir := fs.String("persistent-dir", getDefaultCacheDir(), "Directory to persistently store checked out repositories instead of a temporary directory")
 	tempDir := fs.String("temp-dir", "", "Directory to use for temporary files instead of the default")
 	reposConfOpt := fs.String("repos-conf", "", "Path to repos.conf file or directory")
 
@@ -451,7 +461,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	}
 
 	log.Printf("Generating site (v%s) from remote repositories: %s into %s", version, location, *outDir)
-	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError, *persistentDir, *reposConfOpt, *tempDir)
+	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError, *persistentDir, *reposConfOpt, *tempDir, *mode)
 }
 
 func parseLayoutConfFromFS(sysFS fs.FS, path string) (*g2.LayoutConf, error) {
@@ -3897,7 +3907,7 @@ func renderPage(path string, tmpl *template.Template, name string, data interfac
 	return nil
 }
 
-func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool, persistentDir string, reposConfPath string, tempDir string) error {
+func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool, persistentDir string, reposConfPath string, tempDir string, mode string) error {
 	var repos g2.Repositories
 
 	if reposConfPath != "" {
@@ -3969,7 +3979,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	var tmpDir string
 	var cleanup func()
 
-	if persistentDir != "" {
+	if mode == "persistent" {
 		tmpDir = persistentDir
 		if err := os.MkdirAll(tmpDir, 0755); err != nil {
 			return fmt.Errorf("creating persistent dir: %w", err)
@@ -4030,7 +4040,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			defer cancel()
 
 			t0 := time.Now()
-			if err := FetchRepo(ctx, gitUrl, repoPath, useZip, persistentDir != "", retries); err != nil {
+			if err := FetchRepo(ctx, gitUrl, repoPath, useZip, mode == "persistent", retries); err != nil {
 				log.Printf("Failed to fetch %s: %v", repo.Name, err)
 				if !continueOnError {
 					return fmt.Errorf("fetching %s: %w", repo.Name, err)


### PR DESCRIPTION
Added a `-temp-dir` flag to `overlay site generate` and `overlays site generate` commands to allow users to override the system default temporary directory when cloning repositories.

---
*PR created automatically by Jules for task [15425427180103090151](https://jules.google.com/task/15425427180103090151) started by @arran4*