### PR TITLE
Fix slice index out of bounds panic in package rendering templates

### DIFF
--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -27,7 +27,16 @@ func getTemplateFuncMap() template.FuncMap {
 			if val.Kind() == reflect.Slice || val.Kind() == reflect.Map || val.Kind() == reflect.String || val.Kind() == reflect.Array { return val.Len() }
 			return 0
 		},
+		"packageLink": packageLinkFunc,
 	}
+}
+
+func packageLinkFunc(baseURL string, pkg string) template.HTML {
+	parts := strings.Split(pkg, "/")
+	if len(parts) == 2 {
+		return template.HTML(fmt.Sprintf("<a href=\"%spackages/%s/%s/\">%s</a>", template.HTMLEscapeString(baseURL), url.PathEscape(parts[0]), url.PathEscape(parts[1]), template.HTMLEscapeString(pkg)))
+	}
+	return template.HTML(template.HTMLEscapeString(pkg))
 }
 
 func formatKeywordsFunc(keywords string, baseURL string) template.HTML {

--- a/cmd/g2/template_render_test.go
+++ b/cmd/g2/template_render_test.go
@@ -26,7 +26,10 @@ func TestAllTemplatesRender(t *testing.T) {
 			data := GenericPageContext{}
 			// populate it with some dummy data to avoid nil pointer derefs
 			data.GlobalPackage = &AggPackage{}
-			data.RepoPackage = &g2.PackageData{}
+			data.RepoPackage = &g2.PackageData{
+				ReverseVirtuals: []string{"category/package", "invalid", "x/y"},
+				Equivalents: []string{"category/package", "invalid", "x/y"},
+			}
 			data.Project = &AggProject{Project: &g2.Project{}}
 			data.RepoCategory = &g2.CategoryData{}
 			data.Category = map[string]interface{}{}

--- a/templates/views/ebuild_details.html
+++ b/templates/views/ebuild_details.html
@@ -26,16 +26,12 @@
 <div class="alert alert-info">
     <strong>Notice:</strong> This package is in a virtual group:
     {{range $index, $virtual := .RepoPackage.ReverseVirtuals}}{{if $index}}, {{end}}
-    {{$parts := split $virtual "/"}}
-    {{if eq (len $parts) 2}}
-    <a href="{{$.BaseURL}}packages/{{index $parts 0}}/{{index $parts 1}}/">{{$virtual}}</a>{{else}}{{$virtual}}{{end}}{{end}}
+    {{packageLink $.BaseURL $virtual}}{{end}}
     {{if gt (len .RepoPackage.Equivalents) 0}}
     <br/>
     Equivalents:
     {{range $index, $eq := .RepoPackage.Equivalents}}{{if $index}}, {{end}}
-    {{$parts := split $eq "/"}}
-    {{if eq (len $parts) 2}}
-    <a href="{{$.BaseURL}}packages/{{index $parts 0}}/{{index $parts 1}}/">{{$eq}}</a>{{else}}{{$eq}}{{end}}{{end}}
+    {{packageLink $.BaseURL $eq}}{{end}}
     {{end}}
 </div>
 {{end}}

--- a/templates/views/ebuild_details.html
+++ b/templates/views/ebuild_details.html
@@ -26,12 +26,16 @@
 <div class="alert alert-info">
     <strong>Notice:</strong> This package is in a virtual group:
     {{range $index, $virtual := .RepoPackage.ReverseVirtuals}}{{if $index}}, {{end}}
-    <a href="{{$.BaseURL}}packages/{{index (split $virtual "/") 0}}/{{index (split $virtual "/") 1}}/">{{$virtual}}</a>{{end}}
+    {{$parts := split $virtual "/"}}
+    {{if eq (len $parts) 2}}
+    <a href="{{$.BaseURL}}packages/{{index $parts 0}}/{{index $parts 1}}/">{{$virtual}}</a>{{else}}{{$virtual}}{{end}}{{end}}
     {{if gt (len .RepoPackage.Equivalents) 0}}
     <br/>
     Equivalents:
     {{range $index, $eq := .RepoPackage.Equivalents}}{{if $index}}, {{end}}
-    <a href="{{$.BaseURL}}packages/{{index (split $eq "/") 0}}/{{index (split $eq "/") 1}}/">{{$eq}}</a>{{end}}
+    {{$parts := split $eq "/"}}
+    {{if eq (len $parts) 2}}
+    <a href="{{$.BaseURL}}packages/{{index $parts 0}}/{{index $parts 1}}/">{{$eq}}</a>{{else}}{{$eq}}{{end}}{{end}}
     {{end}}
 </div>
 {{end}}

--- a/templates/views/repo_package.html
+++ b/templates/views/repo_package.html
@@ -35,16 +35,12 @@
 <div class="alert alert-info">
     <strong>Notice:</strong> This package is in a virtual group:
     {{range $index, $virtual := .RepoPackage.ReverseVirtuals}}{{if $index}}, {{end}}
-    {{$parts := split $virtual "/"}}
-    {{if eq (len $parts) 2}}
-    <a href="{{$.BaseURL}}packages/{{index $parts 0}}/{{index $parts 1}}/">{{$virtual}}</a>{{else}}{{$virtual}}{{end}}{{end}}
+    {{packageLink $.BaseURL $virtual}}{{end}}
     {{if gt (len .RepoPackage.Equivalents) 0}}
     <br/>
     Equivalents:
     {{range $index, $eq := .RepoPackage.Equivalents}}{{if $index}}, {{end}}
-    {{$parts := split $eq "/"}}
-    {{if eq (len $parts) 2}}
-    <a href="{{$.BaseURL}}packages/{{index $parts 0}}/{{index $parts 1}}/">{{$eq}}</a>{{else}}{{$eq}}{{end}}{{end}}
+    {{packageLink $.BaseURL $eq}}{{end}}
     {{end}}
 </div>
 {{end}}

--- a/templates/views/repo_package.html
+++ b/templates/views/repo_package.html
@@ -35,12 +35,16 @@
 <div class="alert alert-info">
     <strong>Notice:</strong> This package is in a virtual group:
     {{range $index, $virtual := .RepoPackage.ReverseVirtuals}}{{if $index}}, {{end}}
-    <a href="{{$.BaseURL}}packages/{{index (split $virtual "/") 0}}/{{index (split $virtual "/") 1}}/">{{$virtual}}</a>{{end}}
+    {{$parts := split $virtual "/"}}
+    {{if eq (len $parts) 2}}
+    <a href="{{$.BaseURL}}packages/{{index $parts 0}}/{{index $parts 1}}/">{{$virtual}}</a>{{else}}{{$virtual}}{{end}}{{end}}
     {{if gt (len .RepoPackage.Equivalents) 0}}
     <br/>
     Equivalents:
     {{range $index, $eq := .RepoPackage.Equivalents}}{{if $index}}, {{end}}
-    <a href="{{$.BaseURL}}packages/{{index (split $eq "/") 0}}/{{index (split $eq "/") 1}}/">{{$eq}}</a>{{end}}
+    {{$parts := split $eq "/"}}
+    {{if eq (len $parts) 2}}
+    <a href="{{$.BaseURL}}packages/{{index $parts 0}}/{{index $parts 1}}/">{{$eq}}</a>{{else}}{{$eq}}{{end}}{{end}}
     {{end}}
 </div>
 {{end}}


### PR DESCRIPTION
Fixes the template rendering panics documented by adding length checking and updating test mock data.

---
*PR created automatically by Jules for task [6412917950978719940](https://jules.google.com/task/6412917950978719940) started by @arran4*