### PR TITLE
Fix template context panics in package_picker and index.html

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1724,6 +1724,11 @@ type AggPackage struct {
 	ReverseVirtuals     []string
 	VirtualDeps         []string
 }
+
+func (a *AggPackage) ReposList() []*SiteData {
+	return mapToList(a.Repos)
+}
+
 type AggProject struct {
 	Project  *g2.Project
 	Packages []*AggPackage

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -579,7 +579,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					"Title":       "Package: " + pkg.Category + "/" + pkg.Name,
 					"BaseURL":     baseURL,
 					"Breadcrumbs": []Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Packages", URL: "../../"}, {Name: pkg.Category, URL: "../../../categories/" + pkg.Category + "/"}, {Name: pkg.Name}},
-					"Package":     map[string]interface{}{"Category": pkg.Category, "Name": pkg.Name, "ReposList": reposList},
+					"GlobalPackage": pkg,
 					"Version":     version,
 					"GenInfo":     s.GenInfo,
 				})

--- a/cmd/g2/template_render_test.go
+++ b/cmd/g2/template_render_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+    "github.com/arran4/g2"
+)
+
+func TestAllTemplatesRender(t *testing.T) {
+	tmpl, err := GetSiteTemplates()
+	if err != nil {
+		t.Fatalf("failed to get templates: %v", err)
+	}
+
+	templates := tmpl.Templates()
+
+	for _, tpl := range templates {
+		name := tpl.Name()
+		if name == "layout_header.html" || name == "layout_footer.html" || name == "" {
+			continue
+		}
+        // we skip layout files, test only views
+        // to find what's wrong with them
+
+		t.Run(name, func(t *testing.T) {
+            data := GenericPageContext{}
+            // populate it with some dummy data to avoid nil pointer derefs
+            data.GlobalPackage = &AggPackage{}
+            data.RepoPackage = &PackageData{}
+            data.Project = &AggProject{Project: &g2.Project{}}
+            data.RepoCategory = &CategoryData{}
+            data.Category = map[string]interface{}{}
+            data.GlobalProfile = &g2.AggProfile{}
+            data.RepoProfile = &g2.ProfileData{}
+            data.Group = &RepoGroup{}
+            data.GlobalUseFlag = &AggUseFlag{}
+            data.License = &AggLicense{}
+            data.Arch = &AggArch{}
+            data.Repo = &SiteData{}
+            data.Manifest = &ManifestEntryData{
+                Entry: &g2.ManifestEntry{},
+            }
+            data.VersionData = &VersionData{
+                Ebuild: &g2.Ebuild{
+                    Vars: map[string]string{},
+                },
+            }
+            data.Eclass = &AggEclass{}
+            data.UseExpandDesc = &g2.UseExpandDesc{}
+
+			var buf bytes.Buffer
+			err := tpl.Execute(&buf, data)
+			if err != nil {
+				t.Logf("template %s failed to render: %v", name, err)
+                t.Fail()
+			}
+		})
+	}
+}

--- a/templates/views/index.html
+++ b/templates/views/index.html
@@ -13,14 +13,14 @@
 
 <h2>Categories</h2>
 <ul>
-    {{range .Categories}}
+    {{range .GlobalCategories}}
     <li><a href="categories/{{.Name}}/">{{.Name}}</a></li>
     {{end}}
 </ul>
 
 <h2>All Packages</h2>
 <ul>
-    {{range .AllPackages}}
+    {{range .GlobalPackages}}
     <li><a href="packages/{{.Name}}/">{{.Category}}/{{.Name}}</a></li>
     {{end}}
 </ul>

--- a/templates/views/package_picker.html
+++ b/templates/views/package_picker.html
@@ -1,5 +1,5 @@
 
-<h2>Package: {{.RepoPackage.Category}}/{{.RepoPackage.Name}}</h2>
+<h2>Package: {{.GlobalPackage.Category}}/{{.GlobalPackage.Name}}</h2>
 {{if .MovedToName}}
 <div class="alert alert-warning">
     <strong>Notice:</strong> Older versions of this package were moved to <a href="{{.MovedToURL}}">{{.MovedToName}}</a>.
@@ -7,7 +7,7 @@
 {{end}}
 <p>This package is available in multiple overlays. Please select one:</p>
 <ul>
-    {{range .RepoPackage.ReposList}}
-    <li><a href="{{$.BaseURL}}repos/{{.RepoName}}/categories/{{$.RepoPackage.Category}}/packages/{{$.RepoPackage.Name}}/">{{.RepoName}}</a></li>
+    {{range .GlobalPackage.ReposList}}
+    <li><a href="{{$.BaseURL}}repos/{{.RepoName}}/categories/{{$.GlobalPackage.Category}}/packages/{{$.GlobalPackage.Name}}/">{{.RepoName}}</a></li>
     {{end}}
 </ul>


### PR DESCRIPTION
This PR fixes template context resolution failures leading to `nil pointer` panics in `package_picker.html` and `index.html`. It correctly aligns the view templates with the actual objects they are being passed (`.GlobalPackage`, `.GlobalCategories`, `.GlobalPackages`). To ensure robust templates going forward, a `template_render_test.go` suite was added to execute all layout views sequentially with an initialized structural payload to test for evaluation panics natively.

No backwards incompatible changes, and UI works natively across `g2 site serve`.

---
*PR created automatically by Jules for task [17430125952762620372](https://jules.google.com/task/17430125952762620372) started by @arran4*