### PR TITLE
fix: remove arbitrary truncation of highest versions per architecture in UI listings

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -432,10 +432,7 @@ func getHighestVersionsAndCount(versions []g2.VersionData, site *g2.SiteData) ([
 		}
 
 		var result []g2.VersionGroup
-		for i, ver := range sortedVersions {
-			if i >= 2 {
-				break
-			}
+		for _, ver := range sortedVersions {
 			archs := groups[ver]
 
 			// sort archs


### PR DESCRIPTION
Fixes an issue where valid stable/testing versions of a package for different architectures were being silently truncated from the UI if the package had more than 2 distinct valid versions across all architectures. By dropping the arbitrary cutoff logic, all relevant architectures and their respective versions are accurately shown. Snapshot/live ebuilds (`9999`) remain explicitly segmented as before, and proper ebuild links are maintained.

---
*PR created automatically by Jules for task [13790407379348443763](https://jules.google.com/task/13790407379348443763) started by @arran4*