### PR TITLE
Support specific target packages as positional arguments in g2 lint

### DIFF
--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -35,6 +35,13 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 		return nil
 	}
 	fs := flag.NewFlagSet("lint", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Printf("Usage: g2 lint [flags] [<location>] [<target_package>...]\n\n")
+		fmt.Printf("  <location>\tOptional path to the overlay directory (defaults to '.'). Detected automatically if it's a valid repo.\n")
+		fmt.Printf("  <target_package>\tOptional specific packages or categories to lint instead of the entire repository (e.g. app-misc/foo or just foo).\n\n")
+		fmt.Printf("Flags:\n")
+		fs.PrintDefaults()
+	}
 	format := fs.String("format", "text", "Output format: text or json")
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/arran4/g2"
@@ -44,13 +45,51 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 	}
 
 	location := "."
+	var targetPkgs []string
+
 	if fs.NArg() > 0 {
-		location = fs.Arg(0)
+		firstArg := fs.Arg(0)
+		isRepo := false
+		if _, err := os.Stat(filepath.Join(firstArg, "profiles")); err == nil {
+			isRepo = true
+		} else if _, err := os.Stat(filepath.Join(firstArg, "metadata", "layout.conf")); err == nil {
+			isRepo = true
+		} else if firstArg == "." {
+			isRepo = true
+		} else if len(fs.Args()) == 1 {
+			_, errProfiles := os.Stat("profiles")
+			_, errMetadata := os.Stat(filepath.Join("metadata", "layout.conf"))
+			if errProfiles == nil || errMetadata == nil {
+				isRepo = false
+			} else {
+				cleanArg := filepath.ToSlash(filepath.Clean(firstArg))
+				if !strings.Contains(cleanArg, "/") {
+					isRepo = true
+				}
+			}
+		}
+
+		if isRepo {
+			location = firstArg
+			targetPkgs = fs.Args()[1:]
+		} else {
+			targetPkgs = fs.Args()
+		}
 	}
 
 	siteData, err := parseRepo(os.DirFS(location), ".", "Linting", true, nil)
 	if err != nil {
 		return fmt.Errorf("parsing repo: %w", err)
+	}
+
+	var targetMap map[string]bool
+	if len(targetPkgs) > 0 {
+		targetMap = make(map[string]bool)
+		for _, p := range targetPkgs {
+			cleanP := filepath.ToSlash(filepath.Clean(p))
+			targetMap[cleanP] = true
+			targetMap[filepath.Base(cleanP)] = true
+		}
 	}
 
 	hasErrors := false
@@ -59,6 +98,12 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 
 	for _, cat := range siteData.Categories {
 		for _, pkg := range cat.Packages {
+			if len(targetMap) > 0 {
+				qualified := pkg.Category + "/" + pkg.Name
+				if !targetMap[qualified] && !targetMap[pkg.Name] && !targetMap[pkg.Category] {
+					continue
+				}
+			}
 			pkgCopy := g2.PackageData{
 				Name:          pkg.Name,
 				Category:      pkg.Category,

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -56,17 +56,6 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 			isRepo = true
 		} else if firstArg == "." {
 			isRepo = true
-		} else if len(fs.Args()) == 1 {
-			_, errProfiles := os.Stat("profiles")
-			_, errMetadata := os.Stat(filepath.Join("metadata", "layout.conf"))
-			if errProfiles == nil || errMetadata == nil {
-				isRepo = false
-			} else {
-				cleanArg := filepath.ToSlash(filepath.Clean(firstArg))
-				if !strings.Contains(cleanArg, "/") {
-					isRepo = true
-				}
-			}
 		}
 
 		if isRepo {
@@ -88,7 +77,6 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 		for _, p := range targetPkgs {
 			cleanP := filepath.ToSlash(filepath.Clean(p))
 			targetMap[cleanP] = true
-			targetMap[filepath.Base(cleanP)] = true
 		}
 	}
 

--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -34,7 +34,7 @@ func main() {
 		fmt.Printf("\t\t %s \t\t %s\n", "ebuild", "commands relating to ebuild files")
 		fmt.Printf("\t\t %s \t\t %s\n", "overlay", "commands relating to a single overlay")
 		fmt.Printf("\t\t %s \t\t %s\n", "overlays", "commands relating to multiple overlays")
-		fmt.Printf("\t\t %s \t\t %s\n", "lint", "lints the repository for errors")
+		fmt.Printf("\t\t %s \t\t %s\n", "lint", "lints the repository for errors (supports optional target packages)")
 		fmt.Printf("\t\t %s \t\t %s\n", "use", "commands relating to USE flags, use.desc, and use.local.desc")
 		fmt.Printf("\t\t %s \t\t %s\n", "site", "commands relating to static sites")
 		fmt.Printf("\t\t %s \t\t %s\n", "cache", "commands relating to md5-dict/cache")

--- a/readme.md
+++ b/readme.md
@@ -260,17 +260,20 @@ Checks the repository for errors such as ebuild `IUSE` variables missing in `met
 **Usage:**
 
 ```bash
-g2 lint [<location>]
+g2 lint [<location>] [<target_package>...]
 ```
 
 **Arguments:**
 
-* `<location>`: Path to the overlay directory (defaults to `.`).
+* `<location>`: Path to the overlay directory (defaults to `.`). Detected automatically if it's a valid repo.
+* `<target_package>`: Optional specific packages or categories to lint instead of the entire repository (e.g. `app-misc/foo` or just `foo`).
 
 **Example:**
 
 ```bash
 g2 lint /var/db/repos/my-overlay
+g2 lint . app-misc/foo
+g2 lint /var/db/repos/my-overlay app-misc/foo dev-util/bar
 ```
 
 ### `use`

--- a/readme.md
+++ b/readme.md
@@ -276,6 +276,8 @@ g2 lint . app-misc/foo
 g2 lint /var/db/repos/my-overlay app-misc/foo dev-util/bar
 ```
 
+*(Note: In the future, this command may be split into separate subcommands like `g2 lint repo`, `g2 lint package`, and `g2 lint query` for clarity. It does not currently support full package queries like `<pn>::guru`, `app-misc/foo-v3`, or `>=`)*
+
 ### `use`
 
 Manage and discover USE flags, `use.desc`, and `use.local.desc`.


### PR DESCRIPTION
Modify `g2 lint` argument parsing in `cmd/g2/lint.go` to support specifying explicit packages/directories to lint instead of defaulting to linting the entire repository. This solves issues in CI workflows (like `g2-lint.yml`) where `g2 lint $DIRS` would fail on unrelated packages.

---
*PR created automatically by Jules for task [2925962514397850246](https://jules.google.com/task/2925962514397850246) started by @arran4*