### PR TITLE
Remove duplicate assignment warning in ebuild_parser.go

### DIFF
--- a/ebuild_parser.go
+++ b/ebuild_parser.go
@@ -273,8 +273,6 @@ func (p *EbuildParser) Parse() (ParsedEbuild, error) {
 				} else {
 					if _, exists := result.Variables[ident]; !exists {
 						result.Order = append(result.Order, ident)
-					} else {
-						result.Warnings = append(result.Warnings, fmt.Sprintf("Duplicate assignment for variable '%s'", ident))
 					}
 					result.Variables[ident] = val
 				}


### PR DESCRIPTION
Fixes the duplicate assignment warning in `ebuild_parser.go` which happens whenever a variable is assigned twice. Because variables can be reassigned during evaluation and it is valid.

---
*PR created automatically by Jules for task [13918315615769844765](https://jules.google.com/task/13918315615769844765) started by @arran4*