### PR TITLE
Fix invalid licenses appearing in UI by using g2.ParseLicense

### DIFF
--- a/cmd/g2/search_index.go
+++ b/cmd/g2/search_index.go
@@ -103,6 +103,9 @@ func generateSearchData(outDir, outZip string, sites []*g2.SiteData, maxChunkSiz
 
 						licenseStr := ver.Ebuild.Vars["LICENSE"]
 						for _, l := range g2.ParseLicense(licenseStr) {
+							if l == "" {
+								continue
+							}
 							licenses = append(licenses, l)
 							if site.LicenseMapping != nil {
 								if aliases, ok := site.LicenseMapping[l]; ok {

--- a/cmd/g2/search_index.go
+++ b/cmd/g2/search_index.go
@@ -102,16 +102,14 @@ func generateSearchData(outDir, outZip string, sites []*g2.SiteData, maxChunkSiz
 						urls = append(urls, strings.Fields(homepage)...)
 
 						licenseStr := ver.Ebuild.Vars["LICENSE"]
-						forEachToken(licenseStr, func(l string) {
-							if l != "||" && l != "(" && l != ")" && (len(l) == 0 || l[0] != '?') {
-								licenses = append(licenses, l)
-								if site.LicenseMapping != nil {
-									if aliases, ok := site.LicenseMapping[l]; ok {
-										licenses = append(licenses, aliases...)
-									}
+						for _, l := range g2.ParseLicense(licenseStr) {
+							licenses = append(licenses, l)
+							if site.LicenseMapping != nil {
+								if aliases, ok := site.LicenseMapping[l]; ok {
+									licenses = append(licenses, aliases...)
 								}
 							}
-						})
+						}
 
 						keywordStr := ver.Ebuild.Vars["KEYWORDS"]
 						forEachToken(keywordStr, func(kw string) {

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -381,41 +381,45 @@ func newSiteServer(sites []*g2.SiteData, genInfo GenerationInfo) (*SiteServer, e
 
 				for _, ver := range pkg.Versions {
 					if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
-						lic := ver.Ebuild.Vars["LICENSE"]
-						if lic != "" {
-							if !isValidLicense(lic) {
-								log.Printf("Warning: Invalid license skipped: %q in package %s", lic, pkgKey)
-								continue
-							}
-							if _, ok := aggLicenses[lic]; !ok {
-								aggLicenses[lic] = &AggLicense{Name: lic}
-							}
+						licenseStr := ver.Ebuild.Vars["LICENSE"]
+						licenses := g2.ParseLicense(licenseStr)
 
-							found := false
-							for _, p := range aggLicenses[lic].Packages {
-								if p.Name == pkg.Name && p.Category == pkg.Category {
-									found = true
-									break
+						for _, lic := range licenses {
+							if lic != "" {
+								if !isValidLicense(lic) {
+									log.Printf("Warning: Invalid license skipped: %q in package %s", lic, pkgKey)
+									continue
 								}
-							}
-							if !found {
-								aggLicenses[lic].Packages = append(aggLicenses[lic].Packages, aggPackages[pkgKey])
-								aggLicenses[lic].Count++
-							}
+								if _, ok := aggLicenses[lic]; !ok {
+									aggLicenses[lic] = &AggLicense{Name: lic}
+								}
 
-							// Add aliases from this site's license mapping
-							if site.LicenseMapping != nil {
-								if aliases, ok := site.LicenseMapping[lic]; ok {
-									for _, alias := range aliases {
-										hasAlias := false
-										for _, existing := range aggLicenses[lic].Aliases {
-											if existing == alias {
-												hasAlias = true
-												break
+								found := false
+								for _, p := range aggLicenses[lic].Packages {
+									if p.Name == pkg.Name && p.Category == pkg.Category {
+										found = true
+										break
+									}
+								}
+								if !found {
+									aggLicenses[lic].Packages = append(aggLicenses[lic].Packages, aggPackages[pkgKey])
+									aggLicenses[lic].Count++
+								}
+
+								// Add aliases from this site's license mapping
+								if site.LicenseMapping != nil {
+									if aliases, ok := site.LicenseMapping[lic]; ok {
+										for _, alias := range aliases {
+											hasAlias := false
+											for _, existing := range aggLicenses[lic].Aliases {
+												if existing == alias {
+													hasAlias = true
+													break
+												}
 											}
-										}
-										if !hasAlias {
-											aggLicenses[lic].Aliases = append(aggLicenses[lic].Aliases, alias)
+											if !hasAlias {
+												aggLicenses[lic].Aliases = append(aggLicenses[lic].Aliases, alias)
+											}
 										}
 									}
 								}


### PR DESCRIPTION
Fix invalid licenses appearing in UI by using g2.ParseLicense

This commit resolves an issue where invalid strings like USE conditionals
(e.g., `foo?`) and dependency operators (e.g., `||`, `()`) were being parsed
and displayed as valid licenses.

Two changes were made:
1. In `cmd/g2/search_index.go`, replaced the buggy custom `forEachToken` loop
   with a call to `g2.ParseLicense`, which correctly evaluates the
   dependency AST and extracts valid licenses.
2. In `cmd/g2/site_serve.go`, parsed the raw `LICENSE` ebuild variable
   using `g2.ParseLicense` and aggregated the individual parsed licenses
   instead of mistakenly validating and adding the entire unparsed license
   string as a single license entity.

---
*PR created automatically by Jules for task [8350631065647079044](https://jules.google.com/task/8350631065647079044) started by @arran4*