### PR TITLE
feat: add repo-name missing lint rule

### DIFF
--- a/lints/ebuild/repo_name_missing.go
+++ b/lints/ebuild/repo_name_missing.go
@@ -30,6 +30,7 @@ func init() {
 
 type RepoNameMissingLintRule struct {
 	mu        sync.RWMutex
+	once      sync.Once
 	repoCache map[string]bool // map[repoDir]hasRepoName
 }
 
@@ -41,45 +42,42 @@ func (r *RepoNameMissingLintRule) LintWithQA(repoDir string, pkg *g2.PackageData
 	var results []lints.LintResult
 	severity := lints.SeverityError
 
+	r.once.Do(func() {
+		r.repoCache = make(map[string]bool)
+	})
+
 	r.mu.RLock()
-	if r.repoCache == nil {
-		r.mu.RUnlock()
-		r.mu.Lock()
-		if r.repoCache == nil {
-			r.repoCache = make(map[string]bool)
-		}
-		r.mu.Unlock()
-		r.mu.RLock()
-	}
 	hasName, cached := r.repoCache[repoDir]
 	r.mu.RUnlock()
 
 	if !cached {
-		r.mu.Lock()
-		hasName, cached = r.repoCache[repoDir]
-		if !cached {
-			hasName = false
-			// Check layout.conf
-			lc, err := g2.ParseLayoutConf(filepath.Join(repoDir, "metadata", "layout.conf"))
-			if err == nil && lc.GetValue("repo-name") != "" {
+		// Perform I/O outside of the lock to avoid blocking other goroutines
+		hasName = false
+		lc, err := g2.ParseLayoutConf(filepath.Join(repoDir, "metadata", "layout.conf"))
+		if err == nil && lc.GetValue("repo-name") != "" {
+			hasName = true
+		} else {
+			// Check profiles/repo_name
+			b, err := os.ReadFile(filepath.Join(repoDir, "profiles", "repo_name"))
+			if err == nil && strings.TrimSpace(string(b)) != "" {
 				hasName = true
-			} else {
-				// Check profiles/repo_name
-				b, err := os.ReadFile(filepath.Join(repoDir, "profiles", "repo_name"))
-				if err == nil && strings.TrimSpace(string(b)) != "" {
-					hasName = true
-				}
 			}
-			r.repoCache[repoDir] = hasName
 		}
+
+		r.mu.Lock()
+		r.repoCache[repoDir] = hasName
 		r.mu.Unlock()
 	}
 
 	if !hasName {
+		var pkgName string
+		if pkg != nil {
+			pkgName = pkg.Category + "/" + pkg.Name
+		}
 		res := lints.LintResult{
 			RuleMetadata: ruleRepoNameMissing,
 			Message:      fmt.Sprintf("[%s] Repository is missing a repo-name in metadata/layout.conf or profiles/repo_name", cases.Title(language.Und, cases.NoLower).String(string(severity))),
-			Package:      pkg.Category + "/" + pkg.Name,
+			Package:      pkgName,
 		}
 		results = append(results, res)
 	}

--- a/lints/ebuild/repo_name_missing.go
+++ b/lints/ebuild/repo_name_missing.go
@@ -1,0 +1,88 @@
+package ebuild
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleRepoNameMissing = lints.RuleMetadata{
+	ID:          "RepoNameMissing",
+	Title:       "Missing Repository Name",
+	Description: "Every Gentoo repository must define a unique repository name, either via repo-name in metadata/layout.conf or in profiles/repo_name.",
+	URL:         "https://devmanual.gentoo.org/general-concepts/overlay-layout/",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"repo-layout"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleRepoNameMissing)
+	lints.RegisterLintRule(&RepoNameMissingLintRule{})
+}
+
+type RepoNameMissingLintRule struct {
+	mu        sync.RWMutex
+	repoCache map[string]bool // map[repoDir]hasRepoName
+}
+
+func (r *RepoNameMissingLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *RepoNameMissingLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	r.mu.RLock()
+	if r.repoCache == nil {
+		r.mu.RUnlock()
+		r.mu.Lock()
+		if r.repoCache == nil {
+			r.repoCache = make(map[string]bool)
+		}
+		r.mu.Unlock()
+		r.mu.RLock()
+	}
+	hasName, cached := r.repoCache[repoDir]
+	r.mu.RUnlock()
+
+	if !cached {
+		r.mu.Lock()
+		hasName, cached = r.repoCache[repoDir]
+		if !cached {
+			hasName = false
+			// Check layout.conf
+			lc, err := g2.ParseLayoutConf(filepath.Join(repoDir, "metadata", "layout.conf"))
+			if err == nil && lc.GetValue("repo-name") != "" {
+				hasName = true
+			} else {
+				// Check profiles/repo_name
+				b, err := os.ReadFile(filepath.Join(repoDir, "profiles", "repo_name"))
+				if err == nil && strings.TrimSpace(string(b)) != "" {
+					hasName = true
+				}
+			}
+			r.repoCache[repoDir] = hasName
+		}
+		r.mu.Unlock()
+	}
+
+	if !hasName {
+		res := lints.LintResult{
+			RuleMetadata: ruleRepoNameMissing,
+			Message:      fmt.Sprintf("[%s] Repository is missing a repo-name in metadata/layout.conf or profiles/repo_name", cases.Title(language.Und, cases.NoLower).String(string(severity))),
+			Package:      pkg.Category + "/" + pkg.Name,
+		}
+		results = append(results, res)
+	}
+
+	return results
+}

--- a/lints/ebuild/repo_name_missing_test.go
+++ b/lints/ebuild/repo_name_missing_test.go
@@ -1,0 +1,92 @@
+package ebuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestRepoNameMissingLintRule(t *testing.T) {
+	category := "app-test"
+	name := "testpkg"
+
+	pkgData := &g2.PackageData{
+		Category: category,
+		Name:     name,
+	}
+
+	tests := []struct {
+		name         string
+		setupRepo    func(repoDir string)
+		expectErrors int
+	}{
+		{
+			name: "Missing repo-name",
+			setupRepo: func(repoDir string) {
+				// Create metadata and profiles dirs, but leave them empty
+				os.MkdirAll(filepath.Join(repoDir, "metadata"), 0755)
+				os.MkdirAll(filepath.Join(repoDir, "profiles"), 0755)
+			},
+			expectErrors: 1,
+		},
+		{
+			name: "Present in layout.conf",
+			setupRepo: func(repoDir string) {
+				metadataDir := filepath.Join(repoDir, "metadata")
+				os.MkdirAll(metadataDir, 0755)
+				layoutConf := "repo-name = test-overlay\nmasters = gentoo\n"
+				os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644)
+			},
+			expectErrors: 0,
+		},
+		{
+			name: "Present in profiles/repo_name",
+			setupRepo: func(repoDir string) {
+				profilesDir := filepath.Join(repoDir, "profiles")
+				os.MkdirAll(profilesDir, 0755)
+				os.WriteFile(filepath.Join(profilesDir, "repo_name"), []byte("test-overlay\n"), 0644)
+			},
+			expectErrors: 0,
+		},
+		{
+			name: "Empty layout.conf repo-name",
+			setupRepo: func(repoDir string) {
+				metadataDir := filepath.Join(repoDir, "metadata")
+				os.MkdirAll(metadataDir, 0755)
+				layoutConf := "repo-name =\nmasters = gentoo\n"
+				os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644)
+			},
+			expectErrors: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "repo-name-test")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			tt.setupRepo(tempDir)
+
+			rule := &RepoNameMissingLintRule{}
+			results := rule.Lint(tempDir, pkgData)
+
+			if len(results) != tt.expectErrors {
+				t.Errorf("expected %d errors, got %d", tt.expectErrors, len(results))
+				for _, r := range results {
+					t.Log(r.Message)
+				}
+			}
+
+			for _, result := range results {
+				if result.RuleMetadata.ID != ruleRepoNameMissing.ID {
+					t.Errorf("expected rule ID %s, got %s", ruleRepoNameMissing.ID, result.RuleMetadata.ID)
+				}
+			}
+		})
+	}
+}

