### PR TITLE
Fix missing categories on repository-specific pages

### DIFF
--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -521,8 +521,8 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"Title":      s.Title,
 			"BaseURL":    "",
 			"Repos":      s.Sites,
-			"Categories": s.AggCategories,
-			"Packages":   s.AggPackages,
+			"GlobalCategories": s.AggCategories,
+			"GlobalPackages":   s.AggPackages,
 			"Licenses":   s.AggLicenses,
 			"UseFlags":   s.AggUseFlags,
 			"Projects":   s.AggProjects,
@@ -557,7 +557,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				"Title":       "Categories",
 				"BaseURL":     baseURL,
 				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Categories"}},
-				"Categories":  s.AggCategories,
+				"GlobalCategories":  s.AggCategories,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,
 			})
@@ -868,7 +868,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							"Title":       site.RepoName + " - Categories",
 							"BaseURL":     baseURL,
 							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Categories"}},
-							"Categories":  site.Categories,
+							"RepoCategories":  site.Categories,
 							"Version":     version,
 							"GenInfo":     s.GenInfo,
 						})

--- a/templates/views/categories.html
+++ b/templates/views/categories.html
@@ -1,7 +1,16 @@
 
+{{if .RepoCategories}}
+<h2>Repo Categories</h2>
+<ul>
+    {{range .RepoCategories}}
+    <li><a href="{{.Name}}/">{{.Name}}</a> ({{len .Packages}} packages)</li>
+    {{end}}
+</ul>
+{{else}}
 <h2>All Categories</h2>
 <ul>
     {{range .GlobalCategories}}
     <li><a href="{{.Name}}/">{{.Name}}</a> ({{len .Packages}} packages)</li>
     {{end}}
 </ul>
+{{end}}

--- a/templates/views/categories.html
+++ b/templates/views/categories.html
@@ -6,7 +6,7 @@
     <li><a href="{{.Name}}/">{{.Name}}</a> ({{len .Packages}} packages)</li>
     {{end}}
 </ul>
-{{else}}
+{{else if .GlobalCategories}}
 <h2>All Categories</h2>
 <ul>
     {{range .GlobalCategories}}


### PR DESCRIPTION
Resolves an issue where category lists within individual repository pages (like `/repos/kde/categories/`) were completely empty. The core problem was that the `categories.html` template ignored the repository-specific `.RepoCategories` context, iterating over the global categories instead. In addition to fixing the template, the patch corrects context mapping keys in the local development server (`cmd/g2/site_serve.go`) to ensure consistency with the static site generator logic.

---
*PR created automatically by Jules for task [1262444207127952557](https://jules.google.com/task/1262444207127952557) started by @arran4*