### PR TITLE
Add site generation execution profiler

### DIFF
--- a/cmd/g2/gen_info.go
+++ b/cmd/g2/gen_info.go
@@ -1,6 +1,7 @@
 package main
 
 type GenerationInfo struct {
+	Profiler        *Profiler
 	Args            []string
 	RepositoriesXML string
 	FastGit         bool

--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -1273,7 +1273,7 @@ func generateSite(outDir string, sites []*g2.SiteData, recentDuration time.Durat
 	if genInfo.Profiler == nil {
 		genInfo.Profiler = NewProfiler(false, "")
 	}
-	defer genInfo.Profiler.Write()
+	defer func() { _ = genInfo.Profiler.Write() }()
 
 	defer genInfo.Profiler.Track("Total Generation")()
 

--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -1273,7 +1273,11 @@ func generateSite(outDir string, sites []*g2.SiteData, recentDuration time.Durat
 	if genInfo.Profiler == nil {
 		genInfo.Profiler = NewProfiler(false, "")
 	}
-	defer func() { _ = genInfo.Profiler.Write() }()
+	defer func() {
+		if err := genInfo.Profiler.Write(); err != nil {
+			log.Printf("Error writing profile: %v", err)
+		}
+	}()
 
 	defer genInfo.Profiler.Track("Total Generation")()
 

--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -1270,24 +1270,40 @@ func generateRepoPackagesPages(repoDir string, tmpl *template.Template, site *g2
 }
 
 func generateSite(outDir string, sites []*g2.SiteData, recentDuration time.Duration, recentDurationStr string, genInfo GenerationInfo) error {
+	if genInfo.Profiler == nil {
+		genInfo.Profiler = NewProfiler(false, "")
+	}
+	defer genInfo.Profiler.Write()
+
+	defer genInfo.Profiler.Track("Total Generation")()
+
 	log.Printf("Starting site generation (v%s) with %d repos to %s", version, len(sites), outDir)
+	stepMkdir := genInfo.Profiler.Track("Create Output Directory")
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		return err
 	}
+	stepMkdir()
 
+	stepPopulate := genInfo.Profiler.Track("Populate Package Use Flags")
 	for _, site := range sites {
 		populatePkgUseFlags(site)
 	}
+	stepPopulate()
 
 	// Generate search index
+	stepSearchIndex := genInfo.Profiler.Track("Generate Search Index")
 	if err := generateSearchIndex(outDir, sites); err != nil {
 		log.Printf("Warning: failed to generate search index: %v", err)
 	}
+	stepSearchIndex()
 
+	stepTemplates := genInfo.Profiler.Track("Load Templates")
 	tmpl, err := GetSiteTemplates()
 	if err != nil {
 		return fmt.Errorf("loading templates: %w", err)
 	}
+	stepTemplates()
+
 
 	for _, site := range sites {
 		aggPackagesMap := make(map[string]*AggPackage)
@@ -1320,29 +1336,39 @@ func generateSite(outDir string, sites []*g2.SiteData, recentDuration time.Durat
 
 	// Render Phases
 	log.Printf("[PHASE] Rendering global pages...")
+	stepGlobalPages := genInfo.Profiler.Track("Render Global Pages")
 	if err := generateGlobalPages(outDir, tmpl, sites, data, title, version, recentDurationStr, genInfo); err != nil {
 		return err
 	}
+	stepGlobalPages()
 
 	log.Printf("[PHASE] Rendering %d category pages...", len(data.Categories))
+	stepCategoryPages := genInfo.Profiler.Track("Render Category Pages")
 	if err := generateCategoryPages(outDir, tmpl, data, title, version, genInfo); err != nil {
 		return err
 	}
+	stepCategoryPages()
 
 	log.Printf("[PHASE] Rendering package pages...")
+	stepPackagePages := genInfo.Profiler.Track("Render Package Pages")
 	if err := generatePackagePages(outDir, tmpl, data, title, version, genInfo); err != nil {
 		return err
 	}
+	stepPackagePages()
 
 	log.Printf("[PHASE] Rendering other global pages...")
+	stepOtherGlobalPages := genInfo.Profiler.Track("Render Other Global Pages")
 	if err := generateOtherGlobalPages(outDir, tmpl, data, title, version, genInfo); err != nil {
 		return err
 	}
+	stepOtherGlobalPages()
 
 	log.Printf("[PHASE] Rendering %d repository pages...", len(sites))
+	stepRepositoryPages := genInfo.Profiler.Track("Render Repository Pages")
 	if err := generateRepoPages(outDir, tmpl, sites, data, title, version, recentDurationStr, genInfo); err != nil {
 		return err
 	}
+	stepRepositoryPages()
 
 	totalNodes := len(data.Categories) + data.TotalPackages + len(data.Profiles) + len(data.GlobalNews) + len(data.Moves) + len(data.Eclasses)
 	for _, pkg := range data.Packages {

--- a/cmd/g2/profiler.go
+++ b/cmd/g2/profiler.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+type Profiler struct {
+	enabled   bool
+	outPath   string
+	events    []ProfileEvent
+	startTime time.Time
+}
+
+type ProfileEvent struct {
+	Name     string
+	Duration time.Duration
+}
+
+func NewProfiler(enabled bool, outPath string) *Profiler {
+	return &Profiler{
+		enabled:   enabled,
+		outPath:   outPath,
+		startTime: time.Now(),
+	}
+}
+
+func (p *Profiler) Record(name string, d time.Duration) {
+	if !p.enabled {
+		return
+	}
+	p.events = append(p.events, ProfileEvent{Name: name, Duration: d})
+}
+
+func (p *Profiler) Track(name string) func() {
+	if !p.enabled {
+		return func() {}
+	}
+	start := time.Now()
+	return func() {
+		p.Record(name, time.Since(start))
+	}
+}
+
+func (p *Profiler) Write() error {
+	if !p.enabled {
+		return nil
+	}
+	var out io.Writer
+	if p.outPath == "-" {
+		out = os.Stdout
+	} else {
+		f, err := os.Create(p.outPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		out = f
+	}
+
+	total := time.Since(p.startTime)
+	fmt.Fprintf(out, "Site Generation Profile Report\n")
+	fmt.Fprintf(out, "==============================\n")
+	for _, ev := range p.events {
+		fmt.Fprintf(out, "%-40s %v\n", ev.Name+":", ev.Duration)
+	}
+	fmt.Fprintf(out, "------------------------------\n")
+	fmt.Fprintf(out, "%-40s %v\n", "Total Time:", total)
+	return nil
+}

--- a/cmd/g2/profiler.go
+++ b/cmd/g2/profiler.go
@@ -56,17 +56,17 @@ func (p *Profiler) Write() error {
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		out = f
 	}
 
 	total := time.Since(p.startTime)
-	fmt.Fprintf(out, "Site Generation Profile Report\n")
-	fmt.Fprintf(out, "==============================\n")
+	_, _ = fmt.Fprintf(out, "Site Generation Profile Report\n")
+	_, _ = fmt.Fprintf(out, "==============================\n")
 	for _, ev := range p.events {
-		fmt.Fprintf(out, "%-40s %v\n", ev.Name+":", ev.Duration)
+		_, _ = fmt.Fprintf(out, "%-40s %v\n", ev.Name+":", ev.Duration)
 	}
-	fmt.Fprintf(out, "------------------------------\n")
-	fmt.Fprintf(out, "%-40s %v\n", "Total Time:", total)
+	_, _ = fmt.Fprintf(out, "------------------------------\n")
+	_, _ = fmt.Fprintf(out, "%-40s %v\n", "Total Time:", total)
 	return nil
 }

--- a/cmd/g2/profiler.go
+++ b/cmd/g2/profiler.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 )
 
 type Profiler struct {
+	mu        sync.Mutex
 	enabled   bool
 	outPath   string
 	events    []ProfileEvent
@@ -31,6 +33,8 @@ func (p *Profiler) Record(name string, d time.Duration) {
 	if !p.enabled {
 		return
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.events = append(p.events, ProfileEvent{Name: name, Duration: d})
 }
 

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -80,6 +80,8 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	}
 
 	fs := flag.NewFlagSet("overlay site generate", flag.ExitOnError)
+	profileSiteGen := fs.Bool("profile", false, "Generate a profile report of site generation")
+	profileOut := fs.String("profile-out", "profile.txt", "Output file for the profile report, or '-' for stdout")
 	outDir := fs.String("out", "site_out", "Output directory for the generated site")
 	clear := fs.Bool("clear", false, "Clear output directory before generation")
 	recentDurOpt := fs.String("recent-duration", "3mo", "Duration to consider an update 'recent' (e.g. 3mo, 14d, 72h)")
@@ -262,6 +264,8 @@ func (cfg *MainArgConfig) cmdOverlay(args []string) error {
 	})
 
 	genInfo := GenerationInfo{Args: cfg.Args, FastGit: *fastGit, RecentDuration: recentDurationStr}
+	profiler := NewProfiler(*profileSiteGen, *profileOut)
+	genInfo.Profiler = profiler
 	if err := generateSite(*outDir, allSites, recentDuration, recentDurationStr, genInfo); err != nil {
 		return fmt.Errorf("generating site: %w", err)
 	}
@@ -289,6 +293,8 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	}
 
 	fs := flag.NewFlagSet("overlays site generate", flag.ExitOnError)
+	profileSiteGen := fs.Bool("profile", false, "Generate a profile report of site generation")
+	profileOut := fs.String("profile-out", "profile.txt", "Output file for the profile report, or '-' for stdout")
 	outDir := fs.String("out", "site_out", "Output directory for the generated site")
 	clear := fs.Bool("clear", false, "Clear output directory before generation")
 	recentDurOpt := fs.String("recent-duration", "3mo", "Duration to consider an update 'recent' (e.g. 3mo, 14d, 72h)")
@@ -327,7 +333,7 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	}
 
 	log.Printf("Generating site (v%s) from remote repositories: %s into %s", version, location, *outDir)
-	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError, *persistentDir, *reposConfOpt, *tempDir, *workMode, *mode)
+	return cfg.cmdSiteRemote(location, *outDir, recentDuration, recentDurationStr, *fastGit, *useZip, *concurrency, *retries, *continueOnError, *persistentDir, *reposConfOpt, *tempDir, *workMode, *mode, *profileSiteGen, *profileOut)
 }
 
 func parseLayoutConfFromFS(sysFS fs.FS, path string) (*g2.LayoutConf, error) {
@@ -1842,7 +1848,7 @@ func renderPage(path string, tmpl *template.Template, name string, data interfac
 	return nil
 }
 
-func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool, persistentDir string, reposConfPath string, tempDir string, workMode string, mode string) error {
+func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, recentDuration time.Duration, recentDurationStr string, fastGit bool, useZip bool, concurrency int, retries int, continueOnError bool, persistentDir string, reposConfPath string, tempDir string, workMode string, mode string, profileSiteGen bool, profileOut string) error {
 	var repos g2.Repositories
 
 	if reposConfPath != "" {
@@ -2388,7 +2394,9 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	log.Printf("--------------------------------------------------")
 
 	log.Printf("Generating integrated site (v%s) for %d repos", version, len(allSites))
-	if err := generateSite(outDir, allSites, recentDuration, recentDurationStr, GenerationInfo{}); err != nil {
+	profiler := NewProfiler(profileSiteGen, profileOut)
+	genInfo := GenerationInfo{Profiler: profiler}
+	if err := generateSite(outDir, allSites, recentDuration, recentDurationStr, genInfo); err != nil {
 		return fmt.Errorf("generating integrated site: %w", err)
 	}
 

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -2395,7 +2395,12 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 
 	log.Printf("Generating integrated site (v%s) for %d repos", version, len(allSites))
 	profiler := NewProfiler(profileSiteGen, profileOut)
-	genInfo := GenerationInfo{Profiler: profiler}
+	genInfo := GenerationInfo{
+		Profiler:       profiler,
+		Args:           cfg.Args,
+		FastGit:        fastGit,
+		RecentDuration: recentDurationStr,
+	}
 	if err := generateSite(outDir, allSites, recentDuration, recentDurationStr, genInfo); err != nil {
 		return fmt.Errorf("generating integrated site: %w", err)
 	}


### PR DESCRIPTION
Implemented a profiler for `g2` static site generation.

- Added `-profile` (boolean) to enable profiling and `-profile-out` (string, defaults to `profile.txt`, accepts `-` for stdout) flags to `overlay site generate` and `overlays site generate` CLI commands.
- Created `Profiler` utility in `cmd/g2/profiler.go`.
- Added tracking steps for major generation phases (Output Directory Creation, Using flags population, Search Index Generation, Template Loading, Global Pages rendering, etc) in `generateSite()`.
- Wires up the output to happen cleanly via `defer`.

---
*PR created automatically by Jules for task [12850066540585968943](https://jules.google.com/task/12850066540585968943) started by @arran4*