### PR TITLE
feat: resolve breadcrumbs using absolute paths relative to site root

### DIFF
--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -55,8 +55,8 @@ func pathRel(basePath, targetPath string) string {
 		return "."
 	}
 
-	basePath = strings.TrimPrefix(basePath, "/")
-	targetPath = strings.TrimPrefix(targetPath, "/")
+	basePath = strings.Trim(basePath, "/")
+	targetPath = strings.Trim(targetPath, "/")
 
 	baseParts := strings.Split(basePath, "/")
 	targetParts := strings.Split(targetPath, "/")

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -43,10 +43,66 @@ func getTemplateFuncMap() template.FuncMap {
 			}
 			return 0
 		},
-		"formatDependency":  formatDependencyFunc,
-		"packageLink":       packageLinkFunc,
-		"formatPkgLinkBody": formatPkgLinkBodyFunc,
+		"formatDependency":   formatDependencyFunc,
+		"packageLink":        packageLinkFunc,
+		"formatPkgLinkBody":  formatPkgLinkBodyFunc,
+		"resolveBreadcrumbs": resolveBreadcrumbsFunc,
 	}
+}
+
+func pathRel(basePath, targetPath string) string {
+	if basePath == targetPath {
+		return "."
+	}
+
+	basePath = strings.TrimPrefix(basePath, "/")
+	targetPath = strings.TrimPrefix(targetPath, "/")
+
+	baseParts := strings.Split(basePath, "/")
+	targetParts := strings.Split(targetPath, "/")
+
+	if len(baseParts) == 1 && baseParts[0] == "" {
+		baseParts = nil
+	}
+	if len(targetParts) == 1 && targetParts[0] == "" {
+		targetParts = nil
+	}
+
+	i := 0
+	for i < len(baseParts) && i < len(targetParts) && baseParts[i] == targetParts[i] {
+		i++
+	}
+
+	var res []string
+	for j := i; j < len(baseParts); j++ {
+		res = append(res, "..")
+	}
+	for j := i; j < len(targetParts); j++ {
+		res = append(res, targetParts[j])
+	}
+
+	if len(res) == 0 {
+		return "."
+	}
+
+	return strings.Join(res, "/")
+}
+
+func resolveBreadcrumbsFunc(currentPath string, crumbs []g2.Breadcrumb) []g2.Breadcrumb {
+	var resolved []g2.Breadcrumb
+	for _, crumb := range crumbs {
+		urlStr := crumb.URL
+		if crumb.Path != "" {
+			rel := pathRel(currentPath, crumb.Path)
+			if rel == "." {
+				urlStr = "" // current page doesn't usually need a link
+			} else {
+				urlStr = rel + "/"
+			}
+		}
+		resolved = append(resolved, g2.Breadcrumb{Name: crumb.Name, URL: urlStr, Path: crumb.Path})
+	}
+	return resolved
 }
 
 var tmplPkgRegex = regexp.MustCompile(`&lt;pkg&gt;(.*?)&lt;/pkg&gt;`)

--- a/cmd/g2/template_funcs_test.go
+++ b/cmd/g2/template_funcs_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"html/template"
 	"testing"
+	"github.com/arran4/g2"
 )
 
 func TestFormatKeywordsFunc(t *testing.T) {
@@ -110,6 +111,77 @@ func TestFormatDependencyFunc(t *testing.T) {
 			result := formatDependencyFunc(tt.baseURL, tt.dep)
 			if result != tt.expected {
 				t.Errorf("formatDependencyFunc() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+
+func TestResolveBreadcrumbsFunc(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentPath string
+		crumbs      []g2.Breadcrumb
+		expected    []g2.Breadcrumb
+	}{
+		{
+			name:        "root to root",
+			currentPath: "/",
+			crumbs: []g2.Breadcrumb{
+				{Name: "Home", Path: "/"},
+			},
+			expected: []g2.Breadcrumb{
+				{Name: "Home", Path: "/", URL: ""},
+			},
+		},
+		{
+			name:        "sub to root",
+			currentPath: "/categories/app-admin/foo",
+			crumbs: []g2.Breadcrumb{
+				{Name: "Home", Path: "/"},
+				{Name: "Categories", Path: "/categories"},
+				{Name: "app-admin", Path: "/categories/app-admin"},
+				{Name: "foo", Path: "/categories/app-admin/foo"},
+			},
+			expected: []g2.Breadcrumb{
+				{Name: "Home", Path: "/", URL: "../../../"},
+				{Name: "Categories", Path: "/categories", URL: "../../"},
+				{Name: "app-admin", Path: "/categories/app-admin", URL: "../"},
+				{Name: "foo", Path: "/categories/app-admin/foo", URL: ""},
+			},
+		},
+		{
+			name:        "sibling to sibling",
+			currentPath: "/categories/app-admin/foo",
+			crumbs: []g2.Breadcrumb{
+				{Name: "bar", Path: "/categories/app-admin/bar"},
+			},
+			expected: []g2.Breadcrumb{
+				{Name: "bar", Path: "/categories/app-admin/bar", URL: "../bar/"},
+			},
+		},
+		{
+			name:        "fallback to URL if Path empty",
+			currentPath: "/categories/app-admin/foo",
+			crumbs: []g2.Breadcrumb{
+				{Name: "Home", URL: "../../../"},
+			},
+			expected: []g2.Breadcrumb{
+				{Name: "Home", Path: "", URL: "../../../"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveBreadcrumbsFunc(tt.currentPath, tt.crumbs)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected len %d, got %d", len(tt.expected), len(result))
+			}
+			for i, r := range result {
+				if r.Name != tt.expected[i].Name || r.Path != tt.expected[i].Path || r.URL != tt.expected[i].URL {
+					t.Errorf("expected crumb[%d] = %+v, got %+v", i, tt.expected[i], r)
+				}
 			}
 		})
 	}

--- a/cmd/g2/template_funcs_test.go
+++ b/cmd/g2/template_funcs_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"github.com/arran4/g2"
 	"html/template"
 	"testing"
-	"github.com/arran4/g2"
 )
 
 func TestFormatKeywordsFunc(t *testing.T) {
@@ -116,7 +116,6 @@ func TestFormatDependencyFunc(t *testing.T) {
 	}
 }
 
-
 func TestResolveBreadcrumbsFunc(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -168,6 +167,16 @@ func TestResolveBreadcrumbsFunc(t *testing.T) {
 			},
 			expected: []g2.Breadcrumb{
 				{Name: "Home", Path: "", URL: "../../../"},
+			},
+		},
+		{
+			name:        "trailing slash bug",
+			currentPath: "/categories/app-admin/foo/",
+			crumbs: []g2.Breadcrumb{
+				{Name: "foo", Path: "/categories/app-admin/foo"},
+			},
+			expected: []g2.Breadcrumb{
+				{Name: "foo", Path: "/categories/app-admin/foo", URL: ""},
 			},
 		},
 	}

--- a/site.go
+++ b/site.go
@@ -51,6 +51,7 @@ type LicenseData struct {
 type Breadcrumb struct {
 	Name string
 	URL  string
+	Path string
 }
 
 type ProfileDescEntry struct {


### PR DESCRIPTION
This commit fixes the relative path fragility with breadcrumbs across the static site generation and live server logic. Instead of hardcoded strings representing back-traversal `../../`, it implements absolute paths (relative to the site base directory) via `Path` strings and resolves them contextually through a template function `resolveBreadcrumbs`, utilizing the current page's contextual location (`CurrentPath`).

---
*PR created automatically by Jules for task [8484387505042735922](https://jules.google.com/task/8484387505042735922) started by @arran4*