### PR TITLE
🔒 Warn when unencrypted HTTP is used for package search or updates

### DIFF
--- a/cmd/g2/package.go
+++ b/cmd/g2/package.go
@@ -121,7 +121,7 @@ func (cfg *CmdPackageArgConfig) cmdSearch(args []string) error {
 	engine := NewSearchEngine()
 
 	// Handle loading logic based on type
-	if strings.HasPrefix(searchPath, "http://") || strings.HasPrefix(searchPath, "https://") {
+	if strings.HasPrefix(strings.ToLower(searchPath), "http://") || strings.HasPrefix(strings.ToLower(searchPath), "https://") {
 		// Load from URL
 		// For simplicity we try to fetch manifest.json then data files
 		u, err := url.Parse(searchPath)

--- a/cmd/g2/package.go
+++ b/cmd/g2/package.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,6 +124,13 @@ func (cfg *CmdPackageArgConfig) cmdSearch(args []string) error {
 	if strings.HasPrefix(searchPath, "http://") || strings.HasPrefix(searchPath, "https://") {
 		// Load from URL
 		// For simplicity we try to fetch manifest.json then data files
+		u, err := url.Parse(searchPath)
+		if err != nil {
+			return fmt.Errorf("parsing search path url: %w", err)
+		}
+		if u.Scheme == "http" {
+			log.Printf("WARNING: Using unencrypted HTTP for search index could expose data or allow MITM attacks: %s", searchPath)
+		}
 
 		manifestURL := fmt.Sprintf("%s/data/manifest.json", strings.TrimRight(searchPath, "/"))
 		resp, err := http.Get(manifestURL)
@@ -585,6 +593,14 @@ func (cfg *CmdPackageArgConfig) cmdUpdate(args []string) error {
 	}
 
 	log.Printf("Updating search index from %s to %s", *urlOpt, *outDir)
+
+	u, err := url.Parse(*urlOpt)
+	if err != nil {
+		return fmt.Errorf("parsing search url: %w", err)
+	}
+	if u.Scheme == "http" {
+		log.Printf("WARNING: Using unencrypted HTTP for search update could expose data or allow MITM attacks: %s", *urlOpt)
+	}
 
 	resp, err := http.Get(*urlOpt)
 	if err != nil {

--- a/cmd/g2/package.go
+++ b/cmd/g2/package.go
@@ -592,8 +592,6 @@ func (cfg *CmdPackageArgConfig) cmdUpdate(args []string) error {
 		*outDir = fmt.Sprintf("%s/g2/search", cacheconfig.GetCacheDir())
 	}
 
-	log.Printf("Updating search index from %s to %s", *urlOpt, *outDir)
-
 	u, err := url.Parse(*urlOpt)
 	if err != nil {
 		return fmt.Errorf("parsing search url: %w", err)
@@ -601,6 +599,8 @@ func (cfg *CmdPackageArgConfig) cmdUpdate(args []string) error {
 	if u.Scheme == "http" {
 		log.Printf("WARNING: Using unencrypted HTTP for search update could expose data or allow MITM attacks: %s", *urlOpt)
 	}
+
+	log.Printf("Updating search index from %s to %s", *urlOpt, *outDir)
 
 	resp, err := http.Get(*urlOpt)
 	if err != nil {


### PR DESCRIPTION
🎯 **What:** The user-provided `path` and `url` command-line flags in the package search/update tool were being passed directly into `http.Get()` without validation. This commit adds a validation step (`url.Parse`) and logs a warning when the `http` scheme is used.

⚠️ **Risk:** While primarily a CLI tool, passing unvalidated URLs to `http.Get()` could be exploited if it's integrated as part of an automated pipeline, allowing attackers to issue unauthorized HTTP requests on an internal network (SSRF) or expose sensitive data via a MITM attack due to the unencrypted connection.

🛡️ **Solution:** The change ensures that the URLs provided are properly parsed, and if an unencrypted connection (`http`) is detected, a prominent warning is emitted via `log.Printf` before performing the network request. This is done for both `cmdSearch` and `cmdUpdate`.

---
*PR created automatically by Jules for task [9508024068899763752](https://jules.google.com/task/9508024068899763752) started by @arran4*