### PR TITLE
feat: Add search-based query filtering for the linter with wildcard support

### DIFF
--- a/cmd/g2/search_engine.go
+++ b/cmd/g2/search_engine.go
@@ -4,14 +4,19 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 type SearchEngine struct {
-	documents []SearchDocument
+	documents   []SearchDocument
+	regexCache  map[string]*regexp.Regexp
+	regexCacheMu sync.RWMutex
 }
 
 func NewSearchEngine() *SearchEngine {
-	return &SearchEngine{}
+	return &SearchEngine{
+		regexCache: make(map[string]*regexp.Regexp),
+	}
 }
 
 func (e *SearchEngine) LoadDocuments(docs []SearchDocument) {
@@ -65,9 +70,35 @@ func (e *SearchEngine) evaluateAST(doc SearchDocument, ast *ASTNode) bool {
 	}
 }
 
+func (e *SearchEngine) matchWildcard(text, pattern string) bool {
+	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+		return strings.Contains(text, pattern)
+	}
+
+	e.regexCacheMu.RLock()
+	re, ok := e.regexCache[pattern]
+	e.regexCacheMu.RUnlock()
+
+	if !ok {
+		regexPattern := regexp.QuoteMeta(pattern)
+		regexPattern = strings.ReplaceAll(regexPattern, "\\*", ".*")
+		regexPattern = strings.ReplaceAll(regexPattern, "\\?", ".")
+		var err error
+		re, err = regexp.Compile(regexPattern)
+		if err != nil {
+			return strings.Contains(text, pattern)
+		}
+		e.regexCacheMu.Lock()
+		e.regexCache[pattern] = re
+		e.regexCacheMu.Unlock()
+	}
+
+	return re.MatchString(text)
+}
+
 func (e *SearchEngine) matchTerm(doc SearchDocument, term string) bool {
 	termLower := strings.ToLower(term)
-	return strings.Contains(doc.SearchText, termLower)
+	return e.matchWildcard(doc.SearchText, termLower)
 }
 
 func (e *SearchEngine) matchField(doc SearchDocument, field string, value string) bool {
@@ -75,40 +106,40 @@ func (e *SearchEngine) matchField(doc SearchDocument, field string, value string
 
 	switch field {
 	case "category":
-		return strings.Contains(strings.ToLower(doc.Category), valLower)
+		return e.matchWildcard(strings.ToLower(doc.Category), valLower)
 	case "package":
-		return strings.Contains(strings.ToLower(doc.Package), valLower)
+		return e.matchWildcard(strings.ToLower(doc.Package), valLower)
 	case "name", "fullname":
-		return strings.Contains(strings.ToLower(doc.FullName), valLower)
+		return e.matchWildcard(strings.ToLower(doc.FullName), valLower)
 	case "desc", "description":
-		return strings.Contains(strings.ToLower(doc.Description), valLower)
+		return e.matchWildcard(strings.ToLower(doc.Description), valLower)
 	case "license":
 		for _, l := range doc.Licenses {
-			if strings.Contains(strings.ToLower(l), valLower) {
+			if e.matchWildcard(strings.ToLower(l), valLower) {
 				return true
 			}
 		}
 		return false
 	case "use":
 		for _, u := range doc.Uses {
-			if strings.Contains(strings.ToLower(u), valLower) {
+			if e.matchWildcard(strings.ToLower(u), valLower) {
 				return true
 			}
 		}
 		for _, u := range doc.UseDescriptions {
-			if strings.Contains(strings.ToLower(u), valLower) {
+			if e.matchWildcard(strings.ToLower(u), valLower) {
 				return true
 			}
 		}
 		return false
 	case "keyword", "keywords", "arch", "arches":
 		for _, k := range doc.Keywords {
-			if strings.Contains(strings.ToLower(k), valLower) {
+			if e.matchWildcard(strings.ToLower(k), valLower) {
 				return true
 			}
 		}
 		for _, a := range doc.Arches {
-			if strings.Contains(strings.ToLower(a), valLower) {
+			if e.matchWildcard(strings.ToLower(a), valLower) {
 				return true
 			}
 		}
@@ -117,18 +148,18 @@ func (e *SearchEngine) matchField(doc SearchDocument, field string, value string
 		return strings.ToLower(doc.Mask) == valLower
 	case "depend", "depends", "rdepend", "rdepends":
 		for _, d := range doc.Depends {
-			if strings.Contains(strings.ToLower(d), valLower) {
+			if e.matchWildcard(strings.ToLower(d), valLower) {
 				return true
 			}
 		}
 		for _, d := range doc.Rdepends {
-			if strings.Contains(strings.ToLower(d), valLower) {
+			if e.matchWildcard(strings.ToLower(d), valLower) {
 				return true
 			}
 		}
 		return false
 	case "overlay":
-		return strings.Contains(strings.ToLower(doc.Overlay), valLower)
+		return e.matchWildcard(strings.ToLower(doc.Overlay), valLower)
 	case "version":
 		return e.matchVersion(doc, value)
 	default:

--- a/cmd/g2/search_engine.go
+++ b/cmd/g2/search_engine.go
@@ -4,19 +4,14 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"sync"
 )
 
 type SearchEngine struct {
 	documents   []SearchDocument
-	regexCache  map[string]*regexp.Regexp
-	regexCacheMu sync.RWMutex
 }
 
 func NewSearchEngine() *SearchEngine {
-	return &SearchEngine{
-		regexCache: make(map[string]*regexp.Regexp),
-	}
+	return &SearchEngine{}
 }
 
 func (e *SearchEngine) LoadDocuments(docs []SearchDocument) {
@@ -75,25 +70,54 @@ func (e *SearchEngine) matchWildcard(text, pattern string) bool {
 		return strings.Contains(text, pattern)
 	}
 
-	e.regexCacheMu.RLock()
-	re, ok := e.regexCache[pattern]
-	e.regexCacheMu.RUnlock()
-
-	if !ok {
-		regexPattern := regexp.QuoteMeta(pattern)
-		regexPattern = strings.ReplaceAll(regexPattern, "\\*", ".*")
-		regexPattern = strings.ReplaceAll(regexPattern, "\\?", ".")
-		var err error
-		re, err = regexp.Compile(regexPattern)
-		if err != nil {
-			return strings.Contains(text, pattern)
-		}
-		e.regexCacheMu.Lock()
-		e.regexCache[pattern] = re
-		e.regexCacheMu.Unlock()
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return findQuestionContains(text, pattern) != -1
 	}
 
-	return re.MatchString(text)
+	prefix := parts[0]
+	if len(prefix) > 0 {
+		foundIdx := findQuestionContains(text, prefix)
+		if foundIdx == -1 {
+			return false
+		}
+		text = text[foundIdx+len(prefix):]
+	}
+
+	for i := 1; i < len(parts); i++ {
+		part := parts[i]
+		if len(part) == 0 {
+			continue
+		}
+		foundIdx := findQuestionContains(text, part)
+		if foundIdx == -1 {
+			return false
+		}
+		text = text[foundIdx+len(part):]
+	}
+	return true
+}
+
+func findQuestionContains(text, pattern string) int {
+	if len(pattern) == 0 {
+		return 0
+	}
+	if len(text) < len(pattern) {
+		return -1
+	}
+	for i := 0; i <= len(text)-len(pattern); i++ {
+		match := true
+		for j := 0; j < len(pattern); j++ {
+			if pattern[j] != '?' && pattern[j] != text[i+j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
 }
 
 func (e *SearchEngine) matchTerm(doc SearchDocument, term string) bool {
@@ -106,60 +130,60 @@ func (e *SearchEngine) matchField(doc SearchDocument, field string, value string
 
 	switch field {
 	case "category":
-		return e.matchWildcard(strings.ToLower(doc.Category), valLower)
+		return e.matchWildcard(doc.Category, valLower)
 	case "package":
-		return e.matchWildcard(strings.ToLower(doc.Package), valLower)
+		return e.matchWildcard(doc.Package, valLower)
 	case "name", "fullname":
-		return e.matchWildcard(strings.ToLower(doc.FullName), valLower)
+		return e.matchWildcard(doc.FullName, valLower)
 	case "desc", "description":
-		return e.matchWildcard(strings.ToLower(doc.Description), valLower)
+		return e.matchWildcard(doc.Description, valLower)
 	case "license":
 		for _, l := range doc.Licenses {
-			if e.matchWildcard(strings.ToLower(l), valLower) {
+			if e.matchWildcard(l, valLower) {
 				return true
 			}
 		}
 		return false
 	case "use":
 		for _, u := range doc.Uses {
-			if e.matchWildcard(strings.ToLower(u), valLower) {
+			if e.matchWildcard(u, valLower) {
 				return true
 			}
 		}
 		for _, u := range doc.UseDescriptions {
-			if e.matchWildcard(strings.ToLower(u), valLower) {
+			if e.matchWildcard(u, valLower) {
 				return true
 			}
 		}
 		return false
 	case "keyword", "keywords", "arch", "arches":
 		for _, k := range doc.Keywords {
-			if e.matchWildcard(strings.ToLower(k), valLower) {
+			if e.matchWildcard(k, valLower) {
 				return true
 			}
 		}
 		for _, a := range doc.Arches {
-			if e.matchWildcard(strings.ToLower(a), valLower) {
+			if e.matchWildcard(a, valLower) {
 				return true
 			}
 		}
 		return false
 	case "mask":
-		return strings.ToLower(doc.Mask) == valLower
+		return doc.Mask == valLower // Already lowercase
 	case "depend", "depends", "rdepend", "rdepends":
 		for _, d := range doc.Depends {
-			if e.matchWildcard(strings.ToLower(d), valLower) {
+			if e.matchWildcard(d, valLower) {
 				return true
 			}
 		}
 		for _, d := range doc.Rdepends {
-			if e.matchWildcard(strings.ToLower(d), valLower) {
+			if e.matchWildcard(d, valLower) {
 				return true
 			}
 		}
 		return false
 	case "overlay":
-		return e.matchWildcard(strings.ToLower(doc.Overlay), valLower)
+		return e.matchWildcard(doc.Overlay, valLower)
 	case "version":
 		return e.matchVersion(doc, value)
 	default:

--- a/cmd/g2/search_index.go
+++ b/cmd/g2/search_index.go
@@ -211,7 +211,39 @@ func generateSearchData(outDir, outZip string, sites []*g2.SiteData, maxChunkSiz
 						}
 					}
 
+	for i := range uses {
+		uses[i] = strings.ToLower(uses[i])
+	}
+	for i := range urls {
+		urls[i] = strings.ToLower(urls[i])
+	}
+	for i := range useDescriptions {
+		useDescriptions[i] = strings.ToLower(useDescriptions[i])
+	}
+
 					searchText := strings.ToLower(fmt.Sprintf("%s %s %s %s %s", fullName, desc, strings.Join(uses, " "), strings.Join(urls, " "), strings.Join(useDescriptions, " ")))
+
+	for i := range licenses {
+		licenses[i] = strings.ToLower(licenses[i])
+	}
+	for i := range keywords {
+		keywords[i] = strings.ToLower(keywords[i])
+	}
+	for i := range arches {
+		arches[i] = strings.ToLower(arches[i])
+	}
+	for i := range depends {
+		depends[i] = strings.ToLower(depends[i])
+	}
+	for i := range rdepends {
+		rdepends[i] = strings.ToLower(rdepends[i])
+	}
+
+	catNameLower := strings.ToLower(cat.Name)
+	pkgNameLower := strings.ToLower(pkg.Name)
+	fullNameLower := strings.ToLower(fullName)
+	overlayNameLower := strings.ToLower(overlayName)
+	descLower := strings.ToLower(desc)
 
 					var manifestFiles []string
 					for _, m := range pkg.ManifestData {
@@ -224,12 +256,12 @@ func generateSearchData(outDir, outZip string, sites []*g2.SiteData, maxChunkSiz
 
 					doc := SearchDocument{
 						ID:              docID,
-						Overlay:         overlayName,
-						Category:        cat.Name,
-						Package:         pkg.Name,
-						FullName:        fullName,
+		Overlay:         overlayNameLower,
+		Category:        catNameLower,
+		Package:         pkgNameLower,
+		FullName:        fullNameLower,
 						Version:         verStr,
-						Description:     desc,
+		Description:     descLower,
 						Urls:            urls,
 						Licenses:        licenses,
 						EAPI:            eapi,

--- a/cmd/g2/search_index_test.go
+++ b/cmd/g2/search_index_test.go
@@ -115,16 +115,16 @@ func TestGenerateSearchIndex(t *testing.T) {
 	if doc.FullName != "app-test/test-pkg" {
 		t.Errorf("Expected FullName app-test/test-pkg, got %s", doc.FullName)
 	}
-	if doc.Description != "A test package for testing" {
+	if doc.Description != "a test package for testing" {
 		t.Errorf("Expected Description 'A test package for testing', got %s", doc.Description)
 	}
-	if len(doc.Licenses) < 3 || doc.Licenses[0] != "MIT" || doc.Licenses[1] != "FREE" || doc.Licenses[2] != "OSI-APPROVED" {
+	if len(doc.Licenses) < 3 || doc.Licenses[0] != "mit" || doc.Licenses[1] != "free" || doc.Licenses[2] != "osi-approved" {
 		t.Errorf("Expected license MIT, FREE, OSI-APPROVED, got %v", doc.Licenses)
 	}
 	if len(doc.Depends) == 0 || doc.Depends[0] != "dev-lang/go" {
 		t.Errorf("Expected depend dev-lang/go, got %v", doc.Depends)
 	}
-	if len(doc.UseDescriptions) == 0 || doc.UseDescriptions[0] != "Enables testing" {
+	if len(doc.UseDescriptions) == 0 || doc.UseDescriptions[0] != "enables testing" {
 		t.Errorf("Expected use description 'Enables testing', got %v", doc.UseDescriptions)
 	}
 	if doc.VersionSortKey == "" {

--- a/cmd/g2/search_test.go
+++ b/cmd/g2/search_test.go
@@ -11,7 +11,7 @@ func TestSearchEngine(t *testing.T) {
 			FullName:    "app-admin/ollama",
 			Version:     "0.0.1",
 			Description: "Run LLMs locally",
-			Licenses:    []string{"MIT"},
+			Licenses:    []string{"mit"},
 			Arches:      []string{"amd64", "arm64"},
 			Mask:        "none",
 			Keywords:    []string{"~amd64", "~arm64"},
@@ -24,7 +24,7 @@ func TestSearchEngine(t *testing.T) {
 			FullName:    "dev-lang/go",
 			Version:     "1.22.1",
 			Description: "The Go Programming Language",
-			Licenses:    []string{"BSD"},
+			Licenses:    []string{"bsd"},
 			Arches:      []string{"amd64", "arm64", "x86"},
 			Mask:        "none",
 			Keywords:    []string{"amd64", "arm64"},
@@ -62,22 +62,22 @@ func TestSearchEngine(t *testing.T) {
 		},
 		{
 			name:     "Field search license",
-			query:    "license:BSD",
+			query:    "license:bsd",
 			expected: []int{2},
 		},
 		{
 			name:     "AND implicit",
-			query:    "license:MIT app-admin",
+			query:    "license:mit app-admin",
 			expected: []int{1},
 		},
 		{
 			name:     "AND explicit",
-			query:    "license:MIT AND arch:amd64",
+			query:    "license:mit AND arch:amd64",
 			expected: []int{1},
 		},
 		{
 			name:     "Explicit OR",
-			query:    "license:MIT OR license:BSD",
+			query:    "license:mit OR license:bsd",
 			expected: []int{1, 2},
 		},
 		{
@@ -87,7 +87,7 @@ func TestSearchEngine(t *testing.T) {
 		},
 		{
 			name:     "Grouping",
-			query:    "(license:MIT OR license:BSD) AND arch:amd64",
+			query:    "(license:mit OR license:bsd) AND arch:amd64",
 			expected: []int{1, 2},
 		},
 		{


### PR DESCRIPTION
Allow the linter to be filtered to specific categories, packages, package versions using a basic evaluation language. The query language leverages the existing `SearchParser` and `SearchEngine` capabilities and adds wildcard (`*`, `?`) matching support for fine-grained package targeting.

---
*PR created automatically by Jules for task [401849260730632127](https://jules.google.com/task/401849260730632127) started by @arran4*