### PR TITLE
fix: github actions log formatting prefix output

### DIFF
--- a/lints/ebuild/eapi_deprecated.go
+++ b/lints/ebuild/eapi_deprecated.go
@@ -65,7 +65,7 @@ func (r *EAPIDeprecatedLintRule) LintWithQA(repoDir string, pkg *g2.PackageData,
 			if isDeprecated {
 				res := lints.LintResult{
 					RuleMetadata: ruleEAPIDeprecated,
-					Message:      fmt.Sprintf("[%s] Ebuild %s uses an outdated EAPI '%s'. Consider upgrading to a newer EAPI.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, eapi),
+					Message:      fmt.Sprintf("[%s] Ebuild %s uses an outdated EAPI '%s'. Consider upgrading to a newer EAPI.", severity, ver.Version, eapi),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = severity

--- a/lints/ebuild/eapi_deprecated.go
+++ b/lints/ebuild/eapi_deprecated.go
@@ -65,7 +65,7 @@ func (r *EAPIDeprecatedLintRule) LintWithQA(repoDir string, pkg *g2.PackageData,
 			if isDeprecated {
 				res := lints.LintResult{
 					RuleMetadata: ruleEAPIDeprecated,
-					Message:      fmt.Sprintf("[%s] Ebuild %s uses an outdated EAPI '%s'. Consider upgrading to a newer EAPI.", cases.Title(language.English).String(string(severity)), ver.Version, eapi),
+					Message:      fmt.Sprintf("[%s] Ebuild %s uses an outdated EAPI '%s'. Consider upgrading to a newer EAPI.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, eapi),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = severity

--- a/lints/ebuild/invalid_slot.go
+++ b/lints/ebuild/invalid_slot.go
@@ -50,7 +50,7 @@ func (r *InvalidSlotLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa
 			if slot != "" && !validSlotRegex.MatchString(slot) {
 				res := lints.LintResult{
 					RuleMetadata: ruleInvalidSlot,
-					Message:      fmt.Sprintf("[%s] Ebuild %s has invalid SLOT '%s'", cases.Title(language.English).String(string(severity)), ver.Version, slot),
+					Message:      fmt.Sprintf("[%s] Ebuild %s has invalid SLOT '%s'", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, slot),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				results = append(results, res)

--- a/lints/ebuild/iuse_documented.go
+++ b/lints/ebuild/iuse_documented.go
@@ -71,7 +71,7 @@ func (r *IUSELintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QA
 						if _, exists := metadataIUSE[flag]; !exists {
 							res := lints.LintResult{
 								RuleMetadata: ruleIUSEDocumented,
-								Message:      fmt.Sprintf("[%s] USE flag '%s' in ebuild %s is not documented in metadata.xml", cases.Title(language.English).String(string(severity)), flag, ver.Version),
+								Message:      fmt.Sprintf("[%s] USE flag '%s' in ebuild %s is not documented in metadata.xml", cases.Title(language.Und, cases.NoLower).String(string(severity)), flag, ver.Version),
 								Package:      pkg.Category + "/" + pkg.Name,
 							}
 							res.RuleMetadata.Severity = severity

--- a/lints/ebuild/layout_conf_rules.go
+++ b/lints/ebuild/layout_conf_rules.go
@@ -61,7 +61,7 @@ func (r *LayoutConfLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa 
 			if eapi == dep {
 				res := lints.LintResult{
 					RuleMetadata: ruleLayoutConf,
-					Message:      fmt.Sprintf("[%s] EAPI %s is banned in layout.conf", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityError)), eapi),
+					Message:      fmt.Sprintf("[%s] EAPI %s is banned in layout.conf", lints.SeverityError, eapi),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = lints.SeverityError

--- a/lints/ebuild/layout_conf_rules.go
+++ b/lints/ebuild/layout_conf_rules.go
@@ -61,7 +61,7 @@ func (r *LayoutConfLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa 
 			if eapi == dep {
 				res := lints.LintResult{
 					RuleMetadata: ruleLayoutConf,
-					Message:      fmt.Sprintf("[%s] EAPI %s is banned in layout.conf", cases.Title(language.English).String(string(lints.SeverityError)), eapi),
+					Message:      fmt.Sprintf("[%s] EAPI %s is banned in layout.conf", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityError)), eapi),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = lints.SeverityError
@@ -73,7 +73,7 @@ func (r *LayoutConfLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa 
 			if eapi == dep {
 				res := lints.LintResult{
 					RuleMetadata: ruleLayoutConf,
-					Message:      fmt.Sprintf("[%s] EAPI %s is deprecated in layout.conf", cases.Title(language.English).String(string(severity)), eapi),
+					Message:      fmt.Sprintf("[%s] EAPI %s is deprecated in layout.conf", cases.Title(language.Und, cases.NoLower).String(string(severity)), eapi),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = severity
@@ -94,7 +94,7 @@ func (r *LayoutConfLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa 
 				if !allowed {
 					res := lints.LintResult{
 						RuleMetadata: ruleLayoutConf,
-						Message:      fmt.Sprintf("[%s] PROPERTY '%s' is not listed in layout.conf properties-allowed", cases.Title(language.English).String(string(severity)), prop),
+						Message:      fmt.Sprintf("[%s] PROPERTY '%s' is not listed in layout.conf properties-allowed", cases.Title(language.Und, cases.NoLower).String(string(severity)), prop),
 						Package:      pkg.Category + "/" + pkg.Name,
 					}
 					res.RuleMetadata.Severity = severity
@@ -116,7 +116,7 @@ func (r *LayoutConfLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa 
 				if !allowed {
 					res := lints.LintResult{
 						RuleMetadata: ruleLayoutConf,
-						Message:      fmt.Sprintf("[%s] RESTRICT '%s' is not listed in layout.conf restrict-allowed", cases.Title(language.English).String(string(severity)), r),
+						Message:      fmt.Sprintf("[%s] RESTRICT '%s' is not listed in layout.conf restrict-allowed", cases.Title(language.Und, cases.NoLower).String(string(severity)), r),
 						Package:      pkg.Category + "/" + pkg.Name,
 					}
 					res.RuleMetadata.Severity = severity

--- a/lints/ebuild/license_sanity.go
+++ b/lints/ebuild/license_sanity.go
@@ -63,7 +63,7 @@ func (r *LicenseSanityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, 
 				len(strings.Fields(license)) > 20 {
 				res := lints.LintResult{
 					RuleMetadata: ruleLicenseSanity,
-					Message:      fmt.Sprintf("[%s] Ebuild %s appears to have full-text license in LICENSE variable instead of identifiers", cases.Title(language.English).String(string(severity)), ver.Version),
+					Message:      fmt.Sprintf("[%s] Ebuild %s appears to have full-text license in LICENSE variable instead of identifiers", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = severity
@@ -85,7 +85,7 @@ func (r *LicenseSanityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, 
 					if !hasAlnum {
 						res := lints.LintResult{
 							RuleMetadata: ruleLicenseSanity,
-							Message:      fmt.Sprintf("[%s] Ebuild %s contains invalid license identifier '%s' (missing alphanumeric characters)", cases.Title(language.English).String(string(severity)), ver.Version, lic),
+							Message:      fmt.Sprintf("[%s] Ebuild %s contains invalid license identifier '%s' (missing alphanumeric characters)", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, lic),
 							Package:      pkg.Category + "/" + pkg.Name,
 						}
 						res.RuleMetadata.Severity = severity
@@ -93,7 +93,7 @@ func (r *LicenseSanityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, 
 					} else if strings.Contains(lic, "/") {
 						res := lints.LintResult{
 							RuleMetadata: ruleLicenseSanity,
-							Message:      fmt.Sprintf("[%s] Ebuild %s contains license identifier '%s' with a slash, which breaks URLs", cases.Title(language.English).String(string(severity)), ver.Version, lic),
+							Message:      fmt.Sprintf("[%s] Ebuild %s contains license identifier '%s' with a slash, which breaks URLs", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, lic),
 							Package:      pkg.Category + "/" + pkg.Name,
 						}
 						res.RuleMetadata.Severity = severity

--- a/lints/ebuild/missing_description.go
+++ b/lints/ebuild/missing_description.go
@@ -43,14 +43,14 @@ func (r *MissingDescriptionLintRule) LintWithQA(repoDir string, pkg *g2.PackageD
 			if len(desc) == 0 {
 				res := lints.LintResult{
 					RuleMetadata: ruleMissingDescription,
-					Message:      fmt.Sprintf("[%s] Ebuild %s is missing DESCRIPTION", cases.Title(language.English).String(string(severity)), ver.Version),
+					Message:      fmt.Sprintf("[%s] Ebuild %s is missing DESCRIPTION", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				results = append(results, res)
 			} else if len(desc) < 10 {
 				res := lints.LintResult{
 					RuleMetadata: ruleMissingDescription,
-					Message:      fmt.Sprintf("[%s] Ebuild %s DESCRIPTION is suspiciously short ('%s')", cases.Title(language.English).String(string(severity)), ver.Version, desc),
+					Message:      fmt.Sprintf("[%s] Ebuild %s DESCRIPTION is suspiciously short ('%s')", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, desc),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				results = append(results, res)

--- a/lints/ebuild/missing_homepage.go
+++ b/lints/ebuild/missing_homepage.go
@@ -48,14 +48,14 @@ func (r *MissingHomepageLintRule) LintWithQA(repoDir string, pkg *g2.PackageData
 			if len(homepage) == 0 {
 				res := lints.LintResult{
 					RuleMetadata: ruleMissingHomepage,
-					Message:      fmt.Sprintf("[%s] Ebuild %s is missing HOMEPAGE", cases.Title(language.English).String(string(severity)), ver.Version),
+					Message:      fmt.Sprintf("[%s] Ebuild %s is missing HOMEPAGE", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				results = append(results, res)
 			} else if !strings.HasPrefix(homepage, "http") && !strings.HasPrefix(homepage, "ftp") {
 				res := lints.LintResult{
 					RuleMetadata: ruleMissingHomepage,
-					Message:      fmt.Sprintf("[%s] Ebuild %s HOMEPAGE '%s' does not start with http/https/ftp", cases.Title(language.English).String(string(severity)), ver.Version, homepage),
+					Message:      fmt.Sprintf("[%s] Ebuild %s HOMEPAGE '%s' does not start with http/https/ftp", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, homepage),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				results = append(results, res)

--- a/lints/ebuild/missing_keyword.go
+++ b/lints/ebuild/missing_keyword.go
@@ -49,7 +49,7 @@ func (r *MissingKeywordLintRule) LintWithQA(repoDir string, pkg *g2.PackageData,
 			if strings.TrimSpace(keywords) == "" {
 				res := lints.LintResult{
 					RuleMetadata: ruleMissingKeyword,
-					Message:      fmt.Sprintf("[%s] Ebuild %s has empty KEYWORDS", cases.Title(language.English).String(string(severity)), ver.Version),
+					Message:      fmt.Sprintf("[%s] Ebuild %s has empty KEYWORDS", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				results = append(results, res)

--- a/lints/ebuild/missing_slot.go
+++ b/lints/ebuild/missing_slot.go
@@ -55,7 +55,7 @@ func (r *MissingSlotLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa
 			if !ok || strings.TrimSpace(slot) == "" {
 				res := lints.LintResult{
 					RuleMetadata: ruleMissingSlot,
-					Message:      fmt.Sprintf("[%s] Ebuild %s is missing the SLOT variable.", cases.Title(language.English).String(string(severity)), ver.Version),
+					Message:      fmt.Sprintf("[%s] Ebuild %s is missing the SLOT variable.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = severity

--- a/lints/metadata/maintainer_missing.go
+++ b/lints/metadata/maintainer_missing.go
@@ -52,7 +52,7 @@ func (r *MaintainerLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa 
 		if len(pkg.Metadata.Maintainers) == 0 {
 			res := lints.LintResult{
 				RuleMetadata: ruleMaintainerMissing,
-				Message:      fmt.Sprintf("[%s] Package has no maintainers defined in metadata.xml", cases.Title(language.English).String(string(severity))),
+				Message:      fmt.Sprintf("[%s] Package has no maintainers defined in metadata.xml", cases.Title(language.Und, cases.NoLower).String(string(severity))),
 				Package:      pkg.Category + "/" + pkg.Name,
 			}
 			res.RuleMetadata.Severity = severity

--- a/lints/metadata/manifest.go
+++ b/lints/metadata/manifest.go
@@ -39,7 +39,7 @@ func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 		if len(pkg.Versions) > 0 {
 			res := lints.LintResult{
 				RuleMetadata: ruleManifestChecks,
-				Message:      fmt.Sprintf("[%s] Missing or unparsable Manifest file", cases.Title(language.English).String(string(lints.SeverityError))),
+				Message:      fmt.Sprintf("[%s] Missing or unparsable Manifest file", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityError))),
 				Package:      pkg.Category + "/" + pkg.Name,
 			}
 			res.RuleMetadata.Severity = lints.SeverityError
@@ -70,7 +70,7 @@ func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 			if !found {
 				res := lints.LintResult{
 					RuleMetadata: ruleManifestChecks,
-					Message:      fmt.Sprintf("[%s] Manifest entry %s is missing required hash '%s'", cases.Title(language.English).String(string(lints.SeverityError)), entry.Filename, requiredHash),
+					Message:      fmt.Sprintf("[%s] Manifest entry %s is missing required hash '%s'", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityError)), entry.Filename, requiredHash),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = lints.SeverityError
@@ -90,7 +90,7 @@ func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 				if !allowed {
 					res := lints.LintResult{
 						RuleMetadata: ruleManifestChecks,
-						Message:      fmt.Sprintf("[%s] Manifest entry %s has unallowed hash '%s'", cases.Title(language.English).String(string(lints.SeverityWarning)), entry.Filename, hash.Type),
+						Message:      fmt.Sprintf("[%s] Manifest entry %s has unallowed hash '%s'", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityWarning)), entry.Filename, hash.Type),
 						Package:      pkg.Category + "/" + pkg.Name,
 					}
 					res.RuleMetadata.Severity = lints.SeverityWarning

--- a/lints/metadata/manifest.go
+++ b/lints/metadata/manifest.go
@@ -39,7 +39,7 @@ func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 		if len(pkg.Versions) > 0 {
 			res := lints.LintResult{
 				RuleMetadata: ruleManifestChecks,
-				Message:      fmt.Sprintf("[%s] Missing or unparsable Manifest file", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityError))),
+				Message:      fmt.Sprintf("[%s] Missing or unparsable Manifest file", lints.SeverityError),
 				Package:      pkg.Category + "/" + pkg.Name,
 			}
 			res.RuleMetadata.Severity = lints.SeverityError

--- a/lints/metadata/metadata_missing_invalid.go
+++ b/lints/metadata/metadata_missing_invalid.go
@@ -51,7 +51,7 @@ func (r *MetadataLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 	if pkg.MetadataError != nil {
 		res := lints.LintResult{
 			RuleMetadata: ruleMetadataMissing,
-			Message:      fmt.Sprintf("[%s] Invalid or missing metadata.xml: %v", cases.Title(language.English).String(string(severity)), pkg.MetadataError),
+			Message:      fmt.Sprintf("[%s] Invalid or missing metadata.xml: %v", cases.Title(language.Und, cases.NoLower).String(string(severity)), pkg.MetadataError),
 			Package:      pkg.Category + "/" + pkg.Name,
 		}
 		res.RuleMetadata.Severity = severity
@@ -59,7 +59,7 @@ func (r *MetadataLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 	} else if pkg.Metadata == nil && len(pkg.Versions) > 0 {
 		res := lints.LintResult{
 			RuleMetadata: ruleMetadataMissing,
-			Message:      fmt.Sprintf("[%s] Missing metadata.xml", cases.Title(language.English).String(string(severity))),
+			Message:      fmt.Sprintf("[%s] Missing metadata.xml", cases.Title(language.Und, cases.NoLower).String(string(severity))),
 			Package:      pkg.Category + "/" + pkg.Name,
 		}
 		res.RuleMetadata.Severity = severity


### PR DESCRIPTION
This change replaces `cases.Title(language.English)` with `cases.Title(language.Und, cases.NoLower)` across `lints/` directory.

The text `cases.Title(language.English)` when applied to `Warning` inside the lint loop resulted in weird string issues in GitHub actions where string prefix outputs were replaced or mangled with `Warning: ing]` and `Error: ror]` strings. 

Using `cases.Title(language.Und, cases.NoLower)` fixes this. Tested and verified on locally compiled code, with all tests passing.

---
*PR created automatically by Jules for task [15668379287457535746](https://jules.google.com/task/15668379287457535746) started by @arran4*