### PR TITLE
🧪 test: add invalid XML test case for ParseMetadata

### DIFF
--- a/metadata_test.go
+++ b/metadata_test.go
@@ -34,11 +34,16 @@ func TestParseMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseMetadata(tt.path)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ParseMetadata() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err != nil {
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseMetadata() error = nil, wantErr %v", tt.wantErr)
+				}
 				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseMetadata() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if reflect.TypeOf(got) != reflect.TypeOf(tt.wantType) {

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -12,6 +12,7 @@ func TestParseMetadata(t *testing.T) {
 		name     string
 		path     string
 		wantType interface{}
+		wantErr  bool
 	}{
 		{
 			name:     "PkgMetadata",
@@ -23,13 +24,21 @@ func TestParseMetadata(t *testing.T) {
 			path:     "testdata/cat_metadata.xml",
 			wantType: &CatMetadata{},
 		},
+		{
+			name:    "Invalid XML",
+			path:    "testdata/invalid_metadata.xml",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseMetadata(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseMetadata() error = %v, wantErr %v", err, tt.wantErr)
+			}
 			if err != nil {
-				t.Fatalf("ParseMetadata() error = %v", err)
+				return
 			}
 
 			if reflect.TypeOf(got) != reflect.TypeOf(tt.wantType) {

--- a/testdata/invalid_metadata.xml
+++ b/testdata/invalid_metadata.xml
@@ -1,0 +1,1 @@
+<invalid>


### PR DESCRIPTION
🎯 **What:** Added a test case in `metadata_test.go` to verify that `ParseMetadata` properly returns an error when reading an invalid XML file. Added `testdata/invalid_metadata.xml` containing malformed XML to support this test.

📊 **Coverage:** The scenario where a user provides a malformed/invalid XML file to `ParseMetadata` is now covered. `wantErr` boolean field has been added to the table-driven test structurally verifying error handling dynamically.

✨ **Result:** Improved robustness by asserting that invalid XML inputs predictably yield an error instead of succeeding or causing a panic.

---
*PR created automatically by Jules for task [3338409401397846797](https://jules.google.com/task/3338409401397846797) started by @arran4*