### PR TITLE
fix: reduce noisy rendering logs with phase-level progress indicators

### DIFF
--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -1339,7 +1339,7 @@ log.Printf("[PHASE] Rendering %d category pages...", len(data.Categories))
 		return err
 	}
 
-	log.Printf("[PHASE] Rendering repository pages...")
+log.Printf("[PHASE] Rendering %d repository pages...", len(sites))
 	if err := generateRepoPages(outDir, tmpl, sites, data, title, version, recentDurationStr, genInfo); err != nil {
 		return err
 	}

--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -1324,7 +1324,7 @@ func generateSite(outDir string, sites []*g2.SiteData, recentDuration time.Durat
 		return err
 	}
 
-	log.Printf("[PHASE] Rendering category pages...")
+log.Printf("[PHASE] Rendering %d category pages...", len(data.Categories))
 	if err := generateCategoryPages(outDir, tmpl, data, title, version, genInfo); err != nil {
 		return err
 	}

--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -1319,22 +1319,27 @@ func generateSite(outDir string, sites []*g2.SiteData, recentDuration time.Durat
 	}
 
 	// Render Phases
+	log.Printf("[PHASE] Rendering global pages...")
 	if err := generateGlobalPages(outDir, tmpl, sites, data, title, version, recentDurationStr, genInfo); err != nil {
 		return err
 	}
 
+	log.Printf("[PHASE] Rendering category pages...")
 	if err := generateCategoryPages(outDir, tmpl, data, title, version, genInfo); err != nil {
 		return err
 	}
 
+	log.Printf("[PHASE] Rendering package pages...")
 	if err := generatePackagePages(outDir, tmpl, data, title, version, genInfo); err != nil {
 		return err
 	}
 
+	log.Printf("[PHASE] Rendering other global pages...")
 	if err := generateOtherGlobalPages(outDir, tmpl, data, title, version, genInfo); err != nil {
 		return err
 	}
 
+	log.Printf("[PHASE] Rendering repository pages...")
 	if err := generateRepoPages(outDir, tmpl, sites, data, title, version, recentDurationStr, genInfo); err != nil {
 		return err
 	}

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1795,8 +1795,6 @@ func prepareAggregatedData(sites []*g2.SiteData) *AggregatedData {
 }
 
 func renderPage(path string, tmpl *template.Template, name string, data interface{}) error {
-	log.Printf("Rendering page %s using template %s", path, name)
-
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("creating file %s: %w", path, err)


### PR DESCRIPTION
Fixes an issue where `renderPage` caused very noisy logging by emitting a log statement for every single file being rendered during site generation. This is now replaced with high-level `[PHASE]` logs in `generateSite` to provide cleaner progress indication.

---
*PR created automatically by Jules for task [4002066089682477908](https://jules.google.com/task/4002066089682477908) started by @arran4*