### PR TITLE
Add RSS/Atom news feed generation and alternate-feed metadata

### DIFF
--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/xml"
 	"fmt"
 	"html/template"
@@ -117,14 +118,14 @@ func generateGlobalPages(outDir string, tmpl *template.Template, sites []*g2.Sit
 
 		// Global News Articles
 		for _, n := range data.GlobalNews {
-			newsDir := filepath.Join(outDir, "news", "archive", n.DirName)
+			newsDir := filepath.Join(outDir, "news", "archive", filepath.FromSlash(n.ArchivePath))
 			if err := os.MkdirAll(newsDir, 0755); err != nil {
 				return fmt.Errorf("creating directory %s: %w", newsDir, err)
 			}
 			if err := renderPage(filepath.Join(newsDir, "index.html"), tmpl, "news_article.html", GenericPageContext{
 				Title:          n.Title,
-				BaseURL:        "../../../",
-				Breadcrumbs:    []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: "News", URL: "../../"}, {Name: "Archive", URL: "../"}, {Name: n.Title}},
+				BaseURL:        "../../../../",
+				Breadcrumbs:    []g2.Breadcrumb{{Name: title, URL: "../../../../"}, {Name: "News", URL: "../../../"}, {Name: "Archive", URL: "../../"}, {Name: n.Title}},
 				GlobalNewsItem: &n,
 				Version:        version,
 				GenInfo:        genInfo,
@@ -1113,7 +1114,7 @@ func generateGlobalNewsFeeds(dir, siteTitle string, news []AggNewsItem) error {
 		if item.RepoName != "" {
 			description = fmt.Sprintf("Repository: %s\n\n%s", item.RepoName, description)
 		}
-		items = append(items, newsFeedItem(item.NewsItem, "archive/"+item.DirName+"/", description))
+		items = append(items, newsFeedItem(item.NewsItem, "archive/"+item.ArchivePath+"/", description, item.RepoName))
 	}
 	return renderNewsFeeds(dir, g2.Feed{
 		Title:       siteTitle + " News",
@@ -1126,7 +1127,7 @@ func generateGlobalNewsFeeds(dir, siteTitle string, news []AggNewsItem) error {
 func generateRepoNewsFeeds(dir string, site *g2.SiteData) error {
 	items := make([]g2.FeedItem, 0, len(site.News))
 	for _, item := range site.News {
-		items = append(items, newsFeedItem(item, "archive/"+item.DirName+"/", item.Body))
+		items = append(items, newsFeedItem(item, "archive/"+item.DirName+"/", item.Body, site.RepoName))
 	}
 	return renderNewsFeeds(dir, g2.Feed{
 		Title:       site.RepoName + " News",
@@ -1143,8 +1144,9 @@ func newsAlternates(siteTitle string) []AlternateFeed {
 	}
 }
 
-func newsFeedItem(item g2.NewsItem, link, description string) g2.FeedItem {
+func newsFeedItem(item g2.NewsItem, link, description, repoName string) g2.FeedItem {
 	return g2.FeedItem{
+		ID:          stableURN("news", repoName, item.DirName),
 		Title:       item.Title,
 		Link:        link,
 		Description: description,
@@ -1154,6 +1156,7 @@ func newsFeedItem(item g2.NewsItem, link, description string) g2.FeedItem {
 }
 
 func renderNewsFeeds(dir string, feed g2.Feed) error {
+	feed.ID = stableURN("feed", feed.Title)
 	if len(feed.Items) > 0 {
 		feed.LastBuildDate = feed.Items[0].PubDate
 		feed.Updated = feed.Items[0].Updated
@@ -1169,6 +1172,15 @@ func renderNewsFeeds(dir string, feed g2.Feed) error {
 		return fmt.Errorf("rendering Atom feed: %w", err)
 	}
 	return nil
+}
+
+func stableURN(namespace string, parts ...string) string {
+	digest := sha256.New()
+	for _, part := range parts {
+		_, _ = digest.Write([]byte(part))
+		_, _ = digest.Write([]byte{0})
+	}
+	return fmt.Sprintf("urn:g2:%s:%x", namespace, digest.Sum(nil))
 }
 
 func renderXMLFeed(path, templateName string, feed g2.Feed) error {

--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -1,15 +1,20 @@
 package main
 
 import (
+	"bytes"
+	"encoding/xml"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	texttemplate "text/template"
 	"time"
 
 	"github.com/arran4/g2"
+	sitetemplates "github.com/arran4/g2/templates"
 	"golang.org/x/sync/errgroup"
 	"sort"
 )
@@ -78,11 +83,15 @@ func generateGlobalPages(outDir string, tmpl *template.Template, sites []*g2.Sit
 			Title:            "News Dashboard",
 			BaseURL:          "../",
 			Breadcrumbs:      []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "News"}},
+			AlternateFeeds:   newsAlternates(title),
 			RecentGlobalNews: data.RecentNews,
 			Version:          version,
 			GenInfo:          genInfo,
 		}); err != nil {
 			return fmt.Errorf("rendering page: %w", err)
+		}
+		if err := generateGlobalNewsFeeds(filepath.Join(outDir, "news"), title, data.GlobalNews); err != nil {
+			return fmt.Errorf("generating global news feeds: %w", err)
 		}
 
 		// Global News Archive
@@ -1044,11 +1053,15 @@ func generateRepoNewsPages(repoDir string, tmpl *template.Template, site *g2.Sit
 			Title:          site.RepoName + " - News Dashboard",
 			BaseURL:        "../../../",
 			Breadcrumbs:    []g2.Breadcrumb{{Name: title, URL: "../../../"}, {Name: "Overlays", URL: "../../../overlays/"}, {Name: site.RepoName, URL: "../"}, {Name: "News"}},
+			AlternateFeeds: newsAlternates(site.RepoName),
 			RecentRepoNews: repoRecentNews,
 			Version:        version,
 			GenInfo:        genInfo,
 		}); err != nil {
 			return fmt.Errorf("rendering page: %w", err)
+		}
+		if err := generateRepoNewsFeeds(filepath.Join(repoDir, "news"), site); err != nil {
+			return fmt.Errorf("generating news feeds for repository %q: %w", site.RepoName, err)
 		}
 
 		// Repo News Archive
@@ -1085,6 +1098,101 @@ func generateRepoNewsPages(repoDir string, tmpl *template.Template, site *g2.Sit
 		}
 	}
 	return nil
+}
+
+func generateGlobalNewsFeeds(dir, siteTitle string, news []AggNewsItem) error {
+	items := make([]g2.FeedItem, 0, len(news))
+	for _, item := range news {
+		description := item.Body
+		if item.RepoName != "" {
+			description = fmt.Sprintf("Repository: %s\n\n%s", item.RepoName, description)
+		}
+		items = append(items, newsFeedItem(item.NewsItem, "archive/"+item.DirName+"/", description))
+	}
+	return renderNewsFeeds(dir, g2.Feed{
+		Title:       siteTitle + " News",
+		Link:        "./",
+		Description: "News from " + siteTitle,
+		Items:       items,
+	})
+}
+
+func generateRepoNewsFeeds(dir string, site *g2.SiteData) error {
+	items := make([]g2.FeedItem, 0, len(site.News))
+	for _, item := range site.News {
+		items = append(items, newsFeedItem(item, "archive/"+item.DirName+"/", item.Body))
+	}
+	return renderNewsFeeds(dir, g2.Feed{
+		Title:       site.RepoName + " News",
+		Link:        "./",
+		Description: "News from the " + site.RepoName + " repository",
+		Items:       items,
+	})
+}
+
+func newsAlternates(siteTitle string) []AlternateFeed {
+	return []AlternateFeed{
+		{Type: "application/rss+xml", Title: siteTitle + " News RSS Feed", Href: "index.rss"},
+		{Type: "application/atom+xml", Title: siteTitle + " News Atom Feed", Href: "index.atom"},
+	}
+}
+
+func newsFeedItem(item g2.NewsItem, link, description string) g2.FeedItem {
+	return g2.FeedItem{
+		Title:       item.Title,
+		Link:        link,
+		Description: description,
+		PubDate:     item.Posted.Format(time.RFC1123Z),
+		Updated:     item.Posted.Format(time.RFC3339),
+	}
+}
+
+func renderNewsFeeds(dir string, feed g2.Feed) error {
+	if len(feed.Items) > 0 {
+		feed.LastBuildDate = feed.Items[0].PubDate
+		feed.Updated = feed.Items[0].Updated
+	}
+	rssFeed := feed
+	rssFeed.Title += " RSS Feed"
+	if err := renderXMLFeed(filepath.Join(dir, "index.rss"), "rss.xml", rssFeed); err != nil {
+		return fmt.Errorf("rendering RSS feed: %w", err)
+	}
+	atomFeed := feed
+	atomFeed.Title += " Atom Feed"
+	if err := renderXMLFeed(filepath.Join(dir, "index.atom"), "atom.xml", atomFeed); err != nil {
+		return fmt.Errorf("rendering Atom feed: %w", err)
+	}
+	return nil
+}
+
+func renderXMLFeed(path, templateName string, feed g2.Feed) error {
+	b, err := fs.ReadFile(sitetemplates.SiteFS, "site/"+templateName)
+	if err != nil {
+		return fmt.Errorf("reading %s template: %w", templateName, err)
+	}
+	feedTemplate, err := texttemplate.New(templateName).Funcs(texttemplate.FuncMap{"xml": escapeXML}).Parse(string(b))
+	if err != nil {
+		return fmt.Errorf("parsing %s template: %w", templateName, err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating RSS feed %s: %w", path, err)
+	}
+	if err := feedTemplate.Execute(f, feed); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("executing RSS template for %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing RSS feed %s: %w", path, err)
+	}
+	log.Printf("Generated %s news feed with %d items at %s", templateName, len(feed.Items), path)
+	return nil
+}
+
+func escapeXML(value string) string {
+	var escaped bytes.Buffer
+	_ = xml.EscapeText(&escaped, []byte(value))
+	return escaped.String()
 }
 
 func generateRepoCategoriesPages(repoDir string, tmpl *template.Template, site *g2.SiteData, title, version string, genInfo GenerationInfo) error {

--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	texttemplate "text/template"
 	"time"
 
@@ -17,6 +18,11 @@ import (
 	sitetemplates "github.com/arran4/g2/templates"
 	"golang.org/x/sync/errgroup"
 	"sort"
+)
+
+var (
+	xmlTemplates   = make(map[string]*texttemplate.Template)
+	xmlTemplatesMu sync.RWMutex
 )
 
 func generateGlobalPages(outDir string, tmpl *template.Template, sites []*g2.SiteData, data *AggregatedData, title, version, recentDurationStr string, genInfo GenerationInfo) error {
@@ -1166,27 +1172,49 @@ func renderNewsFeeds(dir string, feed g2.Feed) error {
 }
 
 func renderXMLFeed(path, templateName string, feed g2.Feed) error {
-	b, err := fs.ReadFile(sitetemplates.SiteFS, "site/"+templateName)
+	feedTemplate, err := getXMLTemplate(templateName)
 	if err != nil {
-		return fmt.Errorf("reading %s template: %w", templateName, err)
-	}
-	feedTemplate, err := texttemplate.New(templateName).Funcs(texttemplate.FuncMap{"xml": escapeXML}).Parse(string(b))
-	if err != nil {
-		return fmt.Errorf("parsing %s template: %w", templateName, err)
+		return fmt.Errorf("loading feed template %s: %w", templateName, err)
 	}
 	f, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("creating RSS feed %s: %w", path, err)
+		return fmt.Errorf("creating feed %s: %w", path, err)
 	}
+	defer func() { _ = f.Close() }()
 	if err := feedTemplate.Execute(f, feed); err != nil {
-		_ = f.Close()
-		return fmt.Errorf("executing RSS template for %s: %w", path, err)
+		return fmt.Errorf("executing %s template for %s: %w", templateName, path, err)
 	}
 	if err := f.Close(); err != nil {
-		return fmt.Errorf("closing RSS feed %s: %w", path, err)
+		return fmt.Errorf("closing feed %s: %w", path, err)
 	}
 	log.Printf("Generated %s news feed with %d items at %s", templateName, len(feed.Items), path)
 	return nil
+}
+
+func getXMLTemplate(templateName string) (*texttemplate.Template, error) {
+	xmlTemplatesMu.RLock()
+	feedTemplate, ok := xmlTemplates[templateName]
+	xmlTemplatesMu.RUnlock()
+	if ok {
+		return feedTemplate, nil
+	}
+
+	xmlTemplatesMu.Lock()
+	defer xmlTemplatesMu.Unlock()
+	if feedTemplate, ok = xmlTemplates[templateName]; ok {
+		return feedTemplate, nil
+	}
+
+	b, err := fs.ReadFile(sitetemplates.SiteFS, "site/"+templateName)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s template: %w", templateName, err)
+	}
+	feedTemplate, err = texttemplate.New(templateName).Funcs(texttemplate.FuncMap{"xml": escapeXML}).Parse(string(b))
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s template: %w", templateName, err)
+	}
+	xmlTemplates[templateName] = feedTemplate
+	return feedTemplate, nil
 }
 
 func escapeXML(value string) string {

--- a/cmd/g2/models_page.go
+++ b/cmd/g2/models_page.go
@@ -7,12 +7,13 @@ import (
 )
 
 type GenericPageContext struct {
-	Title       string
-	BaseURL     string
-	Breadcrumbs []g2.Breadcrumb
-	Version     string
-	GenInfo     GenerationInfo
-	Content     template.HTML
+	Title          string
+	BaseURL        string
+	Breadcrumbs    []g2.Breadcrumb
+	Version        string
+	GenInfo        GenerationInfo
+	Content        template.HTML
+	AlternateFeeds []AlternateFeed
 
 	// Additional data fields used by various templates
 	Repos                 []*g2.SiteData
@@ -81,4 +82,13 @@ type GenericPageContext struct {
 
 	// Redirect
 	TargetURL string
+}
+
+// AlternateFeed describes a syndication feed advertised by a page. A slice is
+// used so a page can advertise separate news, package, or differently formatted
+// feeds without changing the shared layout.
+type AlternateFeed struct {
+	Type  string
+	Title string
+	Href  string
 }

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1361,7 +1361,8 @@ type AggPackageMove struct {
 
 type AggNewsItem struct {
 	g2.NewsItem
-	RepoName string
+	RepoName    string
+	ArchivePath string
 }
 
 type AggArch struct {
@@ -1505,8 +1506,9 @@ func aggregateGlobalNews(sites []*g2.SiteData) []AggNewsItem {
 	for _, site := range sites {
 		for _, news := range site.News {
 			globalNews = append(globalNews, AggNewsItem{
-				NewsItem: news,
-				RepoName: site.RepoName,
+				NewsItem:    news,
+				RepoName:    site.RepoName,
+				ArchivePath: path2.Join(site.RepoName, news.DirName),
 			})
 		}
 	}

--- a/cmd/g2/site_test.go
+++ b/cmd/g2/site_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/xml"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -108,6 +110,97 @@ func TestGenerateSite(t *testing.T) {
 	err = generateSite(outDir, []*g2.SiteData{siteData}, 90*24*time.Hour, "3 months", GenerationInfo{})
 	if err != nil {
 		t.Fatalf("generateSite failed: %v", err)
+	}
+
+	type rssDocument struct {
+		Channel struct {
+			Title         string `xml:"title"`
+			LastBuildDate string `xml:"lastBuildDate"`
+			Items         []struct {
+				Title       string `xml:"title"`
+				Link        string `xml:"link"`
+				Description string `xml:"description"`
+				PubDate     string `xml:"pubDate"`
+			} `xml:"item"`
+		} `xml:"channel"`
+	}
+	for _, feedPath := range []string{
+		filepath.Join(outDir, "news", "index.rss"),
+		filepath.Join(outDir, "repos", siteData.RepoName, "news", "index.rss"),
+	} {
+		t.Run(feedPath, func(t *testing.T) {
+			contents, err := os.ReadFile(feedPath)
+			if err != nil {
+				t.Fatalf("reading generated RSS feed: %v", err)
+			}
+			var feed rssDocument
+			if err := xml.Unmarshal(contents, &feed); err != nil {
+				t.Fatalf("parsing generated RSS feed: %v", err)
+			}
+			if len(feed.Channel.Items) != len(siteData.News) {
+				t.Fatalf("RSS item count = %d, want %d", len(feed.Channel.Items), len(siteData.News))
+			}
+			if !strings.Contains(feed.Channel.Title, "News RSS Feed") {
+				t.Errorf("RSS channel title %q does not identify the news RSS feed", feed.Channel.Title)
+			}
+			if feed.Channel.LastBuildDate == "" {
+				t.Error("RSS lastBuildDate is empty")
+			}
+			first := feed.Channel.Items[0]
+			if first.Title != siteData.News[0].Title {
+				t.Errorf("first RSS title = %q, want %q", first.Title, siteData.News[0].Title)
+			}
+			if first.Link != "archive/"+siteData.News[0].DirName+"/" {
+				t.Errorf("first RSS link = %q", first.Link)
+			}
+			if _, err := time.Parse(time.RFC1123Z, first.PubDate); err != nil {
+				t.Errorf("first RSS pubDate %q is invalid: %v", first.PubDate, err)
+			}
+		})
+	}
+
+	type atomDocument struct {
+		Title   string `xml:"title"`
+		Updated string `xml:"updated"`
+		Entries []struct {
+			Title   string `xml:"title"`
+			Updated string `xml:"updated"`
+		} `xml:"entry"`
+	}
+	for _, feedPath := range []string{
+		filepath.Join(outDir, "news", "index.atom"),
+		filepath.Join(outDir, "repos", siteData.RepoName, "news", "index.atom"),
+	} {
+		t.Run(feedPath, func(t *testing.T) {
+			contents, err := os.ReadFile(feedPath)
+			if err != nil {
+				t.Fatalf("reading generated Atom feed: %v", err)
+			}
+			var feed atomDocument
+			if err := xml.Unmarshal(contents, &feed); err != nil {
+				t.Fatalf("parsing generated Atom feed: %v", err)
+			}
+			if len(feed.Entries) != len(siteData.News) {
+				t.Fatalf("Atom entry count = %d, want %d", len(feed.Entries), len(siteData.News))
+			}
+			if !strings.Contains(feed.Title, "News Atom Feed") {
+				t.Errorf("Atom feed title %q does not identify the news Atom feed", feed.Title)
+			}
+			if _, err := time.Parse(time.RFC3339, feed.Updated); err != nil {
+				t.Errorf("Atom updated value %q is invalid: %v", feed.Updated, err)
+			}
+			if feed.Entries[0].Title != siteData.News[0].Title {
+				t.Errorf("first Atom title = %q, want %q", feed.Entries[0].Title, siteData.News[0].Title)
+			}
+		})
+	}
+}
+
+func TestEscapeXML(t *testing.T) {
+	const input = `News & updates <today> "quoted"`
+	const want = `News &amp; updates &lt;today&gt; &#34;quoted&#34;`
+	if got := escapeXML(input); got != want {
+		t.Errorf("escapeXML(%q) = %q, want %q", input, got, want)
 	}
 }
 

--- a/cmd/g2/site_test.go
+++ b/cmd/g2/site_test.go
@@ -162,6 +162,9 @@ func TestGenerateSite(t *testing.T) {
 	type atomDocument struct {
 		Title   string `xml:"title"`
 		Updated string `xml:"updated"`
+		Author  struct {
+			Name string `xml:"name"`
+		} `xml:"author"`
 		Entries []struct {
 			Title   string `xml:"title"`
 			Updated string `xml:"updated"`
@@ -186,6 +189,9 @@ func TestGenerateSite(t *testing.T) {
 			if !strings.Contains(feed.Title, "News Atom Feed") {
 				t.Errorf("Atom feed title %q does not identify the news Atom feed", feed.Title)
 			}
+			if feed.Author.Name == "" {
+				t.Error("Atom feed author name is empty")
+			}
 			if _, err := time.Parse(time.RFC3339, feed.Updated); err != nil {
 				t.Errorf("Atom updated value %q is invalid: %v", feed.Updated, err)
 			}
@@ -193,6 +199,20 @@ func TestGenerateSite(t *testing.T) {
 				t.Errorf("first Atom title = %q, want %q", feed.Entries[0].Title, siteData.News[0].Title)
 			}
 		})
+	}
+}
+
+func TestGetXMLTemplateCachesTemplates(t *testing.T) {
+	first, err := getXMLTemplate("atom.xml")
+	if err != nil {
+		t.Fatalf("getting Atom template: %v", err)
+	}
+	second, err := getXMLTemplate("atom.xml")
+	if err != nil {
+		t.Fatalf("getting cached Atom template: %v", err)
+	}
+	if first != second {
+		t.Error("getXMLTemplate did not return the cached template")
 	}
 }
 

--- a/cmd/g2/site_test.go
+++ b/cmd/g2/site_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/xml"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -117,19 +118,26 @@ func TestGenerateSite(t *testing.T) {
 			Title         string `xml:"title"`
 			LastBuildDate string `xml:"lastBuildDate"`
 			Items         []struct {
-				Title       string `xml:"title"`
-				Link        string `xml:"link"`
+				Title string `xml:"title"`
+				Link  string `xml:"link"`
+				GUID  struct {
+					Value       string `xml:",chardata"`
+					IsPermaLink string `xml:"isPermaLink,attr"`
+				} `xml:"guid"`
 				Description string `xml:"description"`
 				PubDate     string `xml:"pubDate"`
 			} `xml:"item"`
 		} `xml:"channel"`
 	}
-	for _, feedPath := range []string{
-		filepath.Join(outDir, "news", "index.rss"),
-		filepath.Join(outDir, "repos", siteData.RepoName, "news", "index.rss"),
+	for _, test := range []struct {
+		path     string
+		itemLink string
+	}{
+		{filepath.Join(outDir, "news", "index.rss"), "archive/" + siteData.RepoName + "/" + siteData.News[0].DirName + "/"},
+		{filepath.Join(outDir, "repos", siteData.RepoName, "news", "index.rss"), "archive/" + siteData.News[0].DirName + "/"},
 	} {
-		t.Run(feedPath, func(t *testing.T) {
-			contents, err := os.ReadFile(feedPath)
+		t.Run(test.path, func(t *testing.T) {
+			contents, err := os.ReadFile(test.path)
 			if err != nil {
 				t.Fatalf("reading generated RSS feed: %v", err)
 			}
@@ -150,8 +158,14 @@ func TestGenerateSite(t *testing.T) {
 			if first.Title != siteData.News[0].Title {
 				t.Errorf("first RSS title = %q, want %q", first.Title, siteData.News[0].Title)
 			}
-			if first.Link != "archive/"+siteData.News[0].DirName+"/" {
+			if first.Link != test.itemLink {
 				t.Errorf("first RSS link = %q", first.Link)
+			}
+			if first.GUID.Value == "" {
+				t.Error("first RSS guid is empty")
+			}
+			if first.GUID.IsPermaLink != "false" {
+				t.Errorf("first RSS guid isPermaLink = %q, want false", first.GUID.IsPermaLink)
 			}
 			if _, err := time.Parse(time.RFC1123Z, first.PubDate); err != nil {
 				t.Errorf("first RSS pubDate %q is invalid: %v", first.PubDate, err)
@@ -160,12 +174,14 @@ func TestGenerateSite(t *testing.T) {
 	}
 
 	type atomDocument struct {
+		ID      string `xml:"id"`
 		Title   string `xml:"title"`
 		Updated string `xml:"updated"`
 		Author  struct {
 			Name string `xml:"name"`
 		} `xml:"author"`
 		Entries []struct {
+			ID      string `xml:"id"`
 			Title   string `xml:"title"`
 			Updated string `xml:"updated"`
 		} `xml:"entry"`
@@ -192,6 +208,12 @@ func TestGenerateSite(t *testing.T) {
 			if feed.Author.Name == "" {
 				t.Error("Atom feed author name is empty")
 			}
+			if parsed, err := url.Parse(feed.ID); err != nil || parsed.Scheme == "" {
+				t.Errorf("Atom feed id %q is not an absolute IRI: %v", feed.ID, err)
+			}
+			if parsed, err := url.Parse(feed.Entries[0].ID); err != nil || parsed.Scheme == "" {
+				t.Errorf("first Atom entry id %q is not an absolute IRI: %v", feed.Entries[0].ID, err)
+			}
 			if _, err := time.Parse(time.RFC3339, feed.Updated); err != nil {
 				t.Errorf("Atom updated value %q is invalid: %v", feed.Updated, err)
 			}
@@ -199,6 +221,43 @@ func TestGenerateSite(t *testing.T) {
 				t.Errorf("first Atom title = %q, want %q", feed.Entries[0].Title, siteData.News[0].Title)
 			}
 		})
+	}
+}
+
+func TestAggregateGlobalNewsUsesRepositoryPaths(t *testing.T) {
+	news := g2.NewsItem{DirName: "2026-01-01-shared-notice", Title: "Shared notice", Posted: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	sites := []*g2.SiteData{
+		{RepoName: "repo-one", News: []g2.NewsItem{news}},
+		{RepoName: "repo-two", News: []g2.NewsItem{news}},
+	}
+	got := aggregateGlobalNews(sites)
+	if len(got) != 2 {
+		t.Fatalf("aggregateGlobalNews returned %d items, want 2", len(got))
+	}
+	if got[0].ArchivePath == got[1].ArchivePath {
+		t.Fatalf("colliding global archive paths: %q", got[0].ArchivePath)
+	}
+	if got[0].ArchivePath != "repo-one/2026-01-01-shared-notice" {
+		t.Errorf("first archive path = %q", got[0].ArchivePath)
+	}
+	if got[1].ArchivePath != "repo-two/2026-01-01-shared-notice" {
+		t.Errorf("second archive path = %q", got[1].ArchivePath)
+	}
+	firstID := newsFeedItem(got[0].NewsItem, got[0].ArchivePath, got[0].Body, got[0].RepoName).ID
+	secondID := newsFeedItem(got[1].NewsItem, got[1].ArchivePath, got[1].Body, got[1].RepoName).ID
+	if firstID == secondID {
+		t.Fatalf("colliding feed item IDs: %q", firstID)
+	}
+
+	outDir := t.TempDir()
+	if err := generateSite(outDir, sites, 90*24*time.Hour, "3 months", GenerationInfo{}); err != nil {
+		t.Fatalf("generating site with colliding news directory names: %v", err)
+	}
+	for _, item := range got {
+		articlePath := filepath.Join(outDir, "news", "archive", filepath.FromSlash(item.ArchivePath), "index.html")
+		if _, err := os.Stat(articlePath); err != nil {
+			t.Errorf("global news article %s was not generated: %v", item.ArchivePath, err)
+		}
 	}
 }
 

--- a/cmd/g2/template_render_test.go
+++ b/cmd/g2/template_render_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
-	"github.com/arran4/g2"
+	"html"
+	"strings"
 	"testing"
+
+	"github.com/arran4/g2"
 )
 
 type GenericPageContextOption func(*GenericPageContext)
@@ -235,6 +238,33 @@ func TestAllTemplatesRender(t *testing.T) {
 					t.Errorf("template %s failed to render with %s: %v", name, tc.name, err)
 				}
 			})
+		}
+	}
+}
+
+func TestLayoutAdvertisesMultipleAlternateFeeds(t *testing.T) {
+	tmpl, err := GetSiteTemplates()
+	if err != nil {
+		t.Fatalf("getting site templates: %v", err)
+	}
+	var output bytes.Buffer
+	context := GenericPageContext{
+		Title: "News",
+		AlternateFeeds: []AlternateFeed{
+			{Type: "application/rss+xml", Title: "News RSS Feed", Href: "news.rss"},
+			{Type: "application/atom+xml", Title: "News Atom Feed", Href: "news.atom"},
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&output, "layout_header.html", context); err != nil {
+		t.Fatalf("rendering layout header: %v", err)
+	}
+	rendered := html.UnescapeString(output.String())
+	for _, metadata := range []string{
+		`<link rel="alternate" type="application/rss+xml" title="News RSS Feed" href="news.rss" />`,
+		`<link rel="alternate" type="application/atom+xml" title="News Atom Feed" href="news.atom" />`,
+	} {
+		if !strings.Contains(rendered, metadata) {
+			t.Errorf("layout header does not contain %q; output:\n%s", metadata, rendered)
 		}
 	}
 }

--- a/doc/g2.1.md
+++ b/doc/g2.1.md
@@ -80,6 +80,7 @@ Commands for managing a single overlay.
 - **site generate** [*--out <dir>*] [*--clear*] [*location*]
   Generates a static HTML site for the overlay.
   Flags: `-out` (default: `site_out`), `-clear`, `-fast-git-modtime`, `-recent-duration`.
+  Writes RSS 2.0 and Atom feeds for available news to `news/index.rss` and `news/index.atom`.
 - **license list**
   Lists all configured licenses.
 - **license show** *<name>*
@@ -100,6 +101,7 @@ Commands for working across multiple overlays.
 
 - **site generate** [*--out <dir>*] [*--clear*] *<repositoriesFile>*
   Generates an aggregated static HTML site for multiple remote repositories described in a `repositories.xml` file.
+  Writes combined RSS 2.0 and Atom news feeds below `news/` and repository news feeds below `repos/<repository>/news/`.
 
 ## `site`
 Commands relating to generated static sites.

--- a/feeds.go
+++ b/feeds.go
@@ -1,6 +1,7 @@
 package g2
 
 type FeedItem struct {
+	ID          string
 	Title       string
 	Link        string
 	Description string
@@ -9,6 +10,7 @@ type FeedItem struct {
 }
 
 type Feed struct {
+	ID            string
 	Title         string
 	Link          string
 	Description   string

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,8 @@ g2 overlay site generate [-out <dir>] [-clear] [<location>]
 * `-fast-git-modtime`: Use fast (O(1)) but potentially less reliable go-git file log lookup.
 * `-recent-duration`: Duration to consider an update 'recent' (e.g., 3mo, 14d, 72h) (default "3mo").
 
+When the overlay contains news items, the generated news dashboard includes RSS 2.0 and Atom feeds at `news/index.rss` and `news/index.atom`. Aggregated sites also provide combined feeds there, while each repository has its own feeds under `repos/<repository>/news/`.
+
 **Example:**
 
 ```bash

--- a/templates/app/layout_header.html
+++ b/templates/app/layout_header.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{$pageTitle := .Title}}{{if .Breadcrumbs}}{{$pageTitle = ""}}{{range $i, $bc := .Breadcrumbs}}{{if $i}}{{$pageTitle = printf "%s | %s" $pageTitle $bc.Name}}{{else}}{{$pageTitle = $bc.Name}}{{end}}{{end}}{{end}}{{$pageTitle}}</title>
-    <link rel="alternate" type="application/rss+xml" title="RSS" href="index.rss" />
-    <link rel="alternate" type="application/atom+xml" title="Atom" href="index.atom" />
+    {{range .AlternateFeeds}}<link rel="alternate" type="{{.Type}}" title="{{.Title}}" href="{{.Href}}" />
+    {{end}}
     <style>
         body { font-family: sans-serif; margin: 2em; line-height: 1.6; color: #333; }
         h1, h2, h3 { color: #5c4f85; } /* Tyrian purple-ish */

--- a/templates/site/atom.xml
+++ b/templates/site/atom.xml
@@ -4,6 +4,9 @@
   <link href="{{.Link | xml}}"/>
   <updated>{{.Updated | xml}}</updated>
   <id>{{.Link | xml}}</id>
+  <author>
+    <name>{{.Title | xml}}</name>
+  </author>
   {{range .Items}}
   <entry>
     <title>{{.Title | xml}}</title>

--- a/templates/site/atom.xml
+++ b/templates/site/atom.xml
@@ -3,7 +3,7 @@
   <title>{{.Title | xml}}</title>
   <link href="{{.Link | xml}}"/>
   <updated>{{.Updated | xml}}</updated>
-  <id>{{.Link | xml}}</id>
+  <id>{{.ID | xml}}</id>
   <author>
     <name>{{.Title | xml}}</name>
   </author>
@@ -11,7 +11,7 @@
   <entry>
     <title>{{.Title | xml}}</title>
     <link href="{{.Link | xml}}"/>
-    <id>{{.Link | xml}}</id>
+    <id>{{.ID | xml}}</id>
     <updated>{{.Updated | xml}}</updated>
     <summary>{{.Description | xml}}</summary>
   </entry>

--- a/templates/site/atom.xml
+++ b/templates/site/atom.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title>{{.Title}}</title>
-  <link href="{{.Link}}"/>
-  <updated>{{.Updated}}</updated>
-  <id>{{.Link}}</id>
+  <title>{{.Title | xml}}</title>
+  <link href="{{.Link | xml}}"/>
+  <updated>{{.Updated | xml}}</updated>
+  <id>{{.Link | xml}}</id>
   {{range .Items}}
   <entry>
-    <title>{{.Title}}</title>
-    <link href="{{.Link}}"/>
-    <id>{{.Link}}</id>
-    <updated>{{.Updated}}</updated>
-    <summary>{{.Description}}</summary>
+    <title>{{.Title | xml}}</title>
+    <link href="{{.Link | xml}}"/>
+    <id>{{.Link | xml}}</id>
+    <updated>{{.Updated | xml}}</updated>
+    <summary>{{.Description | xml}}</summary>
   </entry>
   {{end}}
 </feed>

--- a/templates/site/rss.xml
+++ b/templates/site/rss.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
 <channel>
-  <title>{{.Title}}</title>
-  <link>{{.Link}}</link>
-  <description>{{.Description}}</description>
-  <lastBuildDate>{{.LastBuildDate}}</lastBuildDate>
+  <title>{{.Title | xml}}</title>
+  <link>{{.Link | xml}}</link>
+  <description>{{.Description | xml}}</description>
+  <lastBuildDate>{{.LastBuildDate | xml}}</lastBuildDate>
   {{range .Items}}
   <item>
-    <title>{{.Title}}</title>
-    <link>{{.Link}}</link>
-    <description>{{.Description}}</description>
-    <pubDate>{{.PubDate}}</pubDate>
+    <title>{{.Title | xml}}</title>
+    <link>{{.Link | xml}}</link>
+    <description>{{.Description | xml}}</description>
+    <pubDate>{{.PubDate | xml}}</pubDate>
   </item>
   {{end}}
 </channel>

--- a/templates/site/rss.xml
+++ b/templates/site/rss.xml
@@ -9,6 +9,7 @@
   <item>
     <title>{{.Title | xml}}</title>
     <link>{{.Link | xml}}</link>
+    <guid isPermaLink="false">{{.ID | xml}}</guid>
     <description>{{.Description | xml}}</description>
     <pubDate>{{.PubDate | xml}}</pubDate>
   </item>

--- a/templates/views/news_archive.html
+++ b/templates/views/news_archive.html
@@ -2,6 +2,11 @@
 
 <div class="news-archive">
     <ul>
+        {{range .GlobalNews}}
+        <li>
+            <a href="{{.ArchivePath}}/">{{.Title}}</a> - {{.Posted.Format "2006-01-02"}}{{if .RepoName}} ({{.RepoName}}){{end}}
+        </li>
+        {{end}}
         {{range .News}}
         <li>
             <a href="{{.DirName}}/">{{.Title}}</a> - {{.Posted.Format "2006-01-02"}}

--- a/templates/views/news_dashboard.html
+++ b/templates/views/news_dashboard.html
@@ -1,6 +1,18 @@
 <h2>{{.Title}}</h2>
 <div class="news-dashboard">
     <p>Subscribe to the News feed: <a href="index.rss">RSS</a> | <a href="index.atom">Atom</a></p>
+    {{range .RecentGlobalNews}}
+    <article class="news-item">
+        <h3><a href="archive/{{.ArchivePath}}/">{{.Title}}</a></h3>
+        <div class="news-meta">
+            <span class="news-date">Posted: {{.Posted.Format "2006-01-02"}}</span>
+            {{if .RepoName}}<span class="news-repo"> in {{.RepoName}}</span>{{end}}
+            {{if .Author}}<span class="news-author"> by {{.Author}}</span>{{end}}
+        </div>
+        <div class="news-body">{{.ToHTMLTemplate}}</div>
+    </article>
+    <hr/>
+    {{end}}
     {{range .RecentRepoNews}}
     <article class="news-item">
         <h3><a href="archive/{{.DirName}}/">{{.Title}}</a></h3>

--- a/templates/views/news_dashboard.html
+++ b/templates/views/news_dashboard.html
@@ -1,5 +1,6 @@
 <h2>{{.Title}}</h2>
 <div class="news-dashboard">
+    <p>Subscribe to the News feed: <a href="index.rss">RSS</a> | <a href="index.atom">Atom</a></p>
     {{range .RecentRepoNews}}
     <article class="news-item">
         <h3><a href="archive/{{.DirName}}/">{{.Title}}</a></h3>


### PR DESCRIPTION
### Motivation

- Provide machine-readable syndicated outputs for site news so users and aggregators can subscribe to overlay and repository news. 
- Advertise available feeds from page headers so browsers and feed readers can discover the feeds automatically.

### Description

- Add feed generation: implement `generateGlobalNewsFeeds`, `generateRepoNewsFeeds`, `newsFeedItem`, `renderNewsFeeds`, and `renderXMLFeed`, and wire them into `generateGlobalPages` and `generateRepoNewsPages` so `news/index.rss` and `news/index.atom` are produced for aggregated and per-repo news. 
- Add XML-escaping support with `escapeXML` and use it in feed templates by parsing `site/rss.xml` and `site/atom.xml` via a `text/template` with an `xml` function. 
- Make page-level feed advertising pluggable by adding `AlternateFeed` and `GenericPageContext.AlternateFeeds`, and update `templates/app/layout_header.html` to render `<link rel="alternate">` elements from that slice. 
- Update news view `templates/views/news_dashboard.html` to include subscribe links, and update docs (`doc/g2.1.md`, `readme.md`) to mention feed outputs. 

### Testing

- Added unit tests `TestGenerateSite` (verifies generated RSS/Atom files parse and contain expected items), `TestEscapeXML` (verifies `escapeXML` output), and `TestLayoutAdvertisesMultipleAlternateFeeds` (verifies header renders alternate links), and updated template tests to still render; these tests were run and passed. 
- Ran package tests for the site generator (unit tests under `cmd/g2`) and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d9f56bcfc832f96fa6269d6e6f8eb)