### PR TITLE
fix: remove unused import

### DIFF
--- a/lints/ebuild/eapi_deprecated.go
+++ b/lints/ebuild/eapi_deprecated.go
@@ -2,7 +2,6 @@ package ebuild
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints"


### PR DESCRIPTION
Removed the unused "strings" import in `lints/ebuild/eapi_deprecated.go` which was causing a golangci-lint typecheck error. All tests pass successfully after the fix.

---
*PR created automatically by Jules for task [669697456333259185](https://jules.google.com/task/669697456333259185) started by @arran4*