### PR TITLE
🔒 Fix XSS vulnerability in `formatKeywordsFunc` template formatting

### DIFF
--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -36,19 +36,24 @@ func formatKeywordsFunc(keywords string, baseURL string) template.HTML {
 	}
 	parts := strings.Fields(keywords)
 	var formatted []string
+	safeBaseURL := template.HTMLEscapeString(baseURL)
 	for _, p := range parts {
 		if strings.HasPrefix(p, "-") {
-			formatted = append(formatted, p)
+			formatted = append(formatted, template.HTMLEscapeString(p))
 			continue
 		}
 
 		arch := p
+		prefix := ""
 		if strings.HasPrefix(p, "~") {
 			arch = p[1:]
-			formatted = append(formatted, fmt.Sprintf("~<a href=\"%sarches/%s/\" class=\"text-decoration-none\">%s</a>", baseURL, arch, arch))
-		} else {
-			formatted = append(formatted, fmt.Sprintf("<a href=\"%sarches/%s/\" class=\"text-decoration-none\">%s</a>", baseURL, arch, arch))
+			prefix = "~"
 		}
+
+		safeArchText := template.HTMLEscapeString(arch)
+		safeArchURL := url.PathEscape(arch)
+
+		formatted = append(formatted, fmt.Sprintf("%s<a href=\"%sarches/%s/\" class=\"text-decoration-none\">%s</a>", prefix, safeBaseURL, safeArchURL, safeArchText))
 	}
 	return template.HTML(strings.Join(formatted, " "))
 }

--- a/cmd/g2/template_funcs_test.go
+++ b/cmd/g2/template_funcs_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"html/template"
+	"testing"
+)
+
+func TestFormatKeywordsFunc(t *testing.T) {
+	tests := []struct {
+		name     string
+		keywords string
+		baseURL  string
+		expected template.HTML
+	}{
+		{
+			name:     "empty keywords",
+			keywords: "",
+			baseURL:  "/",
+			expected: template.HTML(""),
+		},
+		{
+			name:     "simple keywords",
+			keywords: "amd64 x86",
+			baseURL:  "/",
+			expected: template.HTML("<a href=\"/arches/amd64/\" class=\"text-decoration-none\">amd64</a> <a href=\"/arches/x86/\" class=\"text-decoration-none\">x86</a>"),
+		},
+		{
+			name:     "keywords with tilde",
+			keywords: "~amd64 x86",
+			baseURL:  "/",
+			expected: template.HTML("~<a href=\"/arches/amd64/\" class=\"text-decoration-none\">amd64</a> <a href=\"/arches/x86/\" class=\"text-decoration-none\">x86</a>"),
+		},
+		{
+			name:     "keywords with minus",
+			keywords: "-* amd64",
+			baseURL:  "/",
+			expected: template.HTML("-* <a href=\"/arches/amd64/\" class=\"text-decoration-none\">amd64</a>"),
+		},
+		{
+			name:     "xss in baseURL",
+			keywords: "amd64",
+			baseURL:  "\"><script>alert(1)</script>",
+			expected: template.HTML("<a href=\"&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;arches/amd64/\" class=\"text-decoration-none\">amd64</a>"),
+		},
+		{
+			name:     "xss in arch",
+			keywords: "<script>alert(1)</script>",
+			baseURL:  "/",
+			expected: template.HTML("<a href=\"/arches/%3Cscript%3Ealert%281%29%3C%2Fscript%3E/\" class=\"text-decoration-none\">&lt;script&gt;alert(1)&lt;/script&gt;</a>"),
+		},
+		{
+			name:     "xss in arch with tilde",
+			keywords: "~<script>alert(1)</script>",
+			baseURL:  "/",
+			expected: template.HTML("~<a href=\"/arches/%3Cscript%3Ealert%281%29%3C%2Fscript%3E/\" class=\"text-decoration-none\">&lt;script&gt;alert(1)&lt;/script&gt;</a>"),
+		},
+		{
+			name:     "xss in minus keyword",
+			keywords: "-<script>alert(1)</script>",
+			baseURL:  "/",
+			expected: template.HTML("-&lt;script&gt;alert(1)&lt;/script&gt;"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatKeywordsFunc(tt.keywords, tt.baseURL)
+			if result != tt.expected {
+				t.Errorf("formatKeywordsFunc(%q, %q) = %q, want %q", tt.keywords, tt.baseURL, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Cross-Site Scripting (XSS) flaw in `cmd/g2/template_funcs.go`. The `formatKeywordsFunc` function previously injected unescaped data (`baseURL` and `arch` segments) directly into `template.HTML` via manual `fmt.Sprintf` construction.

⚠️ **Risk:** An attacker could exploit this by supplying a malicious `baseURL` or manipulating package keywords/architectures, allowing them to inject arbitrary HTML or JavaScript (e.g., `<script>alert('XSS')</script>`). This could lead to session hijacking, defacement, or forced actions on behalf of viewing users.

🛡️ **Solution:** The fix escapes all dynamic data bound for HTML output:
1. `baseURL` and the text node for the architecture link (`safeArchText`) are escaped using `template.HTMLEscapeString`.
2. The URL segment (`safeArchURL`) is escaped using `url.PathEscape` to ensure valid path routing.
3. Added dedicated test coverage (`TestFormatKeywordsFunc`) in `cmd/g2/template_funcs_test.go` to explicitly test that malicious strings containing XSS vectors are appropriately neutralized.

---
*PR created automatically by Jules for task [6904271844005909829](https://jules.google.com/task/6904271844005909829) started by @arran4*