### PR TITLE
🧪 test: Add table-driven tests for ParseNewsItem

### DIFF
--- a/news_parser_test.go
+++ b/news_parser_test.go
@@ -117,38 +117,9 @@ func TestParseNewsItem(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseNewsItem(tt.content)
 
-			// We only want to compare fields populated in our expected struct.
-			// Format 2.0 has BodyAST which we might not want to check in all cases,
-			// but we can check if it's deeply equal.
-			if got.Title != tt.expected.Title {
-				t.Errorf("Title = %v, want %v", got.Title, tt.expected.Title)
-			}
-			if got.Author != tt.expected.Author {
-				t.Errorf("Author = %v, want %v", got.Author, tt.expected.Author)
-			}
-			if !reflect.DeepEqual(got.Translator, tt.expected.Translator) {
-				t.Errorf("Translator = %v, want %v", got.Translator, tt.expected.Translator)
-			}
-			if !got.Posted.Equal(tt.expected.Posted) {
-				t.Errorf("Posted = %v, want %v", got.Posted, tt.expected.Posted)
-			}
-			if got.Revision != tt.expected.Revision {
-				t.Errorf("Revision = %v, want %v", got.Revision, tt.expected.Revision)
-			}
-			if got.NewsItemFormat != tt.expected.NewsItemFormat {
-				t.Errorf("NewsItemFormat = %v, want %v", got.NewsItemFormat, tt.expected.NewsItemFormat)
-			}
-			if !reflect.DeepEqual(got.DisplayIfInstalled, tt.expected.DisplayIfInstalled) {
-				t.Errorf("DisplayIfInstalled = %v, want %v", got.DisplayIfInstalled, tt.expected.DisplayIfInstalled)
-			}
-			if !reflect.DeepEqual(got.DisplayIfKeyword, tt.expected.DisplayIfKeyword) {
-				t.Errorf("DisplayIfKeyword = %v, want %v", got.DisplayIfKeyword, tt.expected.DisplayIfKeyword)
-			}
-			if !reflect.DeepEqual(got.DisplayIfProfile, tt.expected.DisplayIfProfile) {
-				t.Errorf("DisplayIfProfile = %v, want %v", got.DisplayIfProfile, tt.expected.DisplayIfProfile)
-			}
-			if got.Body != tt.expected.Body {
-				t.Errorf("Body = %v, want %v", got.Body, tt.expected.Body)
+			// Verify all fields of the NewsItem struct match the expected values.
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ParseNewsItem() = %#v, want %#v", got, tt.expected)
 			}
 		})
 	}