--- a/lints/ebuild/repo_name_missing_test.go
+++ b/lints/ebuild/repo_name_missing_test.go
@@ -26,8 +26,8 @@ func TestRepoNameMissingLintRule(t *testing.T) {
 			name: "Missing repo-name",
 			setupRepo: func(repoDir string) {
 				// Create metadata and profiles dirs, but leave them empty
-				os.MkdirAll(filepath.Join(repoDir, "metadata"), 0755)
-				os.MkdirAll(filepath.Join(repoDir, "profiles"), 0755)
+				_ = os.MkdirAll(filepath.Join(repoDir, "metadata"), 0755)
+				_ = os.MkdirAll(filepath.Join(repoDir, "profiles"), 0755)
 			},
 			expectErrors: 1,
 		},
@@ -35,9 +35,9 @@ func TestRepoNameMissingLintRule(t *testing.T) {
 			name: "Present in layout.conf",
 			setupRepo: func(repoDir string) {
 				metadataDir := filepath.Join(repoDir, "metadata")
-				os.MkdirAll(metadataDir, 0755)
+				_ = os.MkdirAll(metadataDir, 0755)
 				layoutConf := "repo-name = test-overlay\nmasters = gentoo\n"
-				os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644)
+				_ = os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644)
 			},
 			expectErrors: 0,
 		},
