### PR TITLE
Fix: lint for missing manifest files

### DIFF
--- a/lints/metadata/manifest.go
+++ b/lints/metadata/manifest.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/arran4/g2"
@@ -96,6 +97,27 @@ func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 					res.RuleMetadata.Severity = lints.SeverityWarning
 					results = append(results, res)
 				}
+			}
+		}
+
+		// Ensure the file exists if it's expected to be in the tree
+		if entry.Type == "EBUILD" || entry.Type == "MISC" || entry.Type == "AUX" {
+			var filePath string
+			if entry.Type == "AUX" {
+				filePath = filepath.Join(repoDir, pkg.Category, pkg.Name, "files", entry.Filename)
+			} else {
+				filePath = filepath.Join(repoDir, pkg.Category, pkg.Name, entry.Filename)
+			}
+
+			_, err := os.Stat(filePath)
+			if os.IsNotExist(err) {
+				res := lints.LintResult{
+					RuleMetadata: ruleManifestChecks,
+					Message:      fmt.Sprintf("[%s] Manifest entry %s references a missing file: %s", cases.Title(language.English).String(string(lints.SeverityError)), entry.Filename, entry.Filename),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = lints.SeverityError
+				results = append(results, res)
 			}
 		}
 	}

--- a/lints/metadata/manifest.go
+++ b/lints/metadata/manifest.go
@@ -113,10 +113,9 @@ func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 			if os.IsNotExist(err) {
 				res := lints.LintResult{
 					RuleMetadata: ruleManifestChecks,
-					Message:      fmt.Sprintf("[%s] Manifest entry %s references a missing file: %s", cases.Title(language.English).String(string(lints.SeverityError)), entry.Filename, entry.Filename),
+					Message:      fmt.Sprintf("[%s] Manifest entry %s references a missing file", cases.Title(language.English).String(string(lints.SeverityError)), entry.Filename),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
-				res.RuleMetadata.Severity = lints.SeverityError
 				results = append(results, res)
 			}
 		}

--- a/lints/metadata/manifest_test.go
+++ b/lints/metadata/manifest_test.go
@@ -1,0 +1,106 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+func TestManifestLintRule_MissingFiles(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "manifest-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	category := "app-test"
+	name := "testpkg"
+
+	pkgDir := filepath.Join(tempDir, category, name)
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatalf("failed to create package dir: %v", err)
+	}
+
+	// Create a layout.conf that requires BLAKE2B
+	metadataDir := filepath.Join(tempDir, "metadata")
+	if err := os.MkdirAll(metadataDir, 0755); err != nil {
+		t.Fatalf("failed to create metadata dir: %v", err)
+	}
+	layoutConf := "masters = gentoo\nmanifest-required-hashes = BLAKE2B\n"
+	if err := os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644); err != nil {
+		t.Fatalf("failed to write layout.conf: %v", err)
+	}
+
+	manifest := &g2.Manifest{
+		Entries: []*g2.ManifestEntry{
+			{
+				Type:     "EBUILD",
+				Filename: "testpkg-1.0.ebuild",
+				Size:     100,
+				Hashes: []g2.Hash{
+					{Type: "BLAKE2B", Value: "hash1"},
+				},
+			},
+			{
+				Type:     "MISC",
+				Filename: "metadata.xml",
+				Size:     100,
+				Hashes: []g2.Hash{
+					{Type: "BLAKE2B", Value: "hash2"},
+				},
+			},
+			{
+				Type:     "AUX",
+				Filename: "test.patch",
+				Size:     100,
+				Hashes: []g2.Hash{
+					{Type: "BLAKE2B", Value: "hash3"},
+				},
+			},
+		},
+	}
+
+	pkgData := &g2.PackageData{
+		Category: category,
+		Name:     name,
+		Manifest: manifest,
+	}
+
+	rule := &ManifestLintRule{}
+	results := rule.Lint(tempDir, pkgData)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	for _, result := range results {
+		if result.RuleMetadata.Severity != lints.SeverityError {
+			t.Errorf("expected error severity, got %v", result.RuleMetadata.Severity)
+		}
+		if result.RuleMetadata.ID != ruleManifestChecks.ID {
+			t.Errorf("expected rule ID %s, got %s", ruleManifestChecks.ID, result.RuleMetadata.ID)
+		}
+	}
+
+	// Now create the files and ensure no errors are reported
+	if err := os.WriteFile(filepath.Join(pkgDir, "testpkg-1.0.ebuild"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write ebuild: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "metadata.xml"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write metadata.xml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgDir, "files"), 0755); err != nil {
+		t.Fatalf("failed to create files dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "files", "test.patch"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write patch: %v", err)
+	}
+
+	results = rule.Lint(tempDir, pkgData)
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d: %v", len(results), results)
+	}
+}

--- a/lints/metadata/manifest_test.go
+++ b/lints/metadata/manifest_test.go
@@ -14,7 +14,9 @@ func TestManifestLintRule_MissingFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
 
 	category := "app-test"
 	name := "testpkg"


### PR DESCRIPTION
- Added file existence check for `EBUILD`, `MISC`, and `AUX` Manifest entries in `lints/metadata/manifest.go`.
- Ensured `AUX` files are properly expected in the `files/` sub-directory.
- Added tests in `lints/metadata/manifest_test.go` to verify correct detection of missing files and successful passes when files exist.

---
*PR created automatically by Jules for task [14630630357033068447](https://jules.google.com/task/14630630357033068447) started by @arran4*