### PR TITLE
🧹 Remove unused EclassData struct in site.go

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -35,12 +35,6 @@ func getProcessMemUsage() uint64 {
 
 type SourceURL string
 
-type EclassData struct {
-	Name string
-}
-
-// End model TODO check
-
 func getDefaultCacheDir() string {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil || cacheDir == "" {


### PR DESCRIPTION
🎯 **What:** Removed unused `EclassData` struct and `// End model TODO check` comment from `cmd/g2/site.go`.
💡 **Why:** The unused struct and comment were cluttering the code and represented unfinished code that was no longer necessary. Removing them improves maintainability and readability without affecting functionality.
✅ **Verification:** Ran `go test .` and `go test ./cmd/g2/...` to ensure all tests pass and no functionality is broken.
✨ **Result:** Improved code health by removing dead code.

---
*PR created automatically by Jules for task [2551029016285790687](https://jules.google.com/task/2551029016285790687) started by @arran4*