### PR TITLE
Add repo context to ebuild parser warnings

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1047,8 +1047,12 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 				ebuildPath := filepath.Join(pkgPath, file.Name())
 				ebuild, err := g2.ParseEbuild(sysFS, filepath.ToSlash(ebuildPath), g2.ParseFull)
 				if err != nil {
-					log.Printf("Warning: parsing ebuild %s: %v", ebuildPath, err)
+					log.Printf("Warning: parsing ebuild %s in repo %s: %v", ebuildPath, repoInfo.Name, err)
 					continue
+				}
+
+				for _, w := range ebuild.ParseWarnings {
+					log.Printf("Warning: parsing ebuild %s in repo %s: %v", ebuildPath, repoInfo.Name, w)
 				}
 
 				version := ""
@@ -1391,8 +1395,11 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 					ebuild, err := g2.ParseEbuild(sysFS, filepath.ToSlash(filepath.Join(eclassDir, e.Name())), g2.ParseFull)
 					if err == nil {
 						site.Eclasses = append(site.Eclasses, ebuild)
+						for _, w := range ebuild.ParseWarnings {
+							log.Printf("Warning: parsing eclass %s in repo %s: %v", e.Name(), repoInfo.Name, w)
+						}
 					} else {
-						log.Printf("Warning: failed to parse eclass %s: %v", e.Name(), err)
+						log.Printf("Warning: failed to parse eclass %s in repo %s: %v", e.Name(), repoInfo.Name, err)
 					}
 				}
 			}

--- a/ebuild_parser.go
+++ b/ebuild_parser.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"strings"
 	"unicode"
 )
@@ -528,7 +527,6 @@ func (p *EbuildParser) consumeFunctionBody() (string, error) {
 	if r != '{' {
 		if r == '(' {
 			msg := "expected '{' for function body but found '(', treating as subshell body"
-			log.Printf("Warning: parsing ebuild variables: %s", msg)
 			p.Warnings = append(p.Warnings, msg)
 			opener = '('
 			closer = ')'


### PR DESCRIPTION
Removed direct logging in the ebuild parser and instead iterated over the parse warnings in the caller (`cmd/g2/site.go`) so that the warnings can be logged with the correct ebuild path and repository name context.

---
*PR created automatically by Jules for task [17979524666756236852](https://jules.google.com/task/17979524666756236852) started by @arran4*