### PR TITLE
feat: Add support for nav keys and filtering to world TUI

### DIFF
--- a/cmd/g2/world_tui.go
+++ b/cmd/g2/world_tui.go
@@ -142,11 +142,12 @@ func runWorldTUI(path string, lines []string) error {
 					}
 					mode = "normal"
 				case 127, 8: // Backspace
-					if mode == "insert" {
+					switch mode {
+					case "insert":
 						if len(inputBuffer) > 0 {
 							inputBuffer = inputBuffer[:len(inputBuffer)-1]
 						}
-					} else if mode == "filter" {
+					case "filter":
 						if len(filterQuery) > 0 {
 							filterQuery = filterQuery[:len(filterQuery)-1]
 							cursor = 0
@@ -154,9 +155,10 @@ func runWorldTUI(path string, lines []string) error {
 					}
 				default:
 					if c >= 32 || c > 127 { // Allows ASCII and extended UTF-8 bytes
-						if mode == "insert" {
+						switch mode {
+						case "insert":
 							inputBuffer += string(c)
-						} else if mode == "filter" {
+						case "filter":
 							filterQuery += string(c)
 							cursor = 0
 						}

--- a/cmd/g2/world_tui.go
+++ b/cmd/g2/world_tui.go
@@ -20,16 +20,20 @@ func runWorldTUI(path string, lines []string) error {
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
 	cursor := 0
-	mode := "normal" // "normal" or "insert"
+	mode := "normal" // "normal", "insert", or "filter"
 	inputBuffer := ""
+	filterQuery := ""
 	scrollOffset := 0
+
+	var filteredIndices []int
+	var listHeight int
 
 	render := func() {
 		// Clear screen and reset cursor
 		fmt.Print("\033[2J\033[H")
 
 		fmt.Print("Manage Portage World List\r\n")
-		fmt.Print("q: quit | s: save | j/k: down/up | c/Space: toggle comment | d: delete | a: add\r\n")
+		fmt.Print("q: quit | s: save | j/k: down/up | c/Space: toggle comment | d: delete | a: add | /: filter\r\n")
 		fmt.Print(strings.Repeat("-", 60) + "\r\n")
 
 		termWidth, termHeight, err := term.GetSize(int(os.Stdin.Fd()))
@@ -40,9 +44,22 @@ func runWorldTUI(path string, lines []string) error {
 		_ = termWidth
 
 		// 3 header lines, 1 or 2 footer lines depending on mode
-		listHeight := termHeight - 4
-		if mode == "insert" {
+		listHeight = termHeight - 4
+		if mode == "insert" || mode == "filter" || filterQuery != "" {
 			listHeight -= 2
+		}
+
+		filteredIndices = nil
+		for i, line := range lines {
+			if filterQuery == "" || strings.Contains(strings.ToLower(line), strings.ToLower(filterQuery)) {
+				filteredIndices = append(filteredIndices, i)
+			}
+		}
+
+		if cursor >= len(filteredIndices) && len(filteredIndices) > 0 {
+			cursor = len(filteredIndices) - 1
+		} else if len(filteredIndices) == 0 {
+			cursor = 0
 		}
 
 		if cursor < scrollOffset {
@@ -50,8 +67,11 @@ func runWorldTUI(path string, lines []string) error {
 		} else if cursor >= scrollOffset+listHeight {
 			scrollOffset = cursor - listHeight + 1
 		}
+		if scrollOffset < 0 {
+			scrollOffset = 0
+		}
 
-		for i, line := range lines {
+		for i, realIdx := range filteredIndices {
 			if i < scrollOffset || i >= scrollOffset+listHeight {
 				continue
 			}
@@ -61,6 +81,7 @@ func runWorldTUI(path string, lines []string) error {
 				fmt.Print("   ")
 			}
 
+			line := lines[realIdx]
 			if strings.HasPrefix(strings.TrimSpace(line), "#") {
 				fmt.Printf("\033[32m%s\033[0m\r\n", line) // Green for comments
 			} else {
@@ -71,6 +92,13 @@ func runWorldTUI(path string, lines []string) error {
 		if mode == "insert" {
 			fmt.Print(strings.Repeat("-", 60) + "\r\n")
 			fmt.Printf("New entry: %s_\r\n", inputBuffer)
+		} else if mode == "filter" || filterQuery != "" {
+			fmt.Print(strings.Repeat("-", 60) + "\r\n")
+			if mode == "filter" {
+				fmt.Printf("Filter: %s_\r\n", filterQuery)
+			} else {
+				fmt.Printf("Filter: %s\r\n", filterQuery)
+			}
 		}
 	}
 
@@ -86,40 +114,52 @@ func runWorldTUI(path string, lines []string) error {
 			return err
 		}
 
-		if mode == "insert" {
-			// Handle insert mode
+		if mode == "insert" || mode == "filter" {
+			// Handle insert/filter mode
 			// Support UTF-8 multi-byte sequences by converting the entire buffer read
 			for i := 0; i < n; i++ {
 				c := buf[i]
 				switch c {
 				case 27: // Esc
+					if mode == "insert" {
+						inputBuffer = ""
+					}
 					mode = "normal"
-					inputBuffer = ""
 				case 13: // Enter
-					if strings.TrimSpace(inputBuffer) != "" {
-						if cursor >= len(lines) {
-							lines = append(lines, inputBuffer)
-						} else {
-							// Add to lines and move cursor
-							lines = append(lines, "")
-							copy(lines[cursor+1:], lines[cursor:])
-							lines[cursor] = inputBuffer
+					if mode == "insert" {
+						if strings.TrimSpace(inputBuffer) != "" {
+							if len(filteredIndices) == 0 || cursor >= len(filteredIndices) {
+								lines = append(lines, inputBuffer)
+							} else {
+								realIdx := filteredIndices[cursor]
+								// Add to lines and move cursor
+								lines = append(lines, "")
+								copy(lines[realIdx+1:], lines[realIdx:])
+								lines[realIdx] = inputBuffer
+							}
+						}
+						inputBuffer = ""
+					}
+					mode = "normal"
+				case 127, 8: // Backspace
+					if mode == "insert" {
+						if len(inputBuffer) > 0 {
+							inputBuffer = inputBuffer[:len(inputBuffer)-1]
+						}
+					} else if mode == "filter" {
+						if len(filterQuery) > 0 {
+							filterQuery = filterQuery[:len(filterQuery)-1]
+							cursor = 0
 						}
 					}
-					mode = "normal"
-					inputBuffer = ""
-				case 127, 8: // Backspace
-					// Basic backspace handling (assumes 1 byte = 1 char for simplicity in deletion,
-					// real UTF-8 backspace requires rune parsing, but this handles standard ASCII well enough
-					// without getting overly complex for this TUI)
-					if len(inputBuffer) > 0 {
-						inputBuffer = inputBuffer[:len(inputBuffer)-1]
-					}
 				default:
-					// Just append printable/valid characters directly from the buffer.
-					// This allows pasting and UTF-8 to work naturally since they arrive in the buffer together.
 					if c >= 32 || c > 127 { // Allows ASCII and extended UTF-8 bytes
-						inputBuffer += string(c)
+						if mode == "insert" {
+							inputBuffer += string(c)
+						} else if mode == "filter" {
+							filterQuery += string(c)
+							cursor = 0
+						}
 					}
 				}
 			}
@@ -132,7 +172,7 @@ func runWorldTUI(path string, lines []string) error {
 				case 's', 13: // s or Enter
 					return writeWorldFile(path, lines)
 				case 'j':
-					if cursor < len(lines) {
+					if cursor < len(filteredIndices)-1 {
 						cursor++
 					}
 				case 'k':
@@ -140,37 +180,81 @@ func runWorldTUI(path string, lines []string) error {
 						cursor--
 					}
 				case 'c', ' ': // Toggle comment
-					if len(lines) > 0 && cursor < len(lines) {
-						line := lines[cursor]
+					if len(filteredIndices) > 0 && cursor < len(filteredIndices) {
+						realIdx := filteredIndices[cursor]
+						line := lines[realIdx]
 						trimmed := strings.TrimSpace(line)
 						if strings.HasPrefix(trimmed, "#") {
 							// Uncomment (remove first occurrence of # and leading spaces)
-							lines[cursor] = strings.TrimSpace(strings.TrimPrefix(trimmed, "#"))
+							lines[realIdx] = strings.TrimSpace(strings.TrimPrefix(trimmed, "#"))
 						} else {
 							// Comment
-							lines[cursor] = "# " + line
+							lines[realIdx] = "# " + line
 						}
 					}
 				case 'd': // Delete
-					if len(lines) > 0 && cursor < len(lines) {
-						lines = append(lines[:cursor], lines[cursor+1:]...)
-						if cursor >= len(lines) && cursor > 0 {
+					if len(filteredIndices) > 0 && cursor < len(filteredIndices) {
+						realIdx := filteredIndices[cursor]
+						lines = append(lines[:realIdx], lines[realIdx+1:]...)
+						if cursor >= len(filteredIndices)-1 && cursor > 0 {
 							cursor--
 						}
 					}
 				case 'a': // Add
 					mode = "insert"
+				case '/': // Filter
+					mode = "filter"
 				}
 			} else if n >= 3 && buf[0] == 27 && buf[1] == 91 {
-				// Handle arrow keys
+				// Handle escape sequences
 				switch buf[2] {
-				case 'A': // Up
+				case 'A': // Up arrow
 					if cursor > 0 {
 						cursor--
 					}
-				case 'B': // Down
-					if cursor < len(lines) {
+				case 'B': // Down arrow
+					if cursor < len(filteredIndices)-1 {
 						cursor++
+					}
+				case '5': // Page Up
+					if n >= 4 && buf[3] == '~' {
+						cursor -= listHeight
+						if cursor < 0 {
+							cursor = 0
+						}
+					}
+				case '6': // Page Down
+					if n >= 4 && buf[3] == '~' {
+						cursor += listHeight
+						if cursor >= len(filteredIndices) && len(filteredIndices) > 0 {
+							cursor = len(filteredIndices) - 1
+						}
+					}
+				case '1', '7': // Home
+					if n >= 4 && buf[3] == '~' {
+						cursor = 0
+					}
+				case '4', '8': // End
+					if n >= 4 && buf[3] == '~' {
+						if len(filteredIndices) > 0 {
+							cursor = len(filteredIndices) - 1
+						}
+					}
+				case 'H': // Home (some terminals)
+					cursor = 0
+				case 'F': // End (some terminals)
+					if len(filteredIndices) > 0 {
+						cursor = len(filteredIndices) - 1
+					}
+				}
+			} else if n >= 3 && buf[0] == 27 && buf[1] == 'O' {
+				// Handle SS3 escape sequences
+				switch buf[2] {
+				case 'H': // Home
+					cursor = 0
+				case 'F': // End
+					if len(filteredIndices) > 0 {
+						cursor = len(filteredIndices) - 1
 					}
 				}
 			}

--- a/cmd/g2/world_tui.go
+++ b/cmd/g2/world_tui.go
@@ -48,10 +48,14 @@ func runWorldTUI(path string, lines []string) error {
 		if mode == "insert" || mode == "filter" || filterQuery != "" {
 			listHeight -= 2
 		}
+		if listHeight < 1 {
+			listHeight = 1
+		}
 
 		filteredIndices = nil
+		filterQueryLower := strings.ToLower(filterQuery)
 		for i, line := range lines {
-			if filterQuery == "" || strings.Contains(strings.ToLower(line), strings.ToLower(filterQuery)) {
+			if filterQuery == "" || strings.Contains(strings.ToLower(line), filterQueryLower) {
 				filteredIndices = append(filteredIndices, i)
 			}
 		}
@@ -144,12 +148,14 @@ func runWorldTUI(path string, lines []string) error {
 				case 127, 8: // Backspace
 					switch mode {
 					case "insert":
-						if len(inputBuffer) > 0 {
-							inputBuffer = inputBuffer[:len(inputBuffer)-1]
+						runes := []rune(inputBuffer)
+						if len(runes) > 0 {
+							inputBuffer = string(runes[:len(runes)-1])
 						}
 					case "filter":
-						if len(filterQuery) > 0 {
-							filterQuery = filterQuery[:len(filterQuery)-1]
+						runes := []rune(filterQuery)
+						if len(runes) > 0 {
+							filterQuery = string(runes[:len(runes)-1])
 							cursor = 0
 						}
 					}


### PR DESCRIPTION
Added support for Page Up, Page Down, Home, and End to the World TUI for faster navigation. Also implemented a new filter mode (accessible via `/`) that filters the world list interactively using case-insensitive substring matching. Updated insert, delete, and comment toggling logic to accurately target the underlying elements when a filter is applied.

---
*PR created automatically by Jules for task [242967381844375822](https://jules.google.com/task/242967381844375822) started by @arran4*