### PR TITLE
🔒 Remove deprecated SHA1 checksum support

### DIFF
--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -199,7 +199,6 @@ func (cfg *MainArgConfig) cmdManifest(args []string) error {
 	blake2s := fs.Bool("blake2s", false, "Calculate BLAKE2S checksum")
 	md5 := fs.Bool("md5", false, "Calculate MD5 checksum")
 	rmd160 := fs.Bool("rmd160", false, "Calculate RMD160 checksum")
-	sha1 := fs.Bool("sha1", false, "Calculate SHA1 checksum")
 	sha256 := fs.Bool("sha256", false, "Calculate SHA256 checksum")
 	sha3_256 := fs.Bool("sha3_256", false, "Calculate SHA3_256 checksum")
 	sha3_512 := fs.Bool("sha3_512", false, "Calculate SHA3_512 checksum")
@@ -230,9 +229,6 @@ func (cfg *MainArgConfig) cmdManifest(args []string) error {
 		}
 		if *rmd160 {
 			hashes = append(hashes, g2.HashRmd160)
-		}
-		if *sha1 {
-			hashes = append(hashes, g2.HashSha1)
 		}
 		if *sha256 {
 			hashes = append(hashes, g2.HashSha256)

--- a/doc/g2.1.md
+++ b/doc/g2.1.md
@@ -19,7 +19,7 @@ Commands relating to **Manifest** files.
 
 - **upsert-from-url** *<url>* *<filename>* *<manifestFileOrDir>*
   Downloads a file from *<url>*, calculates required checksums, and updates or inserts the entry into the `Manifest` file.
-  Flags: `-blake2b`, `-blake2s`, `-md5`, `-rmd160`, `-sha1`, `-sha256`, `-sha3_256`, `-sha3_512`, `-sha512` (default: `blake2b` and `sha512`).
+  Flags: `-blake2b`, `-blake2s`, `-md5`, `-rmd160`, `-sha256`, `-sha3_256`, `-sha3_512`, `-sha512` (default: `blake2b` and `sha512`).
 
 - **verify** [*--fix*] [*--clean*] *<manifestFileOrDir>*
   Verifies the `Manifest` entries against the ebuild URIs. If `--fix` is passed, missing entries will be downloaded and upserted. If `--clean` is passed, unused entries will be removed.

--- a/httputil.go
+++ b/httputil.go
@@ -2,7 +2,6 @@ package g2
 
 import (
 	"crypto/md5"
-	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
@@ -22,7 +21,6 @@ const (
 	HashBlake2s  = "BLAKE2S"
 	HashMd5      = "MD5"
 	HashRmd160   = "RMD160"
-	HashSha1     = "SHA1"
 	HashSha256   = "SHA256"
 	HashSha3_256 = "SHA3_256"
 	HashSha3_512 = "SHA3_512"
@@ -34,7 +32,6 @@ var AllHashes = []string{
 	HashBlake2s,
 	HashMd5,
 	HashRmd160,
-	HashSha1,
 	HashSha256,
 	HashSha3_256,
 	HashSha3_512,
@@ -128,10 +125,6 @@ func DownloadAndChecksum(url string, hashes []string) (*Checksums, error) {
 			h := ripemd160.New() //nolint:staticcheck
 			writers = append(writers, h)
 			hashers[HashRmd160] = h
-		case HashSha1:
-			h := sha1.New()
-			writers = append(writers, h)
-			hashers[HashSha1] = h
 		case HashSha256:
 			h := sha256.New()
 			writers = append(writers, h)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -171,7 +171,7 @@ func TestUpsert(t *testing.T) {
 
 	// Create initial manifest
 	entry1 := &ManifestEntry{Type: "DIST", Filename: "A", Size: 100}
-	entry1.AddHash("SHA256", "123")
+	entry1.AddHash(HashSha256, "123")
 	if err := UpsertManifest(manifestPath, entry1); err != nil {
 		t.Fatalf("First upsert failed: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestUpsert(t *testing.T) {
 
 	// Update existing
 	entry1Updated := &ManifestEntry{Type: "DIST", Filename: "A", Size: 200}
-	entry1Updated.AddHash("SHA256", "999")
+	entry1Updated.AddHash(HashSha256, "999")
 	if err := UpsertManifest(manifestPath, entry1Updated); err != nil {
 		t.Fatalf("Update upsert failed: %v", err)
 	}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -171,7 +171,7 @@ func TestUpsert(t *testing.T) {
 
 	// Create initial manifest
 	entry1 := &ManifestEntry{Type: "DIST", Filename: "A", Size: 100}
-	entry1.AddHash("SHA1", "123")
+	entry1.AddHash("SHA256", "123")
 	if err := UpsertManifest(manifestPath, entry1); err != nil {
 		t.Fatalf("First upsert failed: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestUpsert(t *testing.T) {
 
 	// Update existing
 	entry1Updated := &ManifestEntry{Type: "DIST", Filename: "A", Size: 200}
-	entry1Updated.AddHash("SHA1", "999")
+	entry1Updated.AddHash("SHA256", "999")
 	if err := UpsertManifest(manifestPath, entry1Updated); err != nil {
 		t.Fatalf("Update upsert failed: %v", err)
 	}

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,6 @@ g2 manifest [flags] upsert-from-url <url> <filename> <manifestFileOrDir>
 * `-blake2s` (default: `false`): Calculate BLAKE2S checksum.
 * `-md5` (default: `false`): Calculate MD5 checksum.
 * `-rmd160` (default: `false`): Calculate RMD160 checksum.
-* `-sha1` (default: `false`): Calculate SHA1 checksum.
 * `-sha256` (default: `false`): Calculate SHA256 checksum.
 * `-sha3_256` (default: `false`): Calculate SHA3-256 checksum.
 * `-sha3_512` (default: `false`): Calculate SHA3-512 checksum.


### PR DESCRIPTION
🎯 **What:** The SHA1 cryptographic hash algorithm, used for downloading and verifying checksums in `httputil.go`, was completely removed from the project.
⚠️ **Risk:** SHA1 is cryptographically broken and vulnerable to collision attacks. If left unfixed, attackers could potentially spoof files or bypass integrity checks where SHA1 is relied upon as a primary or fallback verification.
🛡️ **Solution:** The `HashSha1` constant, flag, and relevant switch cases were removed. Test cases were updated to verify with `SHA256` instead. Documentation was similarly cleaned up to remove mention of the `-sha1` option.

---
*PR created automatically by Jules for task [9411971734188057359](https://jules.google.com/task/9411971734188057359) started by @arran4*