### PR TITLE
feat: add hyperlinking for <pkg> tags in metadata

### DIFF
--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -5,9 +5,12 @@ import (
 	"html/template"
 	"net/url"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/arran4/g2"
 )
 
 func getTemplateFuncMap() template.FuncMap {
@@ -31,8 +34,49 @@ func getTemplateFuncMap() template.FuncMap {
 			}
 			return 0
 		},
-		"packageLink": packageLinkFunc,
+		"packageLink":       packageLinkFunc,
+		"formatPkgLinkBody": formatPkgLinkBodyFunc,
 	}
+}
+
+var tmplPkgRegex = regexp.MustCompile(`&lt;pkg&gt;(.*?)&lt;/pkg&gt;|<pkg>(.*?)</pkg>`)
+
+func formatPkgLinkBodyFunc(body string, baseURL string, currentRepo string, repoPkgs interface{}, globalPkgs []*AggPackage) template.HTML {
+	safeBody := template.HTMLEscapeString(body)
+	return template.HTML(tmplPkgRegex.ReplaceAllStringFunc(safeBody, func(m string) string {
+		match := tmplPkgRegex.FindStringSubmatch(m)
+		pkg := match[1]
+		if pkg == "" {
+			pkg = match[2]
+		}
+		parts := strings.Split(pkg, "/")
+		if len(parts) == 2 {
+			repoHasPkg := false
+			if repoPkgs != nil {
+				if rp, ok := repoPkgs.([]*AggPackage); ok {
+					for _, p := range rp {
+						if p.Category == parts[0] && p.Name == parts[1] {
+							repoHasPkg = true
+							break
+						}
+					}
+				} else if rp, ok := repoPkgs.([]g2.PackageData); ok {
+					for _, p := range rp {
+						if p.Category == parts[0] && p.Name == parts[1] {
+							repoHasPkg = true
+							break
+						}
+					}
+				}
+			}
+			if repoHasPkg && currentRepo != "" {
+				return fmt.Sprintf("<a href=\"%srepos/%s/categories/%s/packages/%s/\">%s</a>", template.HTMLEscapeString(baseURL), template.HTMLEscapeString(currentRepo), url.PathEscape(parts[0]), url.PathEscape(parts[1]), template.HTMLEscapeString(pkg))
+			}
+
+			return fmt.Sprintf("<a href=\"%spackages/%s/%s/\">%s</a>", template.HTMLEscapeString(baseURL), url.PathEscape(parts[0]), url.PathEscape(parts[1]), template.HTMLEscapeString(pkg))
+		}
+		return template.HTMLEscapeString(m)
+	}))
 }
 
 func packageLinkFunc(baseURL string, pkg string) template.HTML {

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -39,16 +39,13 @@ func getTemplateFuncMap() template.FuncMap {
 	}
 }
 
-var tmplPkgRegex = regexp.MustCompile(`&lt;pkg&gt;(.*?)&lt;/pkg&gt;|<pkg>(.*?)</pkg>`)
+var tmplPkgRegex = regexp.MustCompile(`&lt;pkg&gt;(.*?)&lt;/pkg&gt;`)
 
 func formatPkgLinkBodyFunc(body string, baseURL string, currentRepo string, repoPkgs interface{}, globalPkgs []*AggPackage) template.HTML {
 	safeBody := template.HTMLEscapeString(body)
 	return template.HTML(tmplPkgRegex.ReplaceAllStringFunc(safeBody, func(m string) string {
 		match := tmplPkgRegex.FindStringSubmatch(m)
 		pkg := match[1]
-		if pkg == "" {
-			pkg = match[2]
-		}
 		parts := strings.Split(pkg, "/")
 		if len(parts) == 2 {
 			repoHasPkg := false
@@ -70,12 +67,12 @@ func formatPkgLinkBodyFunc(body string, baseURL string, currentRepo string, repo
 				}
 			}
 			if repoHasPkg && currentRepo != "" {
-				return fmt.Sprintf("<a href=\"%srepos/%s/categories/%s/packages/%s/\">%s</a>", template.HTMLEscapeString(baseURL), template.HTMLEscapeString(currentRepo), url.PathEscape(parts[0]), url.PathEscape(parts[1]), template.HTMLEscapeString(pkg))
+				return fmt.Sprintf("<a href=\"%srepos/%s/categories/%s/packages/%s/\">%s</a>", template.HTMLEscapeString(baseURL), template.HTMLEscapeString(currentRepo), url.PathEscape(parts[0]), url.PathEscape(parts[1]), pkg)
 			}
 
-			return fmt.Sprintf("<a href=\"%spackages/%s/%s/\">%s</a>", template.HTMLEscapeString(baseURL), url.PathEscape(parts[0]), url.PathEscape(parts[1]), template.HTMLEscapeString(pkg))
+			return fmt.Sprintf("<a href=\"%spackages/%s/%s/\">%s</a>", template.HTMLEscapeString(baseURL), url.PathEscape(parts[0]), url.PathEscape(parts[1]), pkg)
 		}
-		return template.HTMLEscapeString(m)
+		return m
 	}))
 }
 

--- a/templates/views/category.html
+++ b/templates/views/category.html
@@ -47,7 +47,7 @@
             <span class="badge" style="background-color: #17a2b8; color: white; padding: 2px 5px; border-radius: 3px; font-size: 0.8em;">Virtual</span>
             {{end}}
             <span class="package-details">
-            {{if .DominantDescription}}<br/><small><b>Description:</b> {{.DominantDescription}}</small>{{end}}
+            {{if .DominantDescription}}<br/><small><b>Description:</b> {{formatPkgLinkBody .DominantDescription $.BaseURL "" nil $.GlobalPackages}}</small>{{end}}
             {{if .DominantHomepage}}<br/><small><b>Homepage:</b> <a href="{{.DominantHomepage}}">{{.DominantHomepage}}</a></small>{{end}}
             {{if .DominantLicense}}<br/><small><b>License:</b> {{.DominantLicense}}</small>{{end}}
             </span>
@@ -62,7 +62,7 @@
             <span class="badge" style="background-color: #17a2b8; color: white; padding: 2px 5px; border-radius: 3px; font-size: 0.8em;">Virtual</span>
             {{end}}
             <span class="package-details">
-            {{if .DominantDescription}}<br/><small><b>Description:</b> {{.DominantDescription}}</small>{{end}}
+            {{if .DominantDescription}}<br/><small><b>Description:</b> {{formatPkgLinkBody .DominantDescription $.BaseURL $.Repo.RepoName $.RepoPackages $.GlobalPackages}}</small>{{end}}
             {{if .DominantHomepage}}<br/><small><b>Homepage:</b> <a href="{{.DominantHomepage}}">{{.DominantHomepage}}</a></small>{{end}}
             {{if .DominantLicense}}<br/><small><b>License:</b> {{.DominantLicense}}</small>{{end}}
             </span>
@@ -82,7 +82,7 @@
             <span class="badge" style="background-color: #17a2b8; color: white; padding: 2px 5px; border-radius: 3px; font-size: 0.8em;">Virtual</span>
             {{end}}
             <span class="package-details">
-            {{if .DominantDescription}}<br/><small><b>Description:</b> {{.DominantDescription}}</small>{{end}}
+            {{if .DominantDescription}}<br/><small><b>Description:</b> {{formatPkgLinkBody .DominantDescription $.BaseURL "" nil $.GlobalPackages}}</small>{{end}}
             {{if .DominantHomepage}}<br/><small><b>Homepage:</b> <a href="{{.DominantHomepage}}">{{.DominantHomepage}}</a></small>{{end}}
             {{if .DominantLicense}}<br/><small><b>License:</b> {{.DominantLicense}}</small>{{end}}
             </span>


### PR DESCRIPTION
Resolves the issue where <pkg> tags embedded inside Gentoo metadata XML strings (like description, long description, uses, etc.) were being rendered as plaintext with literal `<pkg>kde-frameworks/kwallet</pkg>` tags on the output HTML.

Adds `formatPkgLinkBody` which processes strings, escapes the HTML safely to prevent XSS (since descriptions are user-provided), extracts the package name using a pre-compiled Regex, and attempts to resolve an overlay link (if the package exists within `repoPkgs`), or falls back to a global link.

---
*PR created automatically by Jules for task [14950821101076911390](https://jules.google.com/task/14950821101076911390) started by @arran4*