@@ -45,8 +45,8 @@ func TestRepoNameMissingLintRule(t *testing.T) {
 			name: "Present in profiles/repo_name",
 			setupRepo: func(repoDir string) {
 				profilesDir := filepath.Join(repoDir, "profiles")
-				os.MkdirAll(profilesDir, 0755)
-				os.WriteFile(filepath.Join(profilesDir, "repo_name"), []byte("test-overlay\n"), 0644)
+				_ = os.MkdirAll(profilesDir, 0755)
+				_ = os.WriteFile(filepath.Join(profilesDir, "repo_name"), []byte("test-overlay\n"), 0644)
 			},
 			expectErrors: 0,
 		},
@@ -54,9 +54,9 @@ func TestRepoNameMissingLintRule(t *testing.T) {
 			name: "Empty layout.conf repo-name",
 			setupRepo: func(repoDir string) {
 				metadataDir := filepath.Join(repoDir, "metadata")
-				os.MkdirAll(metadataDir, 0755)
+				_ = os.MkdirAll(metadataDir, 0755)
 				layoutConf := "repo-name =\nmasters = gentoo\n"
-				os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644)
+				_ = os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644)
 			},
 			expectErrors: 1,
 		},
@@ -68,7 +68,9 @@ func TestRepoNameMissingLintRule(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create temp dir: %v", err)
 			}
-			defer os.RemoveAll(tempDir)
+			defer func() {
+				_ = os.RemoveAll(tempDir)
+			}()
 
 			tt.setupRepo(tempDir)
 

--- a/test-repo/metadata/layout.conf
+++ b/test-repo/metadata/layout.conf
@@ -1,2 +1,2 @@
-repo-name = goreleaser-gentoo-smoke-overlay
+repo-name = test-repo
 masters = gentoo

--- a/test-repo/metadata/layout.conf
+++ b/test-repo/metadata/layout.conf
@@ -1,2 +1,2 @@
-repo-name = test-repo
+repo-name = goreleaser-gentoo-smoke-overlay
 masters = gentoo


### PR DESCRIPTION
Added a new lint rule to enforce that `repo-name` is defined in `metadata/layout.conf` or `profiles/repo_name` for a Gentoo overlay. Updated the layout.conf of test-repo.

---
*PR created automatically by Jules for task [8283803766078148861](https://jules.google.com/task/8283803766078148861) started by @arran4*