### PR TITLE
Conditionally render "masked" unmasking instructions

### DIFF
--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -21,6 +21,7 @@ func getTemplateFuncMap() template.FuncMap {
 		"formatKeywords":      formatKeywordsFunc,
 		"hasPrefix":           strings.HasPrefix,
 		"groupIUSEFlags":      groupIUSEFlagsFunc,
+		"isLikelyMasked":      isLikelyMaskedFunc,
 		"len_or_zero": func(v any) int {
 			if v == nil {
 				return 0
@@ -120,4 +121,33 @@ func groupIUSEFlagsFunc(flags []ParsedIUSEFlag, useExpandPrefixes map[string]boo
 		result = append(result, UseFlagGroup{Name: name, Flags: groups[name]})
 	}
 	return result
+}
+
+func isLikelyMaskedFunc(keywords interface{}, explicitlyMasked interface{}) bool {
+	if explicitlyMasked != nil {
+		val := reflect.ValueOf(explicitlyMasked)
+		if val.Kind() == reflect.Ptr && !val.IsNil() {
+			return true
+		} else if val.Kind() != reflect.Ptr && val.IsValid() && !val.IsZero() {
+			return true
+		}
+	}
+
+	keywordsStr := ""
+	if keywords != nil {
+		if s, ok := keywords.(string); ok {
+			keywordsStr = s
+		}
+	}
+
+	if strings.TrimSpace(keywordsStr) == "" {
+		return true
+	}
+	parts := strings.Fields(keywordsStr)
+	for _, p := range parts {
+		if !strings.HasPrefix(p, "-") && !strings.HasPrefix(p, "~") {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -126,9 +126,9 @@ func groupIUSEFlagsFunc(flags []ParsedIUSEFlag, useExpandPrefixes map[string]boo
 func isLikelyMaskedFunc(keywords interface{}, explicitlyMasked interface{}) bool {
 	if explicitlyMasked != nil {
 		val := reflect.ValueOf(explicitlyMasked)
-		if val.Kind() == reflect.Ptr && !val.IsNil() {
+		if val.Kind() == reflect.Pointer && !val.IsNil() {
 			return true
-		} else if val.Kind() != reflect.Ptr && val.IsValid() && !val.IsZero() {
+		} else if val.Kind() != reflect.Pointer && val.IsValid() && !val.IsZero() {
 			return true
 		}
 	}

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -22,6 +22,7 @@ func getTemplateFuncMap() template.FuncMap {
 		"hasPrefix":           strings.HasPrefix,
 		"groupIUSEFlags":      groupIUSEFlagsFunc,
 		"isLikelyMasked":      isLikelyMaskedFunc,
+		"isPkgLikelyMasked":   isPkgLikelyMaskedFunc,
 		"len_or_zero": func(v any) int {
 			if v == nil {
 				return 0
@@ -123,31 +124,79 @@ func groupIUSEFlagsFunc(flags []ParsedIUSEFlag, useExpandPrefixes map[string]boo
 	return result
 }
 
-func isLikelyMaskedFunc(keywords interface{}, explicitlyMasked interface{}) bool {
-	if explicitlyMasked != nil {
-		val := reflect.ValueOf(explicitlyMasked)
-		if val.Kind() == reflect.Pointer && !val.IsNil() {
-			return true
-		} else if val.Kind() != reflect.Pointer && val.IsValid() && !val.IsZero() {
-			return true
-		}
-	}
-
-	keywordsStr := ""
-	if keywords != nil {
-		if s, ok := keywords.(string); ok {
-			keywordsStr = s
-		}
-	}
-
-	if strings.TrimSpace(keywordsStr) == "" {
+func isLikelyMaskedFunc(keywords any, explicitlyMasked any) bool {
+	if val := reflect.ValueOf(explicitlyMasked); val.IsValid() && !val.IsZero() {
 		return true
 	}
+
+	keywordsStr, _ := keywords.(string)
 	parts := strings.Fields(keywordsStr)
+	if len(parts) == 0 {
+		return true
+	}
 	for _, p := range parts {
 		if !strings.HasPrefix(p, "-") && !strings.HasPrefix(p, "~") {
 			return false
 		}
 	}
 	return true
+}
+
+func isPkgLikelyMaskedFunc(pkg any) bool {
+	val := reflect.ValueOf(pkg)
+	if !val.IsValid() || val.IsZero() || val.Kind() != reflect.Struct {
+		return false
+	}
+
+	// Check explicitlyMasked (.Masked)
+	explicitlyMasked := val.FieldByName("Masked")
+	if explicitlyMasked.IsValid() && !explicitlyMasked.IsZero() {
+		return true
+	}
+
+	versions := val.FieldByName("Versions")
+	if versions.IsValid() && versions.Kind() == reflect.Slice {
+		if versions.Len() == 0 {
+			return true // No versions, likely masked/empty
+		}
+
+		allVersionsMasked := true
+		for i := 0; i < versions.Len(); i++ {
+			versionVal := versions.Index(i)
+			if !versionVal.IsValid() || versionVal.Kind() != reflect.Struct {
+				continue
+			}
+
+			ebuildVal := versionVal.FieldByName("Ebuild")
+			if !ebuildVal.IsValid() || ebuildVal.IsZero() {
+				continue
+			}
+
+			if ebuildVal.Kind() == reflect.Pointer {
+				ebuildVal = ebuildVal.Elem()
+			}
+
+			varsVal := ebuildVal.FieldByName("Vars")
+			if !varsVal.IsValid() || varsVal.IsZero() {
+				continue
+			}
+
+			keywordsVal := varsVal.MapIndex(reflect.ValueOf("KEYWORDS"))
+			var keywords string
+			if keywordsVal.IsValid() {
+				keywords = keywordsVal.String()
+			}
+
+			if !isLikelyMaskedFunc(keywords, nil) {
+				allVersionsMasked = false
+				break
+			}
+		}
+
+		if allVersionsMasked {
+			return true
+		}
+	}
+
+	return false
 }

--- a/templates/views/ebuild_details.html
+++ b/templates/views/ebuild_details.html
@@ -54,10 +54,12 @@
     <h3>Install</h3>
     <p>Install this version:</p>
     <pre><code>emerge -a ={{.RepoPackage.Category}}/{{.RepoPackage.Name}}-{{.VersionData.Version}}</code></pre>
+    {{if isLikelyMasked .VersionData.Ebuild.Vars.KEYWORDS .VersionData.Masked}}
     <p>If this version is masked, you can unmask it using the <code>autounmask</code> tool or standard <code>emerge</code> options:</p>
     <pre><code>autounmask ={{.RepoPackage.Category}}/{{.RepoPackage.Name}}-{{.VersionData.Version}}</code></pre>
     <p>Or alternatively:</p>
     <pre><code>emerge --autounmask-write -a ={{.RepoPackage.Category}}/{{.RepoPackage.Name}}-{{.VersionData.Version}}</code></pre>
+    {{end}}
 </div>
 
 <div class="metadata-section">

--- a/templates/views/repo_package.html
+++ b/templates/views/repo_package.html
@@ -55,7 +55,7 @@
     <h3>Install</h3>
     <p>Install this package:</p>
     <pre><code>emerge -a {{.RepoPackage.Category}}/{{.RepoPackage.Name}}</code></pre>
-    {{if .RepoPackage.Masked}}
+    {{if isPkgLikelyMasked .RepoPackage}}
     <p>If the package is masked, you can unmask it using the <code>autounmask</code> tool or standard <code>emerge</code> options:</p>
     <pre><code>autounmask {{.RepoPackage.Category}}/{{.RepoPackage.Name}}</code></pre>
     <p>Or alternatively:</p>

--- a/templates/views/repo_package.html
+++ b/templates/views/repo_package.html
@@ -55,10 +55,12 @@
     <h3>Install</h3>
     <p>Install this package:</p>
     <pre><code>emerge -a {{.RepoPackage.Category}}/{{.RepoPackage.Name}}</code></pre>
+    {{if .RepoPackage.Masked}}
     <p>If the package is masked, you can unmask it using the <code>autounmask</code> tool or standard <code>emerge</code> options:</p>
     <pre><code>autounmask {{.RepoPackage.Category}}/{{.RepoPackage.Name}}</code></pre>
     <p>Or alternatively:</p>
     <pre><code>emerge --autounmask-write -a {{.RepoPackage.Category}}/{{.RepoPackage.Name}}</code></pre>
+    {{end}}
 </div>
 
 <div class="metadata-section">


### PR DESCRIPTION
Conditionally render "masked" unmasking instructions on ebuild and package pages only when the package or version is actually masked.

---
*PR created automatically by Jules for task [7722848623549963392](https://jules.google.com/task/7722848623549963392) started by @arran4*