### PR TITLE
feat: add network-sandbox restriction lint rule

### DIFF
--- a/lints/ebuild/network_sandbox.go
+++ b/lints/ebuild/network_sandbox.go
@@ -28,16 +28,20 @@ func (r *NetworkSandboxLintRule) Lint(repoDir string, pkg *g2.PackageData) []lin
 }
 
 func (r *NetworkSandboxLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	if pkg == nil {
+		return nil
+	}
+
 	var results []lints.LintResult
 
 	for _, ver := range pkg.Versions {
 		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
 			restrict := ver.Ebuild.Vars["RESTRICT"]
-			for _, r := range strings.Fields(restrict) {
-				if r == "network-sandbox" {
+			for _, restrictVal := range strings.Fields(restrict) {
+				if restrictVal == "network-sandbox" {
 					res := lints.LintResult{
 						RuleMetadata: ruleNetworkSandbox,
-						Message:      "Bypassing the network sandbox using `RESTRICT=\"network-sandbox\"` to download dependencies via `npm` during `src_install` violates Gentoo's core packaging policies. Ebuilds must support offline and reproducible builds, meaning all assets must be fetched via `SRC_URI` during the fetch phase and verified using Manifest checksums. To resolve this, you should package the required node modules into a tarball, host it, reference it in `SRC_URI`, and perform an offline installation.",
+						Message:      "Bypassing the network sandbox using `RESTRICT=\"network-sandbox\"` violates Gentoo's core packaging policies. Ebuilds must support offline and reproducible builds, meaning all assets must be fetched via `SRC_URI` during the fetch phase and verified using Manifest checksums. To resolve this, you should package the required dependencies (e.g., node modules, cargo crates) into a tarball, host it, reference it in `SRC_URI` and perform an offline installation.",
 						Package:      pkg.Category + "/" + pkg.Name,
 					}
 					results = append(results, res)

--- a/lints/ebuild/network_sandbox.go
+++ b/lints/ebuild/network_sandbox.go
@@ -1,0 +1,50 @@
+package ebuild
+
+import (
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var ruleNetworkSandbox = lints.RuleMetadata{
+	ID:          "NetworkSandbox",
+	Title:       "Network Sandbox Bypass",
+	Description: "Checks if a package bypasses the network sandbox using RESTRICT=\"network-sandbox\".",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "network-sandbox"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleNetworkSandbox)
+	lints.RegisterLintRule(&NetworkSandboxLintRule{})
+}
+
+type NetworkSandboxLintRule struct{}
+
+func (r *NetworkSandboxLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *NetworkSandboxLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			restrict := ver.Ebuild.Vars["RESTRICT"]
+			for _, r := range strings.Fields(restrict) {
+				if r == "network-sandbox" {
+					res := lints.LintResult{
+						RuleMetadata: ruleNetworkSandbox,
+						Message:      "Bypassing the network sandbox using `RESTRICT=\"network-sandbox\"` to download dependencies via `npm` during `src_install` violates Gentoo's core packaging policies. Ebuilds must support offline and reproducible builds, meaning all assets must be fetched via `SRC_URI` during the fetch phase and verified using Manifest checksums. To resolve this, you should package the required node modules into a tarball, host it, reference it in `SRC_URI`, and perform an offline installation.",
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					results = append(results, res)
+					break
+				}
+			}
+		}
+	}
+	return results
+}

--- a/lints/ebuild/network_sandbox_test.go
+++ b/lints/ebuild/network_sandbox_test.go
@@ -1,0 +1,45 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestNetworkSandboxLintRule(t *testing.T) {
+	rule := &ebuild.NetworkSandboxLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		version  string
+		restrict string
+		want     int
+	}{
+		{"No network-sandbox", "app-misc", "1.0", "test", 0},
+		{"With network-sandbox", "app-misc", "1.0", "network-sandbox test", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Versions: []g2.VersionData{
+					{
+						Version: tt.version,
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RESTRICT": tt.restrict,
+							},
+						},
+					},
+				},
+			}
+			warnings := rule.Lint(".", pkg)
+			if len(warnings) != tt.want {
+				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
+			}
+		})
+	}
+}

--- a/lints/ebuild/network_sandbox_test.go
+++ b/lints/ebuild/network_sandbox_test.go
@@ -1,11 +1,16 @@
 package ebuild_test
 
 import (
+	"embed"
 	"testing"
+    "testing/fstest"
 
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints/ebuild"
 )
+
+//go:embed testdata/*.ebuild
+var testdataFS embed.FS
 
 func TestNetworkSandboxLintRule(t *testing.T) {
 	rule := &ebuild.NetworkSandboxLintRule{}
@@ -14,25 +19,35 @@ func TestNetworkSandboxLintRule(t *testing.T) {
 		name     string
 		category string
 		version  string
-		restrict string
+		filename string
 		want     int
 	}{
-		{"No network-sandbox", "app-misc", "1.0", "test", 0},
-		{"With network-sandbox", "app-misc", "1.0", "network-sandbox test", 1},
+		{"No network-sandbox", "app-misc", "1.0", "testdata/no-network-sandbox.ebuild", 0},
+		{"With network-sandbox", "app-misc", "1.0", "testdata/with-network-sandbox.ebuild", 1},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			content, err := testdataFS.ReadFile(tt.filename)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", tt.filename, err)
+			}
+
+            memFS := fstest.MapFS{
+				tt.filename: {Data: content},
+			}
+
+			ebuildData, err := g2.ParseEbuild(memFS, tt.filename, g2.ParseVariables)
+			if err != nil {
+				t.Fatalf("failed to parse %s: %v", tt.filename, err)
+			}
+
 			pkg := &g2.PackageData{
 				Category: tt.category,
 				Versions: []g2.VersionData{
 					{
 						Version: tt.version,
-						Ebuild: &g2.Ebuild{
-							Vars: map[string]string{
-								"RESTRICT": tt.restrict,
-							},
-						},
+						Ebuild:  ebuildData,
 					},
 				},
 			}

--- a/lints/ebuild/testdata/no-network-sandbox.ebuild
+++ b/lints/ebuild/testdata/no-network-sandbox.ebuild
@@ -1,0 +1,1 @@
+RESTRICT="test"

--- a/lints/ebuild/testdata/with-network-sandbox.ebuild
+++ b/lints/ebuild/testdata/with-network-sandbox.ebuild
@@ -1,0 +1,1 @@
+RESTRICT="network-sandbox test"


### PR DESCRIPTION
Adds a new linting rule to enforce Gentoo's offline and reproducible packaging policy. This rule flags any ebuild bypassing the network sandbox using RESTRICT="network-sandbox" and outputs the specific violation message. Also includes unit tests.

---
*PR created automatically by Jules for task [10869987529962297305](https://jules.google.com/task/10869987529962297305) started by @arran4*