--- a/news_parser_test.go
+++ b/news_parser_test.go
@@ -1,9 +1,158 @@
 package g2
 
 import (
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestParseNewsItem(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected NewsItem
+	}{
+		{
+			name: "Basic Format 1.0",
+			content: "Title: Test News\n" +
+				"Author: Tester <tester@example.com>\n" +
+				"Translator: Trans <trans@example.com>\n" +
+				"Posted: 2023-01-01\n" +
+				"Revision: 1\n" +
+				"News-Item-Format: 1.0\n" +
+				"Display-If-Installed: app-misc/foo\n" +
+				"Display-If-Keyword: amd64\n" +
+				"Display-If-Profile: default/linux/amd64/17.1\n" +
+				"\n" +
+				"This is the body.\n" +
+				"Line 2.",
+			expected: NewsItem{
+				Title:              "Test News",
+				Author:             "Tester",
+				Translator:         []string{"Trans"},
+				Posted:             time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				Revision:           "1",
+				NewsItemFormat:     "1.0",
+				DisplayIfInstalled: []string{"app-misc/foo"},
+				DisplayIfKeyword:   []string{"amd64"},
+				DisplayIfProfile:   []string{"default/linux/amd64/17.1"},
+				Body:               "This is the body.\nLine 2.",
+			},
+		},
+		{
+			name: "Missing Headers",
+			content: "Title: Test News 2\n" +
+				"\n" +
+				"Body only.",
+			expected: NewsItem{
+				Title: "Test News 2",
+				Body:  "Body only.",
+			},
+		},
+		{
+			name: "Multiple Translators and Display Ifs",
+			content: "Title: Multi\n" +
+				"Translator: Trans 1 <t1@example.com>\n" +
+				"Translator: Trans 2 <t2@example.com>\n" +
+				"Display-If-Installed: app-misc/foo\n" +
+				"Display-If-Installed: app-misc/bar\n" +
+				"Display-If-Keyword: amd64\n" +
+				"Display-If-Keyword: x86\n" +
+				"Display-If-Profile: p1\n" +
+				"Display-If-Profile: p2\n" +
+				"\n" +
+				"Body.",
+			expected: NewsItem{
+				Title:              "Multi",
+				Translator:         []string{"Trans 1", "Trans 2"},
+				DisplayIfInstalled: []string{"app-misc/foo", "app-misc/bar"},
+				DisplayIfKeyword:   []string{"amd64", "x86"},
+				DisplayIfProfile:   []string{"p1", "p2"},
+				Body:               "Body.",
+			},
+		},
+		{
+			name: "Invalid Date",
+			content: "Title: Invalid Date\n" +
+				"Posted: invalid-date\n" +
+				"\n" +
+				"Body.",
+			expected: NewsItem{
+				Title: "Invalid Date",
+				Body:  "Body.",
+			},
+		},
+		{
+			name: "Invalid Header Format",
+			content: "Title: No Colon Format\n" +
+				"InvalidHeaderNoColon\n" +
+				"Author: Tester\n" +
+				"\n" +
+				"Body.",
+			expected: NewsItem{
+				Title:  "No Colon Format",
+				Author: "Tester",
+				Body:   "Body.",
+			},
+		},
+		{
+			name: "Empty File",
+			content: "",
+			expected: NewsItem{
+				Body: "",
+			},
+		},
+		{
+			name: "No Body",
+			content: "Title: No Body\n",
+			expected: NewsItem{
+				Title: "No Body",
+				Body:  "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseNewsItem(tt.content)
+
+			// We only want to compare fields populated in our expected struct.
+			// Format 2.0 has BodyAST which we might not want to check in all cases,
+			// but we can check if it's deeply equal.
+			if got.Title != tt.expected.Title {
+				t.Errorf("Title = %v, want %v", got.Title, tt.expected.Title)
+			}
+			if got.Author != tt.expected.Author {
+				t.Errorf("Author = %v, want %v", got.Author, tt.expected.Author)
+			}
+			if !reflect.DeepEqual(got.Translator, tt.expected.Translator) {
+				t.Errorf("Translator = %v, want %v", got.Translator, tt.expected.Translator)
+			}
+			if !got.Posted.Equal(tt.expected.Posted) {
+				t.Errorf("Posted = %v, want %v", got.Posted, tt.expected.Posted)
+			}
+			if got.Revision != tt.expected.Revision {
+				t.Errorf("Revision = %v, want %v", got.Revision, tt.expected.Revision)
+			}
+			if got.NewsItemFormat != tt.expected.NewsItemFormat {
+				t.Errorf("NewsItemFormat = %v, want %v", got.NewsItemFormat, tt.expected.NewsItemFormat)
+			}
+			if !reflect.DeepEqual(got.DisplayIfInstalled, tt.expected.DisplayIfInstalled) {
+				t.Errorf("DisplayIfInstalled = %v, want %v", got.DisplayIfInstalled, tt.expected.DisplayIfInstalled)
+			}
+			if !reflect.DeepEqual(got.DisplayIfKeyword, tt.expected.DisplayIfKeyword) {
+				t.Errorf("DisplayIfKeyword = %v, want %v", got.DisplayIfKeyword, tt.expected.DisplayIfKeyword)
+			}
+			if !reflect.DeepEqual(got.DisplayIfProfile, tt.expected.DisplayIfProfile) {
+				t.Errorf("DisplayIfProfile = %v, want %v", got.DisplayIfProfile, tt.expected.DisplayIfProfile)
+			}
+			if got.Body != tt.expected.Body {
+				t.Errorf("Body = %v, want %v", got.Body, tt.expected.Body)
+			}
+		})
+	}
+}
 
 func TestParseNewsItem_Format2(t *testing.T) {
 	raw := `Title: Update defaults for various mail packages


### PR DESCRIPTION
🎯 **What:** The untested `ParseNewsItem` function in `news_parser.go` lacked explicit coverage for its 1.0 format edge cases and individual fields.
📊 **Coverage:** Added a table-driven test suite (`TestParseNewsItem`) covering:
- Happy path (Basic Format 1.0)
- Missing headers
- Multiple occurrences of headers (Translators, Display-If-Installed, Display-If-Keyword, Display-If-Profile)
- Invalid date formats
- Invalid header formats (missing colon)
- Empty files and missing body
✨ **Result:** Improved test coverage and reliability for parsing Gentoo news items (GLEP 42), ensuring all edge cases are explicitly verified and potential regressions can be caught early.

---
*PR created automatically by Jules for task [12430964550442392407](https://jules.google.com/task/12430964550442392407) started by @arran4*