### PR TITLE
Add github-actions format flag to linting tools

### DIFF
--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -625,7 +625,7 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildAsJson(args []string) error {
 }
 func (cfg *CmdEbuildArgConfig) cmdEbuildCheck(args []string) error {
 	fs := flag.NewFlagSet("check", flag.ExitOnError)
-	format := fs.String("format", "text", "Output format: text or json")
+	format := fs.String("format", "text", "Output format: text, json, or github-actions")
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
@@ -739,6 +739,8 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildCheck(args []string) error {
 			return fmt.Errorf("formatting json: %w", err)
 		}
 		fmt.Println(string(out))
+	} else if *format == "github-actions" {
+		printGithubActionsFormat(filteredWarnings)
 	} else {
 		for _, w := range filteredWarnings {
 			fmt.Printf("%s: [%s] %s\n", w.File, w.RuleMetadata.Severity, w.Message)

--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -733,15 +733,16 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildCheck(args []string) error {
 		hasErrors = true
 	}
 
-	if *format == "json" {
+	switch *format {
+	case "json":
 		out, err := json.MarshalIndent(filteredWarnings, "", "  ")
 		if err != nil {
 			return fmt.Errorf("formatting json: %w", err)
 		}
 		fmt.Println(string(out))
-	} else if *format == "github-actions" {
+	case "github-actions":
 		printGithubActionsFormat(filteredWarnings)
-	} else {
+	default:
 		for _, w := range filteredWarnings {
 			fmt.Printf("%s: [%s] %s\n", w.File, w.RuleMetadata.Severity, w.Message)
 		}

--- a/cmd/g2/github_actions.go
+++ b/cmd/g2/github_actions.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2/lints"
+)
+
+func escapeGithubActions(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
+}
+
+func printGithubActionsFormat(warnings []lints.LintResult) {
+	for _, w := range warnings {
+		sev := "notice"
+		switch w.RuleMetadata.Severity {
+		case lints.SeverityError:
+			sev = "error"
+		case lints.SeverityWarning:
+			sev = "warning"
+		}
+
+		parts := []string{}
+		if w.File != "" {
+			parts = append(parts, fmt.Sprintf("file=%s", w.File))
+		}
+		if w.Line > 0 {
+			parts = append(parts, fmt.Sprintf("line=%d", w.Line))
+		}
+		if w.RuleMetadata.Title != "" {
+			parts = append(parts, fmt.Sprintf("title=%s", escapeGithubActions(w.RuleMetadata.Title)))
+		}
+
+		msg := escapeGithubActions(w.Message)
+
+		if len(parts) > 0 {
+			fmt.Printf("::%s %s::%s\n", sev, strings.Join(parts, ","), msg)
+		} else {
+			fmt.Printf("::%s::%s\n", sev, msg)
+		}
+	}
+}

--- a/cmd/g2/github_actions.go
+++ b/cmd/g2/github_actions.go
@@ -14,6 +14,13 @@ func escapeGithubActions(s string) string {
 	return s
 }
 
+func escapeGithubActionsParam(s string) string {
+	s = escapeGithubActions(s)
+	s = strings.ReplaceAll(s, ",", "%2C")
+	s = strings.ReplaceAll(s, ":", "%3A")
+	return s
+}
+
 func printGithubActionsFormat(warnings []lints.LintResult) {
 	for _, w := range warnings {
 		sev := "notice"
@@ -32,7 +39,7 @@ func printGithubActionsFormat(warnings []lints.LintResult) {
 			parts = append(parts, fmt.Sprintf("line=%d", w.Line))
 		}
 		if w.RuleMetadata.Title != "" {
-			parts = append(parts, fmt.Sprintf("title=%s", escapeGithubActions(w.RuleMetadata.Title)))
+			parts = append(parts, fmt.Sprintf("title=%s", escapeGithubActionsParam(w.RuleMetadata.Title)))
 		}
 
 		msg := escapeGithubActions(w.Message)

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -113,13 +113,14 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 		}
 	}
 
-	if *format == "json" {
+	switch *format {
+	case "json":
 		out, err := json.MarshalIndent(allResults, "", "  ")
 		if err != nil {
 			return fmt.Errorf("formatting json: %w", err)
 		}
 		fmt.Println(string(out))
-	} else if *format == "github-actions" {
+	case "github-actions":
 		printGithubActionsFormat(allResults)
 	}
 

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -34,7 +34,7 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 		return nil
 	}
 	fs := flag.NewFlagSet("lint", flag.ExitOnError)
-	format := fs.String("format", "text", "Output format: text or json")
+	format := fs.String("format", "text", "Output format: text, json, or github-actions")
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
@@ -119,6 +119,8 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 			return fmt.Errorf("formatting json: %w", err)
 		}
 		fmt.Println(string(out))
+	} else if *format == "github-actions" {
+		printGithubActionsFormat(allResults)
 	}
 
 	if hasErrors {

--- a/g2-action-prompt.txt
+++ b/g2-action-prompt.txt
@@ -1,0 +1,6 @@
+Hello! We have added a new `--format=github-actions` flag to the `g2` tool. This format outputs lint errors using the standard GitHub Actions log commands (e.g. `::error file=...,title=...::message`), which allows GitHub to inline the errors directly into pull requests and action summaries, including support for multiline markdown!
+
+Please update this `g2-action` repository to utilize this new formatting flag. Specifically:
+
+1. In the script or Action runner where the `g2 lint` or `g2 ebuild check` command is invoked, append `--format=github-actions`.
+2. Ensure that any previous parsing logic that manually attempted to parse text or JSON to output GitHub Actions annotations can be safely simplified or removed.


### PR DESCRIPTION
This adds the requested GitHub Actions formatter, enabling proper output integration for CI workflows like `g2-action`. It maps G2 severities to GitHub equivalents and properly escapes newlines so multiline messages (like markdown code blocks) are parsed correctly by GitHub.

---
*PR created automatically by Jules for task [275643031767234857](https://jules.google.com/task/275643031767234857) started by @arran4*