### PR TITLE
Standardize overlay reference formatting to Gentoo standard syntax

### DIFF
--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -43,10 +43,11 @@ func getTemplateFuncMap() template.FuncMap {
 			}
 			return 0
 		},
-		"formatDependency":   formatDependencyFunc,
-		"packageLink":        packageLinkFunc,
-		"formatPkgLinkBody":  formatPkgLinkBodyFunc,
-		"resolveBreadcrumbs": resolveBreadcrumbsFunc,
+		"formatDependency":       formatDependencyFunc,
+		"packageLink":            packageLinkFunc,
+		"formatPkgLinkBody":      formatPkgLinkBodyFunc,
+		"formatQualifiedPackage": formatQualifiedPackageFunc,
+		"resolveBreadcrumbs":     resolveBreadcrumbsFunc,
 	}
 }
 
@@ -354,4 +355,11 @@ func isPkgLikelyMaskedFunc(pkg any) bool {
 	}
 
 	return false
+}
+
+func formatQualifiedPackageFunc(category, name, version, overlay string) string {
+	if version != "" {
+		return fmt.Sprintf("=%s/%s-%s::%s", category, name, version, overlay)
+	}
+	return fmt.Sprintf("%s/%s::%s", category, name, overlay)
 }

--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -358,8 +358,14 @@ func isPkgLikelyMaskedFunc(pkg any) bool {
 }
 
 func formatQualifiedPackageFunc(category, name, version, overlay string) string {
-	if version != "" {
-		return fmt.Sprintf("=%s/%s-%s::%s", category, name, version, overlay)
+	if overlay != "" {
+		if version != "" {
+			return fmt.Sprintf("=%s/%s-%s::%s", category, name, version, overlay)
+		}
+		return fmt.Sprintf("%s/%s::%s", category, name, overlay)
 	}
-	return fmt.Sprintf("%s/%s::%s", category, name, overlay)
+	if version != "" {
+		return fmt.Sprintf("=%s/%s-%s", category, name, version)
+	}
+	return fmt.Sprintf("%s/%s", category, name)
 }

--- a/templates/views/category.html
+++ b/templates/views/category.html
@@ -1,4 +1,3 @@
-
 <h2>Category: {{if .GlobalCategory}}{{.GlobalCategory.Name}}{{else if .RepoCategory}}{{.RepoCategory.Name}}{{else}}{{.Category.Name}}{{end}}</h2>
 
 <div class="metadata-section">
@@ -35,14 +34,16 @@
 <ul id="package-list" style="clear: both;">
     {{if .GlobalCategory}}
     {{range .Category.Packages}}
+        {{$pkgName := .Name}}
+        {{$catName := $.GlobalCategory.Name}}
         <li>
             {{if eq (len .ReposList) 1}}
                 {{$repo := index .ReposList 0}}
-                <a href="{{$.BaseURL}}repos/{{$repo.RepoName}}/categories/{{$.GlobalCategory.Name}}/packages/{{.Name}}/">{{.Name}}</a>
+                <a href="{{$.BaseURL}}repos/{{$repo.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/">{{formatQualifiedPackage $catName $pkgName "" $repo.RepoName}}</a>
             {{else}}
-                <a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{.Name}}/">{{.Name}}</a> (ambiguous, available in {{len .ReposList}} overlays)
+                <a href="{{$.BaseURL}}packages/{{$catName}}/{{$pkgName}}/">{{.Name}}</a> (available in: {{range $i, $repo := .ReposList}}{{if $i}}, {{end}}<a href="{{$.BaseURL}}repos/{{$repo.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/">{{formatQualifiedPackage $catName $pkgName "" $repo.RepoName}}</a>{{end}})
             {{end}}
-            {{$pkgName := .Name}}- Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{range $i, $v := .HighestStableVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}">{{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{end}}</span>{{end}}{{end}}{{if .HighestTestingVersion}}, Testing: {{range $i, $v := .HighestTestingVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}">{{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{end}}</span>{{end}}{{end}}{{if .SnapshotVersion}}, Snapshot: {{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{end}}{{end}}
+            - Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{range $i, $v := .HighestStableVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}"><a href="{{$.BaseURL}}packages/{{$catName}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a></span>{{end}}{{end}}{{if .HighestTestingVersion}}, Testing: {{range $i, $v := .HighestTestingVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}"><a href="{{$.BaseURL}}packages/{{$catName}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a></span>{{end}}{{end}}{{if .SnapshotVersion}}, Snapshot: <a href="{{$.BaseURL}}packages/{{$catName}}/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{end}}
             {{if .ReverseVirtuals}}
             <span class="badge" style="background-color: #17a2b8; color: white; padding: 2px 5px; border-radius: 3px; font-size: 0.8em;">Virtual</span>
             {{end}}
@@ -55,9 +56,11 @@
     {{end}}
     {{else if .RepoCategory}}
     {{range .RepoCategory.Packages}}
+        {{$pkgName := .Name}}
+        {{$catName := $.RepoCategory.Name}}
         <li>
-            <a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{.Name}}/">{{.Name}}</a>
-            {{$pkgName := .Name}}- Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{range $i, $v := .HighestStableVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}">{{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{end}}</span>{{end}}{{end}}{{if .HighestTestingVersion}}, Testing: {{range $i, $v := .HighestTestingVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}">{{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{end}}</span>{{end}}{{end}}{{if .SnapshotVersion}}, Snapshot: {{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{end}}{{end}}
+            <a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/">{{formatQualifiedPackage $catName $pkgName "" $.Repo.RepoName}}</a>
+            - Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{range $i, $v := .HighestStableVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}"><a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a></span>{{end}}{{end}}{{if .HighestTestingVersion}}, Testing: {{range $i, $v := .HighestTestingVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}"><a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a></span>{{end}}{{end}}{{if .SnapshotVersion}}, Snapshot: <a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{end}}
             {{if .ReverseVirtuals}}
             <span class="badge" style="background-color: #17a2b8; color: white; padding: 2px 5px; border-radius: 3px; font-size: 0.8em;">Virtual</span>
             {{end}}
@@ -70,14 +73,16 @@
     {{end}}
     {{else}}
     {{range .Category.Packages}}
+        {{$pkgName := .Name}}
+        {{$catName := $.Category.Name}}
         <li>
             {{if eq (len .ReposList) 1}}
                 {{$repo := index .ReposList 0}}
-                <a href="{{$.BaseURL}}repos/{{$repo.RepoName}}/categories/{{$.Category.Name}}/packages/{{.Name}}/">{{.Name}}</a>
+                <a href="{{$.BaseURL}}repos/{{$repo.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/">{{formatQualifiedPackage $catName $pkgName "" $repo.RepoName}}</a>
             {{else}}
-                <a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{.Name}}/">{{.Name}}</a> (ambiguous, available in {{len .ReposList}} overlays)
+                <a href="{{$.BaseURL}}packages/{{$catName}}/{{$pkgName}}/">{{.Name}}</a> (available in: {{range $i, $repo := .ReposList}}{{if $i}}, {{end}}<a href="{{$.BaseURL}}repos/{{$repo.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/">{{formatQualifiedPackage $catName $pkgName "" $repo.RepoName}}</a>{{end}})
             {{end}}
-            {{$pkgName := .Name}}- Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{range $i, $v := .HighestStableVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}">{{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{end}}</span>{{end}}{{end}}{{if .HighestTestingVersion}}, Testing: {{range $i, $v := .HighestTestingVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}">{{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a>{{end}}</span>{{end}}{{end}}{{if .SnapshotVersion}}, Snapshot: {{if $.GlobalCategory}}<a href="{{$.BaseURL}}packages/{{$.GlobalCategory.Name}}/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{else if $.RepoCategory}}<a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/categories/{{$.RepoCategory.Name}}/packages/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{else}}<a href="{{$.BaseURL}}packages/{{$.Category.Name}}/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{end}}{{end}}
+            - Ebuilds: {{.EbuildCount}}{{if .HighestStableVersion}}, Stable: {{range $i, $v := .HighestStableVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}"><a href="{{$.BaseURL}}packages/{{$catName}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a></span>{{end}}{{end}}{{if .HighestTestingVersion}}, Testing: {{range $i, $v := .HighestTestingVersion}}{{if $i}}, {{end}}<span title="{{$v.Archs}}"><a href="{{$.BaseURL}}packages/{{$catName}}/{{$pkgName}}/ebuild/{{$v.Version}}/">{{$v.Version}}</a></span>{{end}}{{end}}{{if .SnapshotVersion}}, Snapshot: <a href="{{$.BaseURL}}packages/{{$catName}}/{{$pkgName}}/ebuild/{{.SnapshotVersion}}/">{{.SnapshotVersion}}</a>{{end}}
             {{if .ReverseVirtuals}}
             <span class="badge" style="background-color: #17a2b8; color: white; padding: 2px 5px; border-radius: 3px; font-size: 0.8em;">Virtual</span>
             {{end}}

--- a/templates/views/package_picker.html
+++ b/templates/views/package_picker.html
@@ -28,7 +28,7 @@
                 <td>
                     <ul class="list-unstyled mb-0">
                     {{range ($globalPkg.GetVersionsInRepo $repoName)}}
-                        <li>{{.Version}}</li>
+                        <li><a href="{{$baseURL}}repos/{{$repoName}}/categories/{{$catName}}/packages/{{$pkgName}}/ebuild/{{.Version}}/">{{formatQualifiedPackage $catName $pkgName .Version $repoName}}</a></li>
                     {{end}}
                     </ul>
                 </td>

--- a/templates/views/packages.html
+++ b/templates/views/packages.html
@@ -9,12 +9,14 @@
         </thead>
         <tbody>
             {{range .GlobalPackages}}
+            {{$catName := .Category}}
+            {{$pkgName := .Name}}
             <tr>
                 <td><a href="{{.Category}}/{{.Name}}/" class="fw-bold">{{.Category}}/{{.Name}}</a></td>
                 <td>
                     <div class="d-flex flex-wrap gap-1">
                         {{range .ReposList}}
-                            <span class="badge bg-light text-dark border">{{.RepoName}}</span>
+                            <a href="../repos/{{.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/">{{formatQualifiedPackage $catName $pkgName "" .RepoName}}</a>
                         {{end}}
                     </div>
                 </td>

--- a/templates/views/packages.html
+++ b/templates/views/packages.html
@@ -11,12 +11,13 @@
             {{range .GlobalPackages}}
             {{$catName := .Category}}
             {{$pkgName := .Name}}
+            {{$baseURL := $.BaseURL}}
             <tr>
                 <td><a href="{{.Category}}/{{.Name}}/" class="fw-bold">{{.Category}}/{{.Name}}</a></td>
                 <td>
                     <div class="d-flex flex-wrap gap-1">
                         {{range .ReposList}}
-                            <a href="../repos/{{.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/">{{formatQualifiedPackage $catName $pkgName "" .RepoName}}</a>
+                            <a href="{{$baseURL}}repos/{{.RepoName}}/categories/{{$catName}}/packages/{{$pkgName}}/">{{formatQualifiedPackage $catName $pkgName "" .RepoName}}</a>
                         {{end}}
                     </div>
                 </td>


### PR DESCRIPTION
This PR implements standard Gentoo overlay specification formatting for UI links globally, shifting from badging and "(ambiguous in N overlays)" text to explicitly listed fully qualified links.

### Changes:
- **`cmd/g2/template_funcs.go`**: Added `formatQualifiedPackageFunc` template helper.
- **`templates/views/category.html`**: Replaced standard badge elements with fully qualified names (removing the `ambiguous` tags altogether and replacing them with a loop over explicitly scoped package variations).
- **`templates/views/packages.html`**: Upgraded global package index repo indicators to use fully qualified formatting.
- **`templates/views/package_picker.html`**: Updated internal version listings of ambiguous packages to display version atoms along with their fully qualified target overlays.

All formatting updates have been verified using Playwright screenshots, tests have been successfully passed, and code hygiene/lints were fixed.

---
*PR created automatically by Jules for task [12782230776655156986](https://jules.google.com/task/12782230776655156986) started by @arran4*