### PR TITLE
perf: optimize repository parsing by precomputing O(1) maps for SlotMoves and InfoPkgs

### DIFF
--- a/cmd/g2/parse_repo.go
+++ b/cmd/g2/parse_repo.go
@@ -235,6 +235,23 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 		}
 	}
 
+	slotMovesMap := make(map[string][]g2.PackageSlotMove)
+	if site.SlotMoves != nil {
+		for _, sm := range site.SlotMoves {
+			slotMovesMap[sm.Package] = append(slotMovesMap[sm.Package], sm)
+		}
+	}
+
+	infoPkgsMap := make(map[string]bool)
+	for j := range site.InfoPkgs {
+		atom := site.InfoPkgs[j].PackageAtom
+		baseAtom := atom
+		if idx := strings.Index(atom, ":"); idx != -1 {
+			baseAtom = atom[:idx]
+		}
+		infoPkgsMap[baseAtom] = true
+	}
+
 	entries, err := fs.ReadDir(sysFS, filepath.ToSlash(repoDir))
 	if err != nil {
 		return fmt.Errorf("reading repo dir: %w", err)
@@ -334,10 +351,10 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 					ModTime:      modTime,
 				}
 
-				if site.SlotMoves != nil {
-					if slot := ebuild.Vars["SLOT"]; slot != "" {
-						for _, sm := range site.SlotMoves {
-							if sm.Package == name+"/"+pkgName && sm.Old == slot {
+				if slot := ebuild.Vars["SLOT"]; slot != "" {
+					if moves, ok := slotMovesMap[name+"/"+pkgName]; ok {
+						for _, sm := range moves {
+							if sm.Old == slot {
 								vd.MovedToSlot = sm.New
 								break
 							}
@@ -505,16 +522,8 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 				})
 			}
 
-			for j := range site.InfoPkgs {
-				atom := site.InfoPkgs[j].PackageAtom
-				baseAtom := atom
-				if idx := strings.Index(atom, ":"); idx != -1 {
-					baseAtom = atom[:idx]
-				}
-				if baseAtom == pkgStr {
-					pkgData.IsInfoPkg = true
-					break
-				}
+			if infoPkgsMap[pkgStr] {
+				pkgData.IsInfoPkg = true
 			}
 
 			pkgData.LintWarnings = lints.PerformLinting(repoDir, &g2PkgData)

--- a/cmd/g2/parse_repo.go
+++ b/cmd/g2/parse_repo.go
@@ -298,6 +298,8 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 				Category: name,
 			}
 
+			pkgStr := name + "/" + pkgName
+
 			files, err := fs.ReadDir(sysFS, filepath.ToSlash(pkgPath))
 			if err != nil {
 				log.Printf("Warning: reading package dir %s: %v", pkgPath, err)
@@ -352,7 +354,7 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 				}
 
 				if slot := ebuild.Vars["SLOT"]; slot != "" {
-					if moves, ok := slotMovesMap[name+"/"+pkgName]; ok {
+					if moves, ok := slotMovesMap[pkgStr]; ok {
 						for _, sm := range moves {
 							if sm.Old == slot {
 								vd.MovedToSlot = sm.New
@@ -498,8 +500,6 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 				MetadataError: pkgData.MetadataError,
 				Manifest:      pkgData.Manifest,
 			}
-
-			pkgStr := pkgData.Category + "/" + pkgData.Name
 
 			if dep, ok := deprecatedMap[pkgStr]; ok {
 				pkgData.Deprecated = dep


### PR DESCRIPTION
The parsing step `parseRepoCategoriesAndPackages` previously iterated through the entire `site.SlotMoves` slice for every version processed and `site.InfoPkgs` for every package processed. This caused a combinatorial explosion resulting in the process taking longer than 2 hours and getting killed for repositories with tens of thousands of packages. 

This change precomputes maps `slotMovesMap` and `infoPkgsMap` before beginning the loops over categories and packages, replacing the inner loops with fast O(1) map lookups.

---
*PR created automatically by Jules for task [10144247349020248120](https://jules.google.com/task/10144247349020248120) started by @arran4*