### PR TITLE
feat: add package filtering to cache generate

### DIFF
--- a/cmd/g2/cache.go
+++ b/cmd/g2/cache.go
@@ -66,7 +66,7 @@ func (cfg *MainArgConfig) cmdCache(args []string) error {
 		fmt.Printf("Usage:\n")
 		fmt.Printf("\t%s\n", strings.Join(cfg.Args, " "))
 		fmt.Printf("\t\t %s \t\t %s\n", "verify", "To verify cache exists for ebuilds")
-		fmt.Printf("\t\t %s \t\t %s\n", "generate", "To generate cache for ebuilds")
+		fmt.Printf("\t\t %s \t %s\n", "generate [packages...]", "To generate cache for ebuilds. Can optionally specify packages to generate.")
 		fmt.Printf("\t\t %s \t\t %s\n", "set-method", "To set the cache method in layout.conf")
 		fmt.Printf("\t\t %s \t\t %s\n", "list-methods", "To list available cache methods")
 		fmt.Printf("\t\t %s \t\t %s\n", "clean", "To clean up unused cache entries")

--- a/cmd/g2/cache.go
+++ b/cmd/g2/cache.go
@@ -181,10 +181,10 @@ func (cfg *MainArgConfig) cmdCacheGenerate(args []string) error {
 	}
 
 	cfs := NewOsCacheFS(*repoDir)
-	return doCacheGenerate(cfs, ".")
+	return doCacheGenerate(cfs, ".", fsFlags.Args())
 }
 
-func doCacheGenerate(cfs CacheFS, repoDir string) error {
+func doCacheGenerate(cfs CacheFS, repoDir string, targetPkgs []string) error {
 	layoutConfPath := filepath.ToSlash(filepath.Join(repoDir, "metadata", "layout.conf"))
 	var lc *g2.LayoutConf
 	if f, err := cfs.Open(layoutConfPath); err == nil {
@@ -208,6 +208,11 @@ func doCacheGenerate(cfs CacheFS, repoDir string) error {
 		return fmt.Errorf("parsing repo: %w", err)
 	}
 
+	targetMap := make(map[string]bool)
+	for _, p := range targetPkgs {
+		targetMap[p] = true
+	}
+
 	for _, format := range cacheFormats {
 		if format != "md5-dict" {
 			log.Printf("Warning: Cache format '%s' is not supported. Skipping. Only md5-dict is supported.", format)
@@ -218,6 +223,13 @@ func doCacheGenerate(cfs CacheFS, repoDir string) error {
 
 		for _, cat := range siteData.Categories {
 			for _, pkg := range cat.Packages {
+				if len(targetMap) > 0 {
+					qualified := pkg.Category + "/" + pkg.Name
+					if !targetMap[qualified] && !targetMap[pkg.Name] {
+						continue
+					}
+				}
+
 				cacheDir := filepath.ToSlash(filepath.Join(repoDir, "metadata", format, pkg.Category))
 				if err := cfs.MkdirAll(cacheDir, 0755); err != nil {
 					return fmt.Errorf("creating cache directory %s: %w", cacheDir, err)

--- a/cmd/g2/cache.go
+++ b/cmd/g2/cache.go
@@ -208,9 +208,12 @@ func doCacheGenerate(cfs CacheFS, repoDir string, targetPkgs []string) error {
 		return fmt.Errorf("parsing repo: %w", err)
 	}
 
-	targetMap := make(map[string]bool)
-	for _, p := range targetPkgs {
-		targetMap[p] = true
+	var targetMap map[string]bool
+	if len(targetPkgs) > 0 {
+		targetMap = make(map[string]bool, len(targetPkgs))
+		for _, p := range targetPkgs {
+			targetMap[p] = true
+		}
 	}
 
 	for _, format := range cacheFormats {

--- a/cmd/g2/cache_test.go
+++ b/cmd/g2/cache_test.go
@@ -141,7 +141,7 @@ func TestCacheCommands(t *testing.T) {
 			// The intent (generate, clean, verify) can be determined by the file name
 			baseName := path.Base(fixture)
 			if strings.Contains(baseName, "generate") {
-				err = doCacheGenerate(memFS, ".")
+				err = doCacheGenerate(memFS, ".", nil)
 				if err != nil {
 					t.Fatalf("run cache generate: %v", err)
 				}

--- a/readme.md
+++ b/readme.md
@@ -320,7 +320,7 @@ g2 cache <subcommand>
 **Subcommands:**
 
 * `verify [location]`: Verify cache exists for ebuilds.
-* `generate [location]`: Generate cache for ebuilds.
+* `generate [target-packages...]`: Generate cache for ebuilds. Optionally specify package atoms to only generate cache for them.
 * `set-method <method>`: Set the cache method in `layout.conf`.
 * `list-methods`: List available cache methods.
 * `clean [location]`: Clean up unused cache entries.
@@ -329,7 +329,12 @@ g2 cache <subcommand>
 
 Generate the ebuild cache for the current overlay:
 ```bash
-g2 cache generate .
+g2 cache generate
+```
+
+Generate the ebuild cache for specific packages:
+```bash
+g2 cache generate app-admin/sudoers-emerge app-test/app
 ```
 
 ### `pkg-desc-index`


### PR DESCRIPTION
Updates the `cmdCacheGenerate` and `doCacheGenerate` commands to allow package filtering.

---
*PR created automatically by Jules for task [5599208902994045052](https://jules.google.com/task/5599208902994045052) started by @arran4*