### PR TITLE
feat: add agent skill subcommand system

### DIFF
--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -47,6 +47,7 @@ func main() {
 		fmt.Printf("\t\t %s \t\t %s\n", "repos-conf", "commands relating to repos.conf")
 		fmt.Printf("\t\t %s \t\t %s\n", "make-conf", "commands relating to make.conf")
 		fmt.Printf("\t\t %s \t\t %s\n", "conf", "commands relating to portage configuration")
+		fmt.Printf("\t\t %s \t\t %s\n", "skill", "manage agent skills")
 		fmt.Printf("\t\t %s \t\t %s\n", "world", "manage the portage world file via TUI")
 	}
 	if err := fs.Parse(os.Args); err != nil {
@@ -63,6 +64,12 @@ func main() {
 	cmd := fs.Arg(1)
 	cfg.Args = append(cfg.Args, cmd)
 	switch cmd {
+	case "skill":
+		if err := cfg.cmdSkill(fs.Args()[2:]); err != nil {
+			log.Printf("skill error: %s", err)
+			os.Exit(-1)
+			return
+		}
 	case "masks":
 		if err := cfg.cmdMasks(fs.Args()[2:]); err != nil {
 			log.Printf("masks error: %s", err)

--- a/cmd/g2/skill.go
+++ b/cmd/g2/skill.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func (c *MainArgConfig) cmdSkill(args []string) error {
+	fs := flag.NewFlagSet("skill", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Printf("Usage: %s skill <subcommand> [flags]\n", c.Args[0])
+		fmt.Printf("Subcommands:\n")
+		fmt.Printf("\tinstall\t\tInstall a new agent skill\n")
+		fmt.Printf("\tupdate\t\tUpdate an installed skill\n")
+		fmt.Printf("\tremove\t\tRemove an installed skill\n")
+		fmt.Printf("\tlist\t\tList installed skills\n")
+		fmt.Printf("\tinspect\t\tInspect an installed skill\n")
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() == 0 {
+		fs.Usage()
+		return nil
+	}
+
+	subCmd := fs.Arg(0)
+	subArgs := fs.Args()[1:]
+
+	switch subCmd {
+	case "install":
+		return c.cmdSkillInstall(subArgs)
+	case "update":
+		return c.cmdSkillUpdate(subArgs)
+	case "remove":
+		return c.cmdSkillRemove(subArgs)
+	case "list":
+		return c.cmdSkillList(subArgs)
+	case "inspect":
+		return c.cmdSkillInspect(subArgs)
+	default:
+		return fmt.Errorf("unknown skill subcommand: %s", subCmd)
+	}
+}

--- a/cmd/g2/skill_core.go
+++ b/cmd/g2/skill_core.go
@@ -106,10 +106,10 @@ func calculateDirDigest(dir string) (string, error) {
 		h.Write([]byte{0})
 
 		if _, err := io.Copy(h, f); err != nil {
-			f.Close()
+			_ = f.Close()
 			return "", err
 		}
-		f.Close()
+		_ = f.Close()
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
@@ -176,7 +176,7 @@ func copyDir(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer s.Close()
+		defer func() { _ = s.Close() }()
 
 		dFile, err := os.Create(dstPath)
 		if err != nil {
@@ -189,4 +189,11 @@ func copyDir(src, dst string) error {
 		}
 		return nil
 	})
+}
+
+func isValidSkillName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	return filepath.Base(name) == name
 }

--- a/cmd/g2/skill_core.go
+++ b/cmd/g2/skill_core.go
@@ -26,19 +26,20 @@ type SkillMetadata struct {
 
 func getSkillBasePath(scope, agent string) (string, error) {
 	var baseDir string
-	if scope == "user" {
+	switch scope {
+	case "user":
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", err
 		}
 		baseDir = home
-	} else if scope == "project" {
+		case "project":
 		pwd, err := os.Getwd()
 		if err != nil {
 			return "", err
 		}
 		baseDir = pwd
-	} else {
+		default:
 		return "", fmt.Errorf("invalid scope: %s", scope)
 	}
 
@@ -182,7 +183,7 @@ func copyDir(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer dFile.Close()
+		defer func() { _ = dFile.Close() }()
 
 		if _, err := io.Copy(dFile, s); err != nil {
 			return err

--- a/cmd/g2/skill_core.go
+++ b/cmd/g2/skill_core.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type SkillMetadata struct {
+	Name             string    `json:"name"`
+	Source           string    `json:"source"`
+	Subpath          string    `json:"subpath"`
+	Revision         string    `json:"revision"`
+	Digest           string    `json:"digest"`
+	InstallationTime time.Time `json:"installation_time"`
+	Scope            string    `json:"scope"`
+	Agent            string    `json:"agent"`
+}
+
+func getSkillBasePath(scope, agent string) (string, error) {
+	var baseDir string
+	if scope == "user" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		baseDir = home
+	} else if scope == "project" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		baseDir = pwd
+	} else {
+		return "", fmt.Errorf("invalid scope: %s", scope)
+	}
+
+	var path string
+	switch agent {
+	case "codex":
+		path = filepath.Join(baseDir, ".codex", "skills")
+	case "claude":
+		path = filepath.Join(baseDir, ".claude", "skills")
+	case "copilot":
+		path = filepath.Join(baseDir, ".copilot", "skills")
+	case "cursor":
+		path = filepath.Join(baseDir, ".cursor", "skills")
+	case "common":
+		path = filepath.Join(baseDir, ".agents", "skills")
+	default:
+		// Default to common if not specified or unknown
+		path = filepath.Join(baseDir, ".agents", "skills")
+	}
+
+	return path, nil
+}
+
+func calculateDirDigest(dir string) (string, error) {
+	h := sha256.New()
+
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "skill-metadata.json" {
+			return nil // Don't include metadata in its own digest
+		}
+
+		files = append(files, relPath)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sort.Strings(files)
+
+	for _, relPath := range files {
+		path := filepath.Join(dir, relPath)
+		f, err := os.Open(path)
+		if err != nil {
+			return "", err
+		}
+
+		h.Write([]byte(relPath))
+		h.Write([]byte{0})
+
+		if _, err := io.Copy(h, f); err != nil {
+			f.Close()
+			return "", err
+		}
+		f.Close()
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func writeSkillMetadata(dir string, meta *SkillMetadata) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, "skill-metadata.json"), data, 0644)
+}
+
+func readSkillMetadata(dir string) (*SkillMetadata, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "skill-metadata.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	var meta SkillMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+
+	return &meta, nil
+}
+
+func copyDir(src, dst string) error {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "skill-metadata.json" {
+			return nil // don't copy existing metadata
+		}
+
+		if strings.Contains(relPath, "..") {
+			return fmt.Errorf("invalid path traversal: %s", relPath)
+		}
+
+		dstPath := filepath.Join(dst, relPath)
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+			return err
+		}
+
+		s, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer s.Close()
+
+		dFile, err := os.Create(dstPath)
+		if err != nil {
+			return err
+		}
+		defer dFile.Close()
+
+		if _, err := io.Copy(dFile, s); err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/cmd/g2/skill_core.go.orig
+++ b/cmd/g2/skill_core.go.orig
@@ -103,6 +103,7 @@ func calculateDirDigest(dir string) (string, error) {
 		}
 
 		h.Write([]byte(relPath))
+		h.Write([]byte{0})
 
 		if _, err := io.Copy(h, f); err != nil {
 			f.Close()
@@ -175,7 +176,7 @@ func copyDir(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer s.Close()
+		defer func() { _ = s.Close() }()
 
 		dFile, err := os.Create(dstPath)
 		if err != nil {

--- a/cmd/g2/skill_core.go.orig
+++ b/cmd/g2/skill_core.go.orig
@@ -106,10 +106,10 @@ func calculateDirDigest(dir string) (string, error) {
 		h.Write([]byte{0})
 
 		if _, err := io.Copy(h, f); err != nil {
-			f.Close()
+			_ = f.Close()
 			return "", err
 		}
-		f.Close()
+		_ = f.Close()
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
@@ -182,11 +182,18 @@ func copyDir(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer dFile.Close()
+		defer func() { _ = dFile.Close() }()
 
 		if _, err := io.Copy(dFile, s); err != nil {
 			return err
 		}
 		return nil
 	})
+}
+
+func isValidSkillName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	return filepath.Base(name) == name
 }

--- a/cmd/g2/skill_core.go.orig
+++ b/cmd/g2/skill_core.go.orig
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type SkillMetadata struct {
+	Name             string    `json:"name"`
+	Source           string    `json:"source"`
+	Subpath          string    `json:"subpath"`
+	Revision         string    `json:"revision"`
+	Digest           string    `json:"digest"`
+	InstallationTime time.Time `json:"installation_time"`
+	Scope            string    `json:"scope"`
+	Agent            string    `json:"agent"`
+}
+
+func getSkillBasePath(scope, agent string) (string, error) {
+	var baseDir string
+	if scope == "user" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		baseDir = home
+	} else if scope == "project" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		baseDir = pwd
+	} else {
+		return "", fmt.Errorf("invalid scope: %s", scope)
+	}
+
+	var path string
+	switch agent {
+	case "codex":
+		path = filepath.Join(baseDir, ".codex", "skills")
+	case "claude":
+		path = filepath.Join(baseDir, ".claude", "skills")
+	case "copilot":
+		path = filepath.Join(baseDir, ".copilot", "skills")
+	case "cursor":
+		path = filepath.Join(baseDir, ".cursor", "skills")
+	case "common":
+		path = filepath.Join(baseDir, ".agents", "skills")
+	default:
+		// Default to common if not specified or unknown
+		path = filepath.Join(baseDir, ".agents", "skills")
+	}
+
+	return path, nil
+}
+
+func calculateDirDigest(dir string) (string, error) {
+	h := sha256.New()
+
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "skill-metadata.json" {
+			return nil // Don't include metadata in its own digest
+		}
+
+		files = append(files, relPath)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sort.Strings(files)
+
+	for _, relPath := range files {
+		path := filepath.Join(dir, relPath)
+		f, err := os.Open(path)
+		if err != nil {
+			return "", err
+		}
+
+		h.Write([]byte(relPath))
+
+		if _, err := io.Copy(h, f); err != nil {
+			f.Close()
+			return "", err
+		}
+		f.Close()
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func writeSkillMetadata(dir string, meta *SkillMetadata) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, "skill-metadata.json"), data, 0644)
+}
+
+func readSkillMetadata(dir string) (*SkillMetadata, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "skill-metadata.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	var meta SkillMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+
+	return &meta, nil
+}
+
+func copyDir(src, dst string) error {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "skill-metadata.json" {
+			return nil // don't copy existing metadata
+		}
+
+		if strings.Contains(relPath, "..") {
+			return fmt.Errorf("invalid path traversal: %s", relPath)
+		}
+
+		dstPath := filepath.Join(dst, relPath)
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+			return err
+		}
+
+		s, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer s.Close()
+
+		dFile, err := os.Create(dstPath)
+		if err != nil {
+			return err
+		}
+		defer dFile.Close()
+
+		if _, err := io.Copy(dFile, s); err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/cmd/g2/skill_inspect.go
+++ b/cmd/g2/skill_inspect.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func (c *MainArgConfig) cmdSkillInspect(args []string) error {
+	fs := flag.NewFlagSet("skill inspect", flag.ExitOnError)
+	scope := fs.String("scope", "project", "Scope to inspect from (user, project)")
+	agent := fs.String("agent", "common", "Target agent (common, codex, claude, copilot, cursor)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: g2 skill inspect <skill-name>")
+	}
+
+	skillName := fs.Arg(0)
+
+	basePath, err := getSkillBasePath(*scope, *agent)
+	if err != nil {
+		return err
+	}
+
+	destDir := filepath.Join(basePath, skillName)
+
+	meta, err := readSkillMetadata(destDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("skill %q not found or not managed by g2 (missing metadata)", skillName)
+		}
+		return fmt.Errorf("failed to read skill metadata: %w", err)
+	}
+
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	// Also print out local modifications if any
+	currentDigest, err := calculateDirDigest(destDir)
+	if err == nil && currentDigest != meta.Digest {
+		fmt.Printf("\nWARNING: Installed skill has local modifications.\n")
+	}
+
+	return nil
+}

--- a/cmd/g2/skill_inspect.go.orig
+++ b/cmd/g2/skill_inspect.go.orig
@@ -22,9 +22,6 @@ func (c *MainArgConfig) cmdSkillInspect(args []string) error {
 	}
 
 	skillName := fs.Arg(0)
-	if !isValidSkillName(skillName) {
-		return fmt.Errorf("invalid skill name: %q", skillName)
-	}
 
 	basePath, err := getSkillBasePath(*scope, *agent)
 	if err != nil {

--- a/cmd/g2/skill_install.go
+++ b/cmd/g2/skill_install.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func (c *MainArgConfig) cmdSkillInstall(args []string) error {
+	fs := flag.NewFlagSet("skill install", flag.ExitOnError)
+	scope := fs.String("scope", "project", "Scope to install the skill (user, project)")
+	agent := fs.String("agent", "common", "Target agent (common, codex, claude, copilot, cursor)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: g2 skill install <source> [skill-name-or-path]")
+	}
+
+	source := fs.Arg(0)
+	skillNameOrPath := ""
+	if fs.NArg() > 1 {
+		skillNameOrPath = fs.Arg(1)
+	} else {
+		skillNameOrPath = filepath.Base(source)
+	}
+
+	basePath, err := getSkillBasePath(*scope, *agent)
+	if err != nil {
+		return err
+	}
+
+	destDir := filepath.Join(basePath, filepath.Base(skillNameOrPath))
+
+	// Ensure destination directory is clean
+	if err := os.RemoveAll(destDir); err != nil {
+		return fmt.Errorf("failed to clear destination directory: %w", err)
+	}
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	var srcPath string
+	var subPath string
+
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "git://") {
+		return fmt.Errorf("remote git sources not yet supported")
+	} else if strings.Contains(source, "/") && !strings.HasPrefix(source, ".") && !strings.HasPrefix(source, "/") {
+		return fmt.Errorf("github sources not yet supported")
+	} else {
+		// local filesystem path
+		srcPath = filepath.Clean(source)
+		if fs.NArg() > 1 && strings.Contains(skillNameOrPath, string(filepath.Separator)) {
+			srcPath = filepath.Join(srcPath, skillNameOrPath)
+			subPath = skillNameOrPath
+		}
+	}
+
+	// Check if SKILL.md exists
+	skillMdPath := filepath.Join(srcPath, "SKILL.md")
+	if _, err := os.Stat(skillMdPath); os.IsNotExist(err) {
+		// Try to see if it's a multi-skill dir without explicit subpath
+		if fs.NArg() == 1 {
+			entries, _ := os.ReadDir(filepath.Join(srcPath, "skills"))
+			if len(entries) > 0 {
+				names := []string{}
+				for _, e := range entries {
+					if e.IsDir() {
+						names = append(names, e.Name())
+					}
+				}
+				if len(names) > 0 {
+					return fmt.Errorf("repository contains multiple skills: %s; specify one explicitly", strings.Join(names, ", "))
+				}
+			}
+		}
+		return fmt.Errorf("SKILL.md not found in source: %s", srcPath)
+	}
+
+	if err := copyDir(srcPath, destDir); err != nil {
+		return fmt.Errorf("failed to copy skill files: %w", err)
+	}
+
+	digest, err := calculateDirDigest(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to calculate digest: %w", err)
+	}
+
+	meta := &SkillMetadata{
+		Name:             filepath.Base(destDir),
+		Source:           source,
+		Subpath:          subPath,
+		Revision:         "local", // or commit hash if git
+		Digest:           digest,
+		InstallationTime: time.Now(),
+		Scope:            *scope,
+		Agent:            *agent,
+	}
+
+	if err := writeSkillMetadata(destDir, meta); err != nil {
+		return fmt.Errorf("failed to write metadata: %w", err)
+	}
+
+	fmt.Printf("Successfully installed skill %q to %s\n", meta.Name, destDir)
+	return nil
+}

--- a/cmd/g2/skill_install.go.orig
+++ b/cmd/g2/skill_install.go.orig
@@ -35,11 +35,7 @@ func (c *MainArgConfig) cmdSkillInstall(args []string) error {
 		return err
 	}
 
-	skillName := filepath.Base(skillNameOrPath)
-	if !isValidSkillName(skillName) {
-		return fmt.Errorf("invalid skill name: %q", skillNameOrPath)
-	}
-	destDir := filepath.Join(basePath, skillName)
+	destDir := filepath.Join(basePath, filepath.Base(skillNameOrPath))
 
 	// Ensure destination directory is clean
 	if err := os.RemoveAll(destDir); err != nil {

--- a/cmd/g2/skill_list.go
+++ b/cmd/g2/skill_list.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+)
+
+func (c *MainArgConfig) cmdSkillList(args []string) error {
+	fs := flag.NewFlagSet("skill list", flag.ExitOnError)
+	scope := fs.String("scope", "project", "Scope to list from (user, project, all)")
+	agent := fs.String("agent", "common", "Target agent (common, codex, claude, copilot, cursor)")
+	format := fs.String("format", "table", "Output format (table, json)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	scopesToSearch := []string{*scope}
+	if *scope == "all" {
+		scopesToSearch = []string{"user", "project"}
+	}
+
+	agentsToSearch := []string{*agent}
+	if *agent == "all" {
+		agentsToSearch = []string{"common", "codex", "claude", "copilot", "cursor"}
+	}
+
+	var allSkills []*SkillMetadata
+
+	for _, s := range scopesToSearch {
+		for _, a := range agentsToSearch {
+			basePath, err := getSkillBasePath(s, a)
+			if err != nil {
+				continue
+			}
+
+			entries, err := os.ReadDir(basePath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", basePath, err)
+				continue
+			}
+
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				destDir := filepath.Join(basePath, e.Name())
+				meta, err := readSkillMetadata(destDir)
+				if err != nil {
+					continue // likely not a g2 skill
+				}
+
+				// override with where it was actually found in case it was moved
+				meta.Scope = s
+				meta.Agent = a
+
+				allSkills = append(allSkills, meta)
+			}
+		}
+	}
+
+	if *format == "json" {
+		data, err := json.MarshalIndent(allSkills, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	if len(allSkills) == 0 {
+		fmt.Println("No skills installed.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tSCOPE\tAGENT\tREVISION\tSOURCE")
+
+	for _, skill := range allSkills {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			skill.Name,
+			skill.Scope,
+			skill.Agent,
+			skill.Revision,
+			skill.Source,
+		)
+	}
+	w.Flush()
+
+	return nil
+}

--- a/cmd/g2/skill_list.go.orig
+++ b/cmd/g2/skill_list.go.orig
@@ -81,10 +81,10 @@ func (c *MainArgConfig) cmdSkillList(args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "NAME\tSCOPE\tAGENT\tREVISION\tSOURCE")
+	fmt.Fprintln(w, "NAME\tSCOPE\tAGENT\tREVISION\tSOURCE")
 
 	for _, skill := range allSkills {
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			skill.Name,
 			skill.Scope,
 			skill.Agent,
@@ -92,7 +92,7 @@ func (c *MainArgConfig) cmdSkillList(args []string) error {
 			skill.Source,
 		)
 	}
-	_ = w.Flush()
+	w.Flush()
 
 	return nil
 }

--- a/cmd/g2/skill_remove.go
+++ b/cmd/g2/skill_remove.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func (c *MainArgConfig) cmdSkillRemove(args []string) error {
+	fs := flag.NewFlagSet("skill remove", flag.ExitOnError)
+	scope := fs.String("scope", "project", "Scope to remove from (user, project)")
+	agent := fs.String("agent", "common", "Target agent (common, codex, claude, copilot, cursor)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: g2 skill remove <skill-name>")
+	}
+
+	skillName := fs.Arg(0)
+
+	basePath, err := getSkillBasePath(*scope, *agent)
+	if err != nil {
+		return err
+	}
+
+	destDir := filepath.Join(basePath, skillName)
+
+	// Safety check to ensure we only remove something that looks like an installed skill
+	if _, err := os.Stat(filepath.Join(destDir, "skill-metadata.json")); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("skill %q not found or not managed by g2 (missing metadata)", skillName)
+		}
+		return fmt.Errorf("failed to read skill metadata: %w", err)
+	}
+
+	if err := os.RemoveAll(destDir); err != nil {
+		return fmt.Errorf("failed to remove skill directory: %w", err)
+	}
+
+	fmt.Printf("Successfully removed skill %q from %s scope for %s agent\n", skillName, *scope, *agent)
+	return nil
+}

--- a/cmd/g2/skill_remove.go.orig
+++ b/cmd/g2/skill_remove.go.orig
@@ -21,9 +21,6 @@ func (c *MainArgConfig) cmdSkillRemove(args []string) error {
 	}
 
 	skillName := fs.Arg(0)
-	if !isValidSkillName(skillName) {
-		return fmt.Errorf("invalid skill name: %q", skillName)
-	}
 
 	basePath, err := getSkillBasePath(*scope, *agent)
 	if err != nil {

--- a/cmd/g2/skill_test.go
+++ b/cmd/g2/skill_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"strings"
+)
+
+func TestSkillInstallLocal(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "g2-skill-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourceDir := filepath.Join(tempDir, "source", "my-skill")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte("# My Skill\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := filepath.Join(tempDir, "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
+
+	c := &MainArgConfig{Args: []string{"g2"}}
+	err = c.cmdSkillInstall([]string{"--scope", "project", sourceDir})
+	if err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	destDir := filepath.Join(projectDir, ".agents", "skills", "my-skill")
+	if _, err := os.Stat(filepath.Join(destDir, "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md not found in dest: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(destDir, "skill-metadata.json")); err != nil {
+		t.Fatalf("skill-metadata.json not found in dest: %v", err)
+	}
+}
+
+func TestSkillUpdateLocal(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "g2-skill-test-update-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourceDir := filepath.Join(tempDir, "source", "my-skill")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte("# My Skill\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := filepath.Join(tempDir, "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
+
+	c := &MainArgConfig{Args: []string{"g2"}}
+
+	// Install
+	if err := c.cmdSkillInstall([]string{"--scope", "project", sourceDir}); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// Update without changes
+	if err := c.cmdSkillUpdate([]string{"--scope", "project", "my-skill"}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Modify Source
+	if err := os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte("# My Skill\nUpdated!\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update with changes
+	if err := c.cmdSkillUpdate([]string{"--scope", "project", "my-skill"}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Check if updated
+	destDir := filepath.Join(projectDir, ".agents", "skills", "my-skill")
+	content, _ := os.ReadFile(filepath.Join(destDir, "SKILL.md"))
+	if string(content) != "# My Skill\nUpdated!\n" {
+		t.Fatalf("Skill not updated! Content: %s", string(content))
+	}
+
+	// Modify dest (local modifications)
+	if err := os.WriteFile(filepath.Join(destDir, "SKILL.md"), []byte("Local changes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update should skip
+	if err := c.cmdSkillUpdate([]string{"--scope", "project", "my-skill"}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	content2, _ := os.ReadFile(filepath.Join(destDir, "SKILL.md"))
+	if string(content2) != "Local changes" {
+		t.Fatalf("Skill overwritten despite local changes!")
+	}
+
+	// Update with force
+	if err := c.cmdSkillUpdate([]string{"--scope", "project", "--force", "my-skill"}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	content3, _ := os.ReadFile(filepath.Join(destDir, "SKILL.md"))
+	if string(content3) != "# My Skill\nUpdated!\n" {
+		t.Fatalf("Skill not forced updated! Content: %s", string(content3))
+	}
+}
+
+func TestSkillRemove(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "g2-skill-test-remove-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourceDir := filepath.Join(tempDir, "source", "my-skill")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte("# My Skill\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := filepath.Join(tempDir, "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
+
+	c := &MainArgConfig{Args: []string{"g2"}}
+
+	// Install
+	if err := c.cmdSkillInstall([]string{"--scope", "project", sourceDir}); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// Remove
+	if err := c.cmdSkillRemove([]string{"--scope", "project", "my-skill"}); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	destDir := filepath.Join(projectDir, ".agents", "skills", "my-skill")
+	if _, err := os.Stat(destDir); !os.IsNotExist(err) {
+		t.Fatalf("Skill directory still exists after remove!")
+	}
+}
+
+func TestSkillList(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "g2-skill-test-list-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourceDir := filepath.Join(tempDir, "source", "my-skill")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte("# My Skill\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := filepath.Join(tempDir, "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
+
+	c := &MainArgConfig{Args: []string{"g2"}}
+
+	// Install
+	if err := c.cmdSkillInstall([]string{"--scope", "project", sourceDir}); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// List
+	if err := c.cmdSkillList([]string{"--scope", "project"}); err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+}
+
+func TestSkillInspect(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "g2-skill-test-inspect-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourceDir := filepath.Join(tempDir, "source", "my-skill")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "SKILL.md"), []byte("# My Skill\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := filepath.Join(tempDir, "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
+
+	c := &MainArgConfig{Args: []string{"g2"}}
+
+	// Install
+	if err := c.cmdSkillInstall([]string{"--scope", "project", sourceDir}); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// Inspect
+	if err := c.cmdSkillInspect([]string{"--scope", "project", "my-skill"}); err != nil {
+		t.Fatalf("Inspect failed: %v", err)
+	}
+}
+
+func TestSkillInstallInvalid(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "g2-skill-test-invalid-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourceDir := filepath.Join(tempDir, "source", "invalid-skill")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// No SKILL.md written
+
+	projectDir := filepath.Join(tempDir, "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
+
+	c := &MainArgConfig{Args: []string{"g2"}}
+
+	// Install should fail
+	err = c.cmdSkillInstall([]string{"--scope", "project", sourceDir})
+	if err == nil {
+		t.Fatalf("Install should have failed because SKILL.md is missing")
+	}
+
+	if !strings.Contains(err.Error(), "SKILL.md not found") {
+		t.Fatalf("Unexpected error message: %v", err)
+	}
+}

--- a/cmd/g2/skill_test.go.orig
+++ b/cmd/g2/skill_test.go.orig
@@ -12,7 +12,7 @@ func TestSkillInstallLocal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	defer os.RemoveAll(tempDir)
 
 	sourceDir := filepath.Join(tempDir, "source", "my-skill")
 	if err := os.MkdirAll(sourceDir, 0755); err != nil {
@@ -28,10 +28,8 @@ func TestSkillInstallLocal(t *testing.T) {
 	}
 
 	cwd, _ := os.Getwd()
-	if err := os.Chdir(projectDir); err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Chdir(cwd) }()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
 
 	c := &MainArgConfig{Args: []string{"g2"}}
 	err = c.cmdSkillInstall([]string{"--scope", "project", sourceDir})
@@ -54,7 +52,7 @@ func TestSkillUpdateLocal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	defer os.RemoveAll(tempDir)
 
 	sourceDir := filepath.Join(tempDir, "source", "my-skill")
 	if err := os.MkdirAll(sourceDir, 0755); err != nil {
@@ -70,8 +68,8 @@ func TestSkillUpdateLocal(t *testing.T) {
 	}
 
 	cwd, _ := os.Getwd()
-	if err := os.Chdir(projectDir); err != nil { t.Fatal(err) }
-	defer func() { _ = os.Chdir(cwd) }()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
 
 	c := &MainArgConfig{Args: []string{"g2"}}
 
@@ -133,7 +131,7 @@ func TestSkillRemove(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	defer os.RemoveAll(tempDir)
 
 	sourceDir := filepath.Join(tempDir, "source", "my-skill")
 	if err := os.MkdirAll(sourceDir, 0755); err != nil {
@@ -149,8 +147,8 @@ func TestSkillRemove(t *testing.T) {
 	}
 
 	cwd, _ := os.Getwd()
-	if err := os.Chdir(projectDir); err != nil { t.Fatal(err) }
-	defer func() { _ = os.Chdir(cwd) }()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
 
 	c := &MainArgConfig{Args: []string{"g2"}}
 
@@ -175,7 +173,7 @@ func TestSkillList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	defer os.RemoveAll(tempDir)
 
 	sourceDir := filepath.Join(tempDir, "source", "my-skill")
 	if err := os.MkdirAll(sourceDir, 0755); err != nil {
@@ -191,8 +189,8 @@ func TestSkillList(t *testing.T) {
 	}
 
 	cwd, _ := os.Getwd()
-	if err := os.Chdir(projectDir); err != nil { t.Fatal(err) }
-	defer func() { _ = os.Chdir(cwd) }()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
 
 	c := &MainArgConfig{Args: []string{"g2"}}
 
@@ -212,7 +210,7 @@ func TestSkillInspect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	defer os.RemoveAll(tempDir)
 
 	sourceDir := filepath.Join(tempDir, "source", "my-skill")
 	if err := os.MkdirAll(sourceDir, 0755); err != nil {
@@ -228,8 +226,8 @@ func TestSkillInspect(t *testing.T) {
 	}
 
 	cwd, _ := os.Getwd()
-	if err := os.Chdir(projectDir); err != nil { t.Fatal(err) }
-	defer func() { _ = os.Chdir(cwd) }()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
 
 	c := &MainArgConfig{Args: []string{"g2"}}
 
@@ -249,7 +247,7 @@ func TestSkillInstallInvalid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	defer os.RemoveAll(tempDir)
 
 	sourceDir := filepath.Join(tempDir, "source", "invalid-skill")
 	if err := os.MkdirAll(sourceDir, 0755); err != nil {
@@ -263,8 +261,8 @@ func TestSkillInstallInvalid(t *testing.T) {
 	}
 
 	cwd, _ := os.Getwd()
-	if err := os.Chdir(projectDir); err != nil { t.Fatal(err) }
-	defer func() { _ = os.Chdir(cwd) }()
+	os.Chdir(projectDir)
+	defer os.Chdir(cwd)
 
 	c := &MainArgConfig{Args: []string{"g2"}}
 

--- a/cmd/g2/skill_update.go
+++ b/cmd/g2/skill_update.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func (c *MainArgConfig) cmdSkillUpdate(args []string) error {
+	fs := flag.NewFlagSet("skill update", flag.ExitOnError)
+	force := fs.Bool("force", false, "Force update even if local modifications exist")
+	all := fs.Bool("all", false, "Update all installed skills")
+	scope := fs.String("scope", "project", "Scope to update from (user, project)")
+	agent := fs.String("agent", "common", "Target agent (common, codex, claude, copilot, cursor)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if !*all && fs.NArg() < 1 {
+		return fmt.Errorf("usage: g2 skill update <skill-name> [--force] or g2 skill update --all")
+	}
+
+	basePath, err := getSkillBasePath(*scope, *agent)
+	if err != nil {
+		return err
+	}
+
+	skillsToUpdate := []string{}
+	if *all {
+		entries, err := os.ReadDir(basePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				fmt.Println("No skills installed.")
+				return nil
+			}
+			return err
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				skillsToUpdate = append(skillsToUpdate, e.Name())
+			}
+		}
+	} else {
+		skillsToUpdate = append(skillsToUpdate, fs.Arg(0))
+	}
+
+	for _, skillName := range skillsToUpdate {
+		destDir := filepath.Join(basePath, skillName)
+
+		meta, err := readSkillMetadata(destDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				fmt.Printf("no source metadata is available for %q, so this skill cannot be updated automatically\n", skillName)
+				continue
+			}
+			return fmt.Errorf("failed to read metadata for %s: %w", skillName, err)
+		}
+
+		// Check for local modifications
+		currentDigest, err := calculateDirDigest(destDir)
+		if err != nil {
+			return fmt.Errorf("failed to calculate digest for %s: %w", skillName, err)
+		}
+
+		if currentDigest != meta.Digest && !*force {
+			fmt.Printf("installed skill %q has local modifications; rerun with --force to replace\n", skillName)
+			continue
+		}
+
+		// For now we only support local path updates. Real remote updates would fetch here.
+		if meta.Revision == "local" {
+			srcPath := meta.Source
+			if meta.Subpath != "" {
+				srcPath = filepath.Join(srcPath, meta.Subpath)
+			}
+
+			// Validate source still exists
+			skillMdPath := filepath.Join(srcPath, "SKILL.md")
+			if _, err := os.Stat(skillMdPath); os.IsNotExist(err) {
+				fmt.Printf("skill %q source no longer exists at %s\n", skillName, srcPath)
+				continue
+			}
+
+			// Re-calculate source digest
+			newSrcDigest, err := calculateDirDigest(srcPath)
+			if err != nil {
+				return err
+			}
+
+			if newSrcDigest == meta.Digest && currentDigest == meta.Digest {
+				fmt.Printf("skill %q is up to date\n", skillName)
+				continue
+			}
+
+			// Perform update
+			if err := os.RemoveAll(destDir); err != nil {
+				return err
+			}
+
+			if err := copyDir(srcPath, destDir); err != nil {
+				return err
+			}
+
+			meta.Digest = newSrcDigest
+			if err := writeSkillMetadata(destDir, meta); err != nil {
+				return err
+			}
+
+			fmt.Printf("Successfully updated skill %q\n", skillName)
+		} else {
+			fmt.Printf("updating remote skills not yet supported for %q\n", skillName)
+		}
+	}
+
+	return nil
+}

--- a/cmd/g2/skill_update.go
+++ b/cmd/g2/skill_update.go
@@ -78,9 +78,12 @@ func (c *MainArgConfig) cmdSkillUpdate(args []string) error {
 
 			// Validate source still exists
 			skillMdPath := filepath.Join(srcPath, "SKILL.md")
-			if _, err := os.Stat(skillMdPath); os.IsNotExist(err) {
-				fmt.Printf("skill %q source no longer exists at %s\n", skillName, srcPath)
-				continue
+			if _, err := os.Stat(skillMdPath); err != nil {
+				if os.IsNotExist(err) {
+					fmt.Printf("skill %q source no longer exists at %s\n", skillName, srcPath)
+					continue
+				}
+				return fmt.Errorf("failed to check SKILL.md for %s: %w", skillName, err)
 			}
 
 			// Re-calculate source digest

--- a/readme.md
+++ b/readme.md
@@ -514,3 +514,50 @@ Lists all available lint rules.
 ```bash
 g2 lint list
 ```
+
+## Agent Skills
+
+`g2` supports an agent-skill subcommand system to let users install, inspect, update, remove, and manage AI agent skills that teach coding agents (like Claude, Cursor, Copilot) how to use this CLI correctly.
+
+### Installation Syntax
+
+Skills can be installed from a local path:
+```bash
+g2 skill install ./skills/g2
+```
+
+### Scopes and Agents
+By default, skills are installed into the `project` scope (the current working directory) under `.agents/skills`.
+
+You can modify the scope and agent target using flags:
+```bash
+# Install to the global user home directory (~/.agents/skills/g2)
+g2 skill install --scope user ./skills/g2
+
+# Install specifically for a given agent tool (e.g. ~/.cursor/skills/g2)
+g2 skill install --scope user ./skills/g2 --agent cursor
+```
+
+### Managing Skills
+List installed skills:
+```bash
+g2 skill list --scope all
+```
+
+Inspect an installed skill's metadata:
+```bash
+g2 skill inspect g2
+```
+
+Update an installed skill (uses source checksums to detect manual modifications):
+```bash
+g2 skill update g2
+
+# Overwrite local modifications
+g2 skill update --force g2
+```
+
+Remove a skill:
+```bash
+g2 skill remove g2
+```

--- a/skills/g2/SKILL.md
+++ b/skills/g2/SKILL.md
@@ -1,0 +1,29 @@
+# g2 Agent Skill
+
+This skill provides operational guidance for AI coding agents to use the `g2` CLI successfully.
+
+## Overview
+`g2` is a multi-faceted command-line toolkit for Gentoo Linux overlays.
+It generates static websites, checks repository lint rules, manages portage configuration, and manipulates packages and metadata.
+
+## Important CLI Context
+
+- **Main entrypoint:** Top-level commands are handled via a switch statement inside `cmd/g2/main.go`. When interacting with the tool, ensure you specify a valid subcommand.
+- **TUI and Interactivity:** Some commands (like `g2 world`) launch an interactive Terminal User Interface (TUI). When running within a non-interactive shell (such as an automated agent session), avoid invoking TUI commands to prevent hanging processes.
+- **Development environment:** To run the site server locally on standard environments, you will need to point to a valid overlay path, e.g., `go run ./cmd/g2 site serve .`
+- **Output formatting:** A GitHub Actions output formatter is available for linting commands using `--format=github-actions`.
+- **Parsing optimizations:** `g2` contains significant optimizations such as fast path resolution for Bash strings during variable resolution to speed up ebuild variable expansion.
+- **Security notes:** Fetching network resources should carefully check schemes to prevent SSRF, and local modifications use robust write-and-rename semantics. The `SHA1` algorithm is explicitly deprecated.
+
+## Common Subcommands
+- `g2 site serve`: Start a local HTTP server for testing site generation templates.
+- `g2 overlay site generate`: Render the repository pages to a static directory.
+- `g2 lint`: Run QA policy and structural checks against the overlay.
+- `g2 cache generate`: Create `md5-dict` (actually `sha256-dict`) cache files to speed up Portge syncs.
+- `g2 package search`: Rapid package queries against the metadata index.
+- `g2 skill`: Manage AI agent skills (install, update, list, remove).
+
+## Best Practices for Agents
+1. When debugging the `g2` internals, check the `MainArgConfig` struct to trace argument passing.
+2. If modifying static site templates, note that the local dev server (`site_serve.go`) uses a `GenericPageContext`, which must be kept in sync with the generator context fields.
+3. Be aware that the `repos.conf` parser differs from `make.conf` (which relies on `mvdan.cc/sh/v3/syntax`).

--- a/skills/g2/embed.go
+++ b/skills/g2/embed.go
@@ -1,0 +1,6 @@
+package g2skill
+
+import "embed"
+
+//go:embed SKILL.md metadata.json
+var SkillFS embed.FS

--- a/skills/g2/metadata.json
+++ b/skills/g2/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "g2-cli-assistant",
+  "description": "Agent skill for operating the g2 Gentoo overlay toolkit",
+  "target_agent": "common",
+  "scope": "project"
+}


### PR DESCRIPTION
Adds the `g2 skill` subcommand subsystem, fulfilling the request to natively manage agent skills in the CLI tool.

---
*PR created automatically by Jules for task [10252836821569087185](https://jules.google.com/task/10252836821569087185) started by @arran4*