### PR TITLE
Fix: update sha3 import to standard library

### DIFF
--- a/httputil.go
+++ b/httputil.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/blake2s"
 	"golang.org/x/crypto/ripemd160" //nolint:staticcheck
-	"golang.org/x/crypto/sha3"
+	"crypto/sha3"
 	"hash"
 	"io"
 	"log"


### PR DESCRIPTION
Replaced `golang.org/x/crypto/sha3` with `crypto/sha3` to fix `govet` inline errors during `golangci-lint` run.

---
*PR created automatically by Jules for task [13240849926833469973](https://jules.google.com/task/13240849926833469973) started by @arran4*