### PR TITLE
Add index page for ebuilds directory

### DIFF
--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -1273,6 +1273,22 @@ func generateRepoPackagesPages(repoDir string, tmpl *template.Template, site *g2
 					}
 				}
 			}
+			ebuildBaseDir := filepath.Join(pkgDir, "ebuild")
+			if err := os.MkdirAll(ebuildBaseDir, 0755); err != nil {
+				return fmt.Errorf("creating directory %s: %w", ebuildBaseDir, err)
+			}
+			if err := renderPage(filepath.Join(ebuildBaseDir, "index.html"), tmpl, "repo_package_ebuilds.html", GenericPageContext{
+				Title:       fmt.Sprintf("%s - %s/%s - Ebuilds", site.RepoName, pkg.Category, pkg.Name),
+				BaseURL:     "../../../../../../../",
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../../../../"}, {Name: site.RepoName, URL: "../../../../../"}, {Name: "Categories", URL: "../../../../"}, {Name: pkg.Category, URL: "../../../"}, {Name: "Packages", URL: "../../"}, {Name: pkg.Name, URL: "../"}, {Name: "Ebuilds"}},
+				Repo:        site,
+				RepoPackage: &pkg,
+				Version:     version,
+				GenInfo:     genInfo,
+			}); err != nil {
+				return fmt.Errorf("rendering page: %w", err)
+			}
+
 			for _, v := range pkg.Versions {
 				versionStr := v.Version
 				if v.Ebuild != nil && v.Ebuild.Vars != nil && v.Ebuild.Vars["PV"] != "" {
@@ -1355,7 +1371,6 @@ func generateSite(outDir string, sites []*g2.SiteData, recentDuration time.Durat
 		return fmt.Errorf("loading templates: %w", err)
 	}
 	stepTemplates()
-
 
 	for _, site := range sites {
 		aggPackagesMap := make(map[string]*AggPackage)

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -53,7 +53,7 @@ func (cfg *MainArgConfig) cmdSiteServe(args []string) error {
 	// Determine if location is a single overlay or we need to fall back to repos.conf / /var/db/repos
 	var sites []*g2.SiteData
 
-limit := *concurrency
+	limit := *concurrency
 	if limit <= 0 {
 		limit = 10
 	}
@@ -518,17 +518,17 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// 1. Root Dashboard
 	if len(parts) == 0 {
 		s.renderPageHTTP(w, "dashboard.html", map[string]interface{}{
-			"Title":      s.Title,
-			"BaseURL":    "",
-			"Repos":      s.Sites,
+			"Title":            s.Title,
+			"BaseURL":          "",
+			"Repos":            s.Sites,
 			"GlobalCategories": s.AggCategories,
 			"GlobalPackages":   s.AggPackages,
-			"Licenses":   s.AggLicenses,
-			"UseFlags":   s.AggUseFlags,
-			"Projects":   s.AggProjects,
-			"Profiles":   []interface{}{},
-			"Version":    version,
-			"GenInfo":    s.GenInfo,
+			"Licenses":         s.AggLicenses,
+			"UseFlags":         s.AggUseFlags,
+			"Projects":         s.AggProjects,
+			"Profiles":         []interface{}{},
+			"Version":          version,
+			"GenInfo":          s.GenInfo,
 		})
 		return
 	}
@@ -554,12 +554,12 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "categories":
 		if len(parts) == 1 {
 			s.renderPageHTTP(w, "categories.html", map[string]interface{}{
-				"Title":       "Categories",
-				"BaseURL":     baseURL,
-				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Categories"}},
-				"GlobalCategories":  s.AggCategories,
-				"Version":     version,
-				"GenInfo":     s.GenInfo,
+				"Title":            "Categories",
+				"BaseURL":          baseURL,
+				"Breadcrumbs":      []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Categories"}},
+				"GlobalCategories": s.AggCategories,
+				"Version":          version,
+				"GenInfo":          s.GenInfo,
 			})
 			return
 		} else if len(parts) == 2 {
@@ -865,12 +865,12 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				case "categories":
 					if len(parts) == 3 {
 						s.renderPageHTTP(w, "categories.html", map[string]interface{}{
-							"Title":       site.RepoName + " - Categories",
-							"BaseURL":     baseURL,
-							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Categories"}},
-							"RepoCategories":  site.Categories,
-							"Version":     version,
-							"GenInfo":     s.GenInfo,
+							"Title":          site.RepoName + " - Categories",
+							"BaseURL":        baseURL,
+							"Breadcrumbs":    []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Categories"}},
+							"RepoCategories": site.Categories,
+							"Version":        version,
+							"GenInfo":        s.GenInfo,
 						})
 						return
 					} else if len(parts) == 4 {
@@ -953,6 +953,25 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								"Version":       version,
 								"GenInfo":       s.GenInfo,
 								"ValidLicenses": validLicenses,
+							})
+							return
+						} else if len(parts) == 7 && parts[6] == "ebuild" {
+							s.renderPageHTTP(w, "repo_package_ebuilds.html", map[string]interface{}{
+								"Title":   fmt.Sprintf("%s - %s/%s - Ebuilds", site.RepoName, pkgData.Category, pkgData.Name),
+								"BaseURL": baseURL,
+								"Breadcrumbs": []g2.Breadcrumb{
+									{Name: s.Title, URL: baseURL},
+									{Name: site.RepoName, URL: "../../../../../"},
+									{Name: "Categories", URL: "../../../../"},
+									{Name: pkgData.Category, URL: "../../../"},
+									{Name: "Packages", URL: "../../"},
+									{Name: pkgData.Name, URL: "../"},
+									{Name: "Ebuilds"},
+								},
+								"Repo":        site,
+								"RepoPackage": pkgData,
+								"Version":     version,
+								"GenInfo":     s.GenInfo,
 							})
 							return
 						} else if len(parts) == 8 && parts[6] == "ebuild" {

--- a/myrepo/profiles/repo_name
+++ b/myrepo/profiles/repo_name
@@ -1,0 +1,1 @@
+repo_name

--- a/myrepo/profiles/repo_name
+++ b/myrepo/profiles/repo_name
@@ -1,1 +1,0 @@
-repo_name

--- a/templates/views/repo_package_ebuilds.html
+++ b/templates/views/repo_package_ebuilds.html
@@ -17,10 +17,11 @@
         </tr>
         {{range .RepoPackage.Versions}}
         <tr>
-            <td><a href="{{.Version}}/">{{if .Ebuild.Vars.PV}}{{.Ebuild.Vars.PV}}{{else}}{{.Version}}{{end}}</a>{{if .EbuildRawURL}} <a href="{{.EbuildRawURL}}" style="font-size: 0.8em; font-weight: normal; color: #888;">(raw)</a>{{end}}</td>
-            <td>{{.Ebuild.Vars.EAPI}}</td>
-            <td>{{.Ebuild.Vars.KEYWORDS}}</td>
-            <td>{{.Ebuild.Vars.SLOT}}</td>
+            {{$vName := .Version}}{{if and .Ebuild .Ebuild.Vars .Ebuild.Vars.PV}}{{$vName = .Ebuild.Vars.PV}}{{end}}
+            <td><a href="{{$vName}}/">{{$vName}}</a>{{if .EbuildRawURL}} <a href="{{.EbuildRawURL}}" style="font-size: 0.8em; font-weight: normal; color: #888;">(raw)</a>{{end}}</td>
+            <td>{{if and .Ebuild .Ebuild.Vars}}{{.Ebuild.Vars.EAPI}}{{end}}</td>
+            <td>{{if and .Ebuild .Ebuild.Vars}}{{.Ebuild.Vars.KEYWORDS}}{{end}}</td>
+            <td>{{if and .Ebuild .Ebuild.Vars}}{{.Ebuild.Vars.SLOT}}{{end}}</td>
         </tr>
         {{end}}
     </table>

--- a/templates/views/repo_package_ebuilds.html
+++ b/templates/views/repo_package_ebuilds.html
@@ -1,0 +1,27 @@
+<div class="metadata-section">
+    <h3>Search</h3>
+    <form action="{{.BaseURL}}search/" method="get">
+        <input type="text" name="q" value="overlay:{{.Repo.RepoName}} category:{{.RepoPackage.Category}} {{.RepoPackage.Name}} " placeholder="Search packages, descriptions, use flags..." style="width: 80%; padding: 0.5rem;" />
+        <button type="submit" style="padding: 0.5rem;">Search</button>
+    </form>
+</div>
+
+<div class="metadata-section">
+    <h3>Ebuilds</h3>
+    <table>
+        <tr>
+            <th>Version</th>
+            <th>EAPI</th>
+            <th>Keywords</th>
+            <th>Slot</th>
+        </tr>
+        {{range .RepoPackage.Versions}}
+        <tr>
+            <td><a href="{{.Version}}/">{{if .Ebuild.Vars.PV}}{{.Ebuild.Vars.PV}}{{else}}{{.Version}}{{end}}</a>{{if .EbuildRawURL}} <a href="{{.EbuildRawURL}}" style="font-size: 0.8em; font-weight: normal; color: #888;">(raw)</a>{{end}}</td>
+            <td>{{.Ebuild.Vars.EAPI}}</td>
+            <td>{{.Ebuild.Vars.KEYWORDS}}</td>
+            <td>{{.Ebuild.Vars.SLOT}}</td>
+        </tr>
+        {{end}}
+    </table>
+</div>


### PR DESCRIPTION
Add index page for ebuilds directory

Added an `index.html` page generated inside the `ebuild/` directory of a package, resolving the issue where navigating to the `ebuild/` URL without a specific version resulted in an empty page or 404. The new page includes the versions table (listing EAPI, Keywords, and Slot for each version) mimicking the primary package view. Updates were made to both the static site generation logic (`generate_site.go`) and the local development server (`site_serve.go`) to display the new `repo_package_ebuilds.html` template.

---
*PR created automatically by Jules for task [5131667604304896413](https://jules.google.com/task/5131667604304896413) started by @arran4*