### PR TITLE
feat: display overlay name in global news article view

### DIFF
--- a/templates/views/news_article.html
+++ b/templates/views/news_article.html
@@ -4,6 +4,7 @@
     {{if .GlobalNewsItem}}
     <div class="news-meta">
         <span class="news-date">Posted: {{.GlobalNewsItem.Posted.Format "2006-01-02"}}</span>
+        {{if .GlobalNewsItem.RepoName}}<span class="news-repo"> in <a href="{{.BaseURL}}repos/{{.GlobalNewsItem.RepoName}}/">{{.GlobalNewsItem.RepoName}}</a></span>{{end}}
         {{if .GlobalNewsItem.Author}}<span class="news-author"> by {{.GlobalNewsItem.Author}}</span>{{end}}
         {{if .GlobalNewsItem.Revision}}<span class="news-revision"> | Revision: {{.GlobalNewsItem.Revision}}</span>{{end}}
         {{if or .GlobalNewsItem.NewsItemFormat .GlobalNewsItem.Translator .GlobalNewsItem.DisplayIfInstalled .GlobalNewsItem.DisplayIfKeyword .GlobalNewsItem.DisplayIfProfile}}


### PR DESCRIPTION
This submission fixes an issue where the overlay/repository a news item originated from was not visible when reading the specific article within the global news section. 

Changes Made:
*   Added an `{{if .GlobalNewsItem.RepoName}}...{{end}}` block within the `news-meta` section of `templates/views/news_article.html`.
*   This outputs the `RepoName` as a hyperlink to the appropriate `repos/{{RepoName}}/` path so the user can easily trace the news source.

---
*PR created automatically by Jules for task [9352260489791978088](https://jules.google.com/task/9352260489791978088) started by @arran4*