### PR TITLE
feat: add repo-specific licenses and overlay count tracking

### DIFF
--- a/cmd/g2/ebuild_deps_test.go
+++ b/cmd/g2/ebuild_deps_test.go
@@ -107,10 +107,10 @@ func TestEbuildDeps(t *testing.T) {
 				forwardSlashPrefix := filepath.ToSlash(tmpDir) + "/"
 				got = strings.ReplaceAll(got, forwardSlashPrefix, "")
 
-					// Normalize remaining double-escaped backslashes to forward slashes for JSON outputs
-					got = strings.ReplaceAll(got, "\\\\", "/")
-					// Normalize standard backslashes to forward slashes for text outputs
-					got = strings.ReplaceAll(got, "\\", "/")
+				// Normalize remaining double-escaped backslashes to forward slashes for JSON outputs
+				got = strings.ReplaceAll(got, "\\\\", "/")
+				// Normalize standard backslashes to forward slashes for text outputs
+				got = strings.ReplaceAll(got, "\\", "/")
 			}
 
 			if strings.TrimSpace(got) != strings.TrimSpace(want) {

--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -630,6 +630,10 @@ func generateRepoPages(outDir string, tmpl *template.Template, sites []*g2.SiteD
 				return err
 			}
 
+			if err := generateRepoLicensesPages(repoDir, tmpl, site, data, title, version, genInfo); err != nil {
+				return err
+			}
+
 			if err := generateRepoDeprecatedMaskedInfoPages(repoDir, tmpl, site, title); err != nil {
 				return err
 			}
@@ -734,6 +738,55 @@ func generateRepoUseFlagsPages(repoDir string, tmpl *template.Template, site *g2
 				GlobalUseFlag: f,
 				Version:       version,
 				GenInfo:       genInfo,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func generateRepoLicensesPages(repoDir string, tmpl *template.Template, site *g2.SiteData, data *AggregatedData, title, version string, genInfo GenerationInfo) error {
+	aggPackagesMap := make(map[string]*AggPackage)
+	for _, p := range data.Packages {
+		aggPackagesMap[p.Category+"/"+p.Name] = p
+	}
+	repoLicenses := getRepoLicenses(site, aggPackagesMap)
+
+	if len(repoLicenses) > 0 {
+		if err := os.MkdirAll(filepath.Join(repoDir, "licenses"), 0755); err != nil {
+			return fmt.Errorf("creating directory: %w", err)
+		}
+		if err := renderPage(filepath.Join(repoDir, "licenses", "index.html"), tmpl, "repo_licenses.html", GenericPageContext{
+			Title:        site.RepoName + " - Licenses",
+			BaseURL:      "../../../",
+			Breadcrumbs:  []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: site.RepoName, URL: "../"}, {Name: "Licenses"}},
+			Repo:         site,
+			RepoLicenses: repoLicenses,
+			Version:      version,
+			GenInfo:      genInfo,
+		}); err != nil {
+			return fmt.Errorf("rendering page: %w", err)
+		}
+
+		for _, lic := range repoLicenses {
+			safeName := sanitizeFilename(lic.Name)
+			if safeName == "" {
+				continue
+			}
+			licDir := filepath.Join(repoDir, "licenses", safeName)
+			if err := os.MkdirAll(licDir, 0755); err != nil {
+				return fmt.Errorf("creating directory %s: %w", licDir, err)
+			}
+
+			if err := renderPage(filepath.Join(licDir, "index.html"), tmpl, "repo_license.html", GenericPageContext{
+				Title:       site.RepoName + " - License: " + lic.Name,
+				BaseURL:     "../../../../",
+				Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../../../"}, {Name: site.RepoName, URL: "../../"}, {Name: "Licenses", URL: "../"}, {Name: lic.Name}},
+				License:     lic,
+				Repo:        site,
+				Version:     version,
+				GenInfo:     genInfo,
 			}); err != nil {
 				return err
 			}

--- a/cmd/g2/models_page.go
+++ b/cmd/g2/models_page.go
@@ -22,6 +22,7 @@ type GenericPageContext struct {
 	GlobalPackages        []*AggPackage
 	RepoPackages          []g2.PackageData
 	Licenses              []*AggLicense
+	RepoLicenses          []*AggLicense
 	UseFlags              []*AggUseFlag
 	UseExpandDescs        map[string]*g2.UseExpandDesc
 	UseExpandDesc         *g2.UseExpandDesc

--- a/cmd/g2/parse_repo.go
+++ b/cmd/g2/parse_repo.go
@@ -88,6 +88,15 @@ func parseRepoProfilesDir(sysFS fs.FS, repoDir string, site *g2.SiteData) {
 		}
 	}
 
+	licensesDir := filepath.Join(repoDir, "licenses")
+	if entries, err := fs.ReadDir(sysFS, filepath.ToSlash(licensesDir)); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				site.ProvidedLicenses = append(site.ProvidedLicenses, entry.Name())
+			}
+		}
+	}
+
 	if f, err := sysFS.Open(filepath.ToSlash(filepath.Join(repoDir, "profiles", "use.desc"))); err == nil {
 		defer func() { _ = f.Close() }()
 		if ud, err := g2.ParseUseDesc(f); err == nil {

--- a/cmd/g2/parse_repo.go
+++ b/cmd/g2/parse_repo.go
@@ -91,7 +91,7 @@ func parseRepoProfilesDir(sysFS fs.FS, repoDir string, site *g2.SiteData) {
 	licensesDir := filepath.Join(repoDir, "licenses")
 	if entries, err := fs.ReadDir(sysFS, filepath.ToSlash(licensesDir)); err == nil {
 		for _, entry := range entries {
-			if !entry.IsDir() {
+			if !entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
 				site.ProvidedLicenses = append(site.ProvidedLicenses, entry.Name())
 			}
 		}

--- a/cmd/g2/search_engine.go
+++ b/cmd/g2/search_engine.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SearchEngine struct {
-	documents   []SearchDocument
+	documents []SearchDocument
 }
 
 func NewSearchEngine() *SearchEngine {

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1120,8 +1120,8 @@ func getRepoLicenses(site *g2.SiteData, aggPackages map[string]*AggPackage) []*A
 							if !found {
 								if aggPkg, ok := aggPackages[pkgKey]; ok {
 									aggLicenses[lic].Packages = append(aggLicenses[lic].Packages, aggPkg)
+									aggLicenses[lic].Count++
 								}
-								aggLicenses[lic].Count++
 							}
 
 							if site.LicenseMapping != nil {
@@ -1154,6 +1154,7 @@ func getRepoLicenses(site *g2.SiteData, aggPackages map[string]*AggPackage) []*A
 	}
 	sort.Slice(sortedLicenses, func(i, j int) bool { return sortedLicenses[i].Name < sortedLicenses[j].Name })
 
+	site.AggLicenses = sortedLicenses
 	return sortedLicenses
 }
 

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -297,7 +297,6 @@ func (cfg *MainArgConfig) cmdOverlays(args []string) error {
 	useZip := fs.Bool("use-zip", false, "Download zip archives instead of git clone when supported")
 	smartMode := fs.Bool("smart-mode", true, "Use smart mode for parsing repositories in memory without disk access")
 
-
 	concurrency := fs.Int("concurrency", 4, "Maximum number of concurrent repository fetches/parses")
 	retries := fs.Int("retries", 3, "Number of times to retry fetching a repository")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue parsing other repositories even if fetching one fails")
@@ -995,11 +994,13 @@ type AggProject struct {
 }
 
 type AggLicense struct {
-	Name     string
-	Count    int
-	Packages []*AggPackage
-	Text     string
-	Aliases  []string
+	Name            string
+	Count           int
+	Packages        []*AggPackage
+	Text            string
+	Aliases         []string
+	ProvidedByRepos map[string]*g2.SiteData
+	UsedByRepos     map[string]*g2.SiteData
 }
 
 type AggUseFlag struct {
@@ -1070,6 +1071,90 @@ func getRepoEclasses(site *g2.SiteData, aggPackages map[string]*AggPackage) []*A
 	sort.Slice(sortedEclasses, func(i, j int) bool { return sortedEclasses[i].Name < sortedEclasses[j].Name })
 
 	return sortedEclasses
+}
+
+func getRepoLicenses(site *g2.SiteData, aggPackages map[string]*AggPackage) []*AggLicense {
+	aggLicenses := make(map[string]*AggLicense)
+
+	for _, providedLic := range site.ProvidedLicenses {
+		if _, ok := aggLicenses[providedLic]; !ok {
+			aggLicenses[providedLic] = &AggLicense{
+				Name:            providedLic,
+				ProvidedByRepos: map[string]*g2.SiteData{site.RepoName: site},
+				UsedByRepos:     make(map[string]*g2.SiteData),
+			}
+		}
+	}
+
+	for _, cat := range site.Categories {
+		for _, pkg := range cat.Packages {
+			pkgKey := pkg.Category + "/" + pkg.Name
+
+			for _, ver := range pkg.Versions {
+				if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+					licenseStr := ver.Ebuild.Vars["LICENSE"]
+					licenses := g2.ParseLicense(licenseStr)
+
+					for _, lic := range licenses {
+						if lic != "" {
+							if !isValidLicense(lic) {
+								continue
+							}
+							if _, ok := aggLicenses[lic]; !ok {
+								aggLicenses[lic] = &AggLicense{
+									Name:            lic,
+									ProvidedByRepos: make(map[string]*g2.SiteData),
+									UsedByRepos:     make(map[string]*g2.SiteData),
+								}
+							}
+
+							aggLicenses[lic].UsedByRepos[site.RepoName] = site
+
+							found := false
+							for _, p := range aggLicenses[lic].Packages {
+								if p.Name == pkg.Name && p.Category == pkg.Category {
+									found = true
+									break
+								}
+							}
+							if !found {
+								if aggPkg, ok := aggPackages[pkgKey]; ok {
+									aggLicenses[lic].Packages = append(aggLicenses[lic].Packages, aggPkg)
+								}
+								aggLicenses[lic].Count++
+							}
+
+							if site.LicenseMapping != nil {
+								if aliases, ok := site.LicenseMapping[lic]; ok {
+									for _, alias := range aliases {
+										hasAlias := false
+										for _, existing := range aggLicenses[lic].Aliases {
+											if existing == alias {
+												hasAlias = true
+												break
+											}
+										}
+										if !hasAlias {
+											aggLicenses[lic].Aliases = append(aggLicenses[lic].Aliases, alias)
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	var sortedLicenses []*AggLicense
+	for _, l := range aggLicenses {
+		sort.Strings(l.Aliases)
+		sortedLicenses = append(sortedLicenses, l)
+	}
+	sort.Slice(sortedLicenses, func(i, j int) bool { return sortedLicenses[i].Name < sortedLicenses[j].Name })
+
+	return sortedLicenses
 }
 
 func getRepoUseFlags(site *g2.SiteData, aggPackages map[string]*AggPackage) []*AggUseFlag {
@@ -1531,6 +1616,17 @@ func aggregatePackagesAndCategories(sites []*g2.SiteData, aggProjects map[string
 	catPkgMap := make(map[string]map[string]*AggPackage)
 
 	for _, site := range sites {
+		for _, providedLic := range site.ProvidedLicenses {
+			if _, ok := aggLicenses[providedLic]; !ok {
+				aggLicenses[providedLic] = &AggLicense{
+					Name:            providedLic,
+					ProvidedByRepos: make(map[string]*g2.SiteData),
+					UsedByRepos:     make(map[string]*g2.SiteData),
+				}
+			}
+			aggLicenses[providedLic].ProvidedByRepos[site.RepoName] = site
+		}
+
 		for _, cat := range site.Categories {
 			if _, ok := aggCategories[cat.Name]; !ok {
 				aggCategories[cat.Name] = &AggCategory{Name: cat.Name}
@@ -1610,8 +1706,14 @@ func aggregatePackagesAndCategories(sites []*g2.SiteData, aggProjects map[string
 									continue
 								}
 								if _, ok := aggLicenses[lic]; !ok {
-									aggLicenses[lic] = &AggLicense{Name: lic}
+									aggLicenses[lic] = &AggLicense{
+										Name:            lic,
+										ProvidedByRepos: make(map[string]*g2.SiteData),
+										UsedByRepos:     make(map[string]*g2.SiteData),
+									}
 								}
+
+								aggLicenses[lic].UsedByRepos[site.RepoName] = site
 
 								found := false
 								for _, p := range aggLicenses[lic].Packages {
@@ -1947,7 +2049,7 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 	var totalPackages int
 	var totalPackageVersions int
 
-limit := concurrency
+	limit := concurrency
 	if limit <= 0 {
 		limit = 10
 	}

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -1213,6 +1213,46 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						})
 						return
 					}
+
+				case "licenses":
+					repoLicenses := getRepoLicenses(site, s.PkgMap)
+
+					if len(parts) == 3 {
+						s.renderPageHTTP(w, "repo_licenses.html", map[string]interface{}{
+							"Title":        site.RepoName + " - Licenses",
+							"BaseURL":      baseURL,
+							"Breadcrumbs":  []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../"}, {Name: "Licenses"}},
+							"RepoLicenses": repoLicenses,
+							"Repo":         site,
+							"Version":      version,
+							"GenInfo":      s.GenInfo,
+						})
+						return
+					} else if len(parts) == 4 {
+						licNameSlug := parts[3]
+						var lic *AggLicense
+						for _, l := range repoLicenses {
+							if sanitizeFilename(l.Name) == licNameSlug {
+								lic = l
+								break
+							}
+						}
+						if lic == nil {
+							http.NotFound(w, r)
+							return
+						}
+
+						s.renderPageHTTP(w, "repo_license.html", map[string]interface{}{
+							"Title":       site.RepoName + " - License: " + lic.Name,
+							"BaseURL":     baseURL,
+							"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: site.RepoName, URL: "../../"}, {Name: "Licenses", URL: "../"}, {Name: lic.Name}},
+							"License":     lic,
+							"Repo":        site,
+							"Version":     version,
+							"GenInfo":     s.GenInfo,
+						})
+						return
+					}
 				}
 			}
 		}

--- a/cmd/g2/smart_mode.go
+++ b/cmd/g2/smart_mode.go
@@ -7,16 +7,16 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
-	"log"
 	"sync"
 
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/storage/memory"
 )
 
 func getZipUrl(gitUrl string) string {
@@ -99,8 +99,8 @@ type billyFS struct {
 }
 
 type billyFile struct {
-	bf billy.File
-	fs billy.Filesystem
+	bf   billy.File
+	fs   billy.Filesystem
 	name string
 }
 
@@ -130,11 +130,11 @@ func (f *billyFile) Close() error {
 type billyDirEntry struct {
 	info fs.FileInfo
 }
-func (b *billyDirEntry) Name() string { return b.info.Name() }
-func (b *billyDirEntry) IsDir() bool { return b.info.IsDir() }
-func (b *billyDirEntry) Type() fs.FileMode { return b.info.Mode().Type() }
-func (b *billyDirEntry) Info() (fs.FileInfo, error) { return b.info, nil }
 
+func (b *billyDirEntry) Name() string               { return b.info.Name() }
+func (b *billyDirEntry) IsDir() bool                { return b.info.IsDir() }
+func (b *billyDirEntry) Type() fs.FileMode          { return b.info.Mode().Type() }
+func (b *billyDirEntry) Info() (fs.FileInfo, error) { return b.info, nil }
 
 func (b *billyFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	if !fs.ValidPath(name) {
@@ -152,12 +152,11 @@ func (b *billyFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return entries, nil
 }
 
-
 func tryFetchGitFS(ctx context.Context, gitUrl string) (fs.FS, error) {
 	st := memory.NewStorage()
 	bfs := memfs.New()
 	_, err := git.CloneContext(ctx, st, bfs, &git.CloneOptions{
-		URL: gitUrl,
+		URL:   gitUrl,
 		Depth: 1,
 	})
 	if err != nil {
@@ -167,9 +166,9 @@ func tryFetchGitFS(ctx context.Context, gitUrl string) (fs.FS, error) {
 }
 
 type MemoryManager struct {
-	mu sync.Mutex
-	cond *sync.Cond
-	reserved uint64
+	mu          sync.Mutex
+	cond        *sync.Cond
+	reserved    uint64
 	activeTasks int
 }
 

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -22,7 +22,7 @@ func getTemplateFuncMap() template.FuncMap {
 		"slugify":             sanitizeFilename,
 		"split":               strings.Split,
 		"formatKeywords":      formatKeywordsFunc,
-		"hasPrefix":           func(s, prefix any) bool {
+		"hasPrefix": func(s, prefix any) bool {
 			sStr, ok1 := s.(string)
 			pStr, ok2 := prefix.(string)
 			if ok1 && ok2 {
@@ -30,9 +30,9 @@ func getTemplateFuncMap() template.FuncMap {
 			}
 			return false
 		},
-		"groupIUSEFlags":      groupIUSEFlagsFunc,
-		"isLikelyMasked":      isLikelyMaskedFunc,
-		"isPkgLikelyMasked":   isPkgLikelyMaskedFunc,
+		"groupIUSEFlags":    groupIUSEFlagsFunc,
+		"isLikelyMasked":    isLikelyMaskedFunc,
+		"isPkgLikelyMasked": isPkgLikelyMaskedFunc,
 		"len_or_zero": func(v any) int {
 			if v == nil {
 				return 0

--- a/cmd/g2/world_tui.go
+++ b/cmd/g2/world_tui.go
@@ -47,12 +47,12 @@ func runWorldTUI(path string, lines []string) error {
 
 		if cursor < scrollOffset {
 			scrollOffset = cursor
-		} else if cursor >= scrollOffset + listHeight {
+		} else if cursor >= scrollOffset+listHeight {
 			scrollOffset = cursor - listHeight + 1
 		}
 
 		for i, line := range lines {
-			if i < scrollOffset || i >= scrollOffset + listHeight {
+			if i < scrollOffset || i >= scrollOffset+listHeight {
 				continue
 			}
 			if i == cursor {

--- a/ebuild_extra_test.go
+++ b/ebuild_extra_test.go
@@ -27,4 +27,3 @@ func TestExtractPackageNameFromDep(t *testing.T) {
 		}
 	}
 }
-

--- a/httputil.go
+++ b/httputil.go
@@ -4,12 +4,12 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha3"
 	"crypto/sha512"
 	"fmt"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/blake2s"
 	"golang.org/x/crypto/ripemd160" //nolint:staticcheck
-	"crypto/sha3"
 	"hash"
 	"io"
 	"log"

--- a/resolver_make_conf.go
+++ b/resolver_make_conf.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"mvdan.cc/sh/v3/interp"
 	"mvdan.cc/sh/v3/syntax"
@@ -61,7 +61,7 @@ func ParseMakeConfContent(content, filename string) (map[string]string, error) {
 
 			// Exclude typical bash built-in variables we don't care about
 			if name == "PWD" || name == "OLDPWD" || name == "SHLVL" || name == "IFS" || name == "OPTIND" || name == "PS4" {
-			    continue
+				continue
 			}
 
 			script := fmt.Sprintf(`echo "${%s[@]}"`, name)
@@ -71,7 +71,7 @@ func ParseMakeConfContent(content, filename string) (map[string]string, error) {
 
 			val := strings.TrimSuffix(outBuf.String(), "\n")
 			if val != "" {
-			    vars[name] = val
+				vars[name] = val
 			}
 		}
 	}

--- a/resolver_make_conf_test.go
+++ b/resolver_make_conf_test.go
@@ -13,12 +13,12 @@ func TestParseMakeConf(t *testing.T) {
 
 	err := os.Mkdir(confDDir, 0755)
 	if err != nil {
-	    t.Fatal(err)
+		t.Fatal(err)
 	}
 
 	err = os.WriteFile(filepath.Join(confDDir, "01-custom.conf"), []byte(`VAR4="sourced"`), 0644)
 	if err != nil {
-	    t.Fatal(err)
+		t.Fatal(err)
 	}
 
 	err = os.WriteFile(confPath, []byte(`
@@ -35,7 +35,7 @@ ARR=(a b c)
 ARR2=(1 2)
 ARR2+=(3)
 
-source "` + filepath.Join(confDDir, "01-custom.conf") + `"
+source "`+filepath.Join(confDDir, "01-custom.conf")+`"
 	`), 0644)
 	if err != nil {
 		t.Fatal(err)
@@ -51,18 +51,18 @@ source "` + filepath.Join(confDDir, "01-custom.conf") + `"
 	}
 
 	if vars["USE"] != "foo bar baz" {
-	    t.Errorf("Unexpected USE: %q", vars["USE"])
+		t.Errorf("Unexpected USE: %q", vars["USE"])
 	}
 
 	if vars["ARR"] != "a b c" {
-	    t.Errorf("Unexpected ARR: %q", vars["ARR"])
+		t.Errorf("Unexpected ARR: %q", vars["ARR"])
 	}
 
 	if vars["ARR2"] != "1 2 3" {
-	    t.Errorf("Unexpected ARR2: %q", vars["ARR2"])
+		t.Errorf("Unexpected ARR2: %q", vars["ARR2"])
 	}
 
 	if vars["VAR4"] != "sourced" {
-	    t.Errorf("Unexpected VAR4 (source failed?): %q", vars["VAR4"])
+		t.Errorf("Unexpected VAR4 (source failed?): %q", vars["VAR4"])
 	}
 }

--- a/site.go
+++ b/site.go
@@ -21,7 +21,7 @@ type SiteData struct {
 	LayoutConf        *LayoutConf
 	LicenseMapping    map[string][]string
 	ProvidedLicenses  []string
-	AggLicenses       interface{}
+	AggLicenses       any // To break cycle, keep CLI specific type as any or redefine
 	QAPolicy          *QAPolicy
 	UseDesc           *UseDesc
 	UseLocalDesc      *UseLocalDesc

--- a/site.go
+++ b/site.go
@@ -21,6 +21,7 @@ type SiteData struct {
 	LayoutConf        *LayoutConf
 	LicenseMapping    map[string][]string
 	ProvidedLicenses  []string
+	AggLicenses       interface{}
 	QAPolicy          *QAPolicy
 	UseDesc           *UseDesc
 	UseLocalDesc      *UseLocalDesc

--- a/site.go
+++ b/site.go
@@ -20,6 +20,7 @@ type SiteData struct {
 	News              []NewsItem
 	LayoutConf        *LayoutConf
 	LicenseMapping    map[string][]string
+	ProvidedLicenses  []string
 	QAPolicy          *QAPolicy
 	UseDesc           *UseDesc
 	UseLocalDesc      *UseLocalDesc

--- a/templates/views/repo_index.html
+++ b/templates/views/repo_index.html
@@ -141,7 +141,9 @@
     {{else if gt .GlobalPackagesCount 0}}
     <li><a href="../../packages/">Packages (Global)</a></li>
     {{end}}
+    {{if or .Repo.AggLicenses .Repo.ProvidedLicenses}}
     <li><a href="licenses/">Licenses</a></li>
+    {{end}}
     {{if gt (len .Repo.Profiles) 0}}
     <li><a href="profiles/">Profiles</a></li>
     {{else if gt .GlobalProfilesCount 0}}

--- a/templates/views/repo_index.html
+++ b/templates/views/repo_index.html
@@ -141,9 +141,7 @@
     {{else if gt .GlobalPackagesCount 0}}
     <li><a href="../../packages/">Packages (Global)</a></li>
     {{end}}
-    {{if and .GlobalLicensesCount (gt .GlobalLicensesCount 0)}}
-    <li><a href="../../licenses/">Licenses (Global)</a></li>
-    {{end}}
+    <li><a href="licenses/">Licenses</a></li>
     {{if gt (len .Repo.Profiles) 0}}
     <li><a href="profiles/">Profiles</a></li>
     {{else if gt .GlobalProfilesCount 0}}

--- a/templates/views/repo_license.html
+++ b/templates/views/repo_license.html
@@ -1,5 +1,4 @@
-
-<h2>License: {{.License.Name}}</h2>
+<h2>License: {{.License.Name}} in {{.Repo.RepoName}}</h2>
 
 <div class="metadata-section">
     <h3>Search</h3>
@@ -37,7 +36,7 @@
 </ul>
 {{end}}
 
-<h3>Packages with this license</h3>
+<h3>Packages with this license in {{.Repo.RepoName}}</h3>
 <ul>
     {{range .License.Packages}}
     <li>

--- a/templates/views/repo_license.html
+++ b/templates/views/repo_license.html
@@ -40,13 +40,7 @@
 <ul>
     {{range .License.Packages}}
     <li>
-        {{if eq (len .Repos) 1}}
-            {{$repo := ""}}
-            {{range $k, $v := .Repos}}{{$repo = $k}}{{end}}
-            <a href="{{$.BaseURL}}repos/{{$repo}}/categories/{{.Category}}/packages/{{.Name}}/">{{.Category}}/{{.Name}}::{{$repo}}</a>
-        {{else}}
-            <a href="{{$.BaseURL}}packages/{{.Category}}/{{.Name}}/">{{.Category}}/{{.Name}}</a>
-        {{end}}
+        <a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{.Category}}/packages/{{.Name}}/">{{.Category}}/{{.Name}}::{{$.Repo.RepoName}}</a>
     </li>
     {{end}}
 </ul>

--- a/templates/views/repo_licenses.html
+++ b/templates/views/repo_licenses.html
@@ -1,7 +1,6 @@
-
-<h2>All Licenses</h2>
+<h2>All Licenses for {{.Repo.RepoName}}</h2>
 <ul>
-    {{range .Licenses}}
+    {{range .RepoLicenses}}
     <li>
         <a href="{{slugify .Name}}/">{{.Name}}</a> ({{.Count}} packages)
         <br><small>Provided in {{len .ProvidedByRepos}} overlays, Used in {{len .UsedByRepos}} overlays.</small>


### PR DESCRIPTION
Add repo-specific licenses and overlay count tracking for licenses.
This enables viewing what licenses are provided by or used by each repository within its local view and in the global licenses page. Also properly appends `::overlayname` to package names.

---
*PR created automatically by Jules for task [11800100660463328019](https://jules.google.com/task/11800100660463328019) started by @arran4*