### PR TITLE
fix: prevent git clone from hanging on credential prompts

### DIFF
--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -89,8 +89,10 @@ func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool, 
 
 func updatePersistentRepo(ctx context.Context, destDir string) error {
 	log.Printf("Persistent repo exists, attempting to fetch and reset: %s", destDir)
+	noPromptEnv := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+
 	cmdFetch := exec.CommandContext(ctx, "git", "fetch", "--force", "--depth", "1", "origin", "HEAD")
-	cmdFetch.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true")
+	cmdFetch.Env = noPromptEnv
 	cmdFetch.Dir = destDir
 	cmdFetch.Stdout = os.Stdout
 	cmdFetch.Stderr = os.Stderr
@@ -99,7 +101,7 @@ func updatePersistentRepo(ctx context.Context, destDir string) error {
 	}
 
 	cmdReset := exec.CommandContext(ctx, "git", "reset", "--hard", "FETCH_HEAD")
-	cmdReset.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true")
+	cmdReset.Env = noPromptEnv
 	cmdReset.Dir = destDir
 	cmdReset.Stdout = os.Stdout
 	cmdReset.Stderr = os.Stderr
@@ -108,7 +110,7 @@ func updatePersistentRepo(ctx context.Context, destDir string) error {
 	}
 
 	cmdClean := exec.CommandContext(ctx, "git", "clean", "-fdx")
-	cmdClean.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true")
+	cmdClean.Env = noPromptEnv
 	cmdClean.Dir = destDir
 	cmdClean.Stdout = os.Stdout
 	cmdClean.Stderr = os.Stderr
@@ -170,7 +172,7 @@ func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", gitUrl, destDir)
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true")
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -90,6 +90,7 @@ func FetchRepo(ctx context.Context, gitUrl string, destDir string, useZip bool, 
 func updatePersistentRepo(ctx context.Context, destDir string) error {
 	log.Printf("Persistent repo exists, attempting to fetch and reset: %s", destDir)
 	cmdFetch := exec.CommandContext(ctx, "git", "fetch", "--force", "--depth", "1", "origin", "HEAD")
+	cmdFetch.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true")
 	cmdFetch.Dir = destDir
 	cmdFetch.Stdout = os.Stdout
 	cmdFetch.Stderr = os.Stderr
@@ -98,6 +99,7 @@ func updatePersistentRepo(ctx context.Context, destDir string) error {
 	}
 
 	cmdReset := exec.CommandContext(ctx, "git", "reset", "--hard", "FETCH_HEAD")
+	cmdReset.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true")
 	cmdReset.Dir = destDir
 	cmdReset.Stdout = os.Stdout
 	cmdReset.Stderr = os.Stderr
@@ -106,6 +108,7 @@ func updatePersistentRepo(ctx context.Context, destDir string) error {
 	}
 
 	cmdClean := exec.CommandContext(ctx, "git", "clean", "-fdx")
+	cmdClean.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true")
 	cmdClean.Dir = destDir
 	cmdClean.Stdout = os.Stdout
 	cmdClean.Stderr = os.Stderr
@@ -167,6 +170,7 @@ func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", gitUrl, destDir)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=/bin/true")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
This fixes an issue where the `g2` site generation process could stall for hours and eventually fail due to a timeout in GitHub Actions when it encountered a repository requiring authentication (e.g., `touchfish-os`). Setting these environment variables ensures that git fails fast instead of waiting indefinitely for input that will never come.

---
*PR created automatically by Jules for task [13023081596074584073](https://jules.google.com/task/13023081596074584073) started by @arran4*