### PR TITLE
Filter full text licenses and separate unsupported licenses

### DIFF
--- a/cmd/g2/generate_site.go
+++ b/cmd/g2/generate_site.go
@@ -539,6 +539,42 @@ func generateOtherGlobalPages(outDir string, tmpl *template.Template, data *Aggr
 		}
 	}
 
+	if err := os.MkdirAll(filepath.Join(outDir, "unsupported-licenses"), 0755); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+	if err := renderPage(filepath.Join(outDir, "unsupported-licenses", "index.html"), tmpl, "licenses.html", GenericPageContext{
+		Title:       "Unsupported Licenses",
+		BaseURL:     "../",
+		Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../"}, {Name: "Unsupported Licenses"}},
+		Licenses:    data.UnsupportedLicenses,
+		Version:     version,
+		GenInfo:     genInfo,
+	}); err != nil {
+		return fmt.Errorf("rendering page: %w", err)
+	}
+
+	for _, lic := range data.UnsupportedLicenses {
+		licDirName := sanitizeFilename(lic.Name)
+		if licDirName == "" {
+			continue // Skip licenses that sanitize down to nothing
+		}
+		licDir := filepath.Join(outDir, "unsupported-licenses", licDirName)
+		if err := os.MkdirAll(licDir, 0755); err != nil {
+			return fmt.Errorf("creating directory %s: %w", licDir, err)
+		}
+
+		if err := renderPage(filepath.Join(licDir, "index.html"), tmpl, "license.html", GenericPageContext{
+			Title:       "Unsupported License: " + lic.Name,
+			BaseURL:     "../../",
+			Breadcrumbs: []g2.Breadcrumb{{Name: title, URL: "../../"}, {Name: "Unsupported Licenses", URL: "../"}, {Name: lic.Name}},
+			License:     lic,
+			Version:     version,
+			GenInfo:     genInfo,
+		}); err != nil {
+			return fmt.Errorf("rendering page: %w", err)
+		}
+	}
+
 	// 5b. Global Projects
 	if len(data.Projects) > 0 {
 		if err := os.MkdirAll(filepath.Join(outDir, "projects"), 0755); err != nil {

--- a/cmd/g2/models_page.go
+++ b/cmd/g2/models_page.go
@@ -23,6 +23,7 @@ type GenericPageContext struct {
 	GlobalPackages        []*AggPackage
 	RepoPackages          []g2.PackageData
 	Licenses              []*AggLicense
+	UnsupportedLicenses   []*AggLicense
 	RepoLicenses          []*AggLicense
 	UseFlags              []*AggUseFlag
 	UseExpandDescs        map[string]*g2.UseExpandDesc

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -509,8 +509,16 @@ func resolveDependencies(node g2.DepNode, pkgMap map[string]bool) ResolvedDepNod
 	return ResolvedDepNode{}
 }
 
-// isValidLicense checks if a license string contains at least one alphanumeric character
+// isValidLicense checks if a license string is a valid identifier
 func isValidLicense(s string) bool {
+	if strings.Contains(s, "/") {
+		return false
+	}
+	sLower := strings.ToLower(s)
+	if strings.Contains(sLower, "copyright (c)") || strings.Contains(sLower, "all rights reserved") || len(strings.Fields(s)) > 20 {
+		return false
+	}
+
 	for _, r := range s {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
 			return true
@@ -1378,10 +1386,11 @@ type RepoGroup struct {
 }
 
 type AggregatedData struct {
-	Categories      []*AggCategory
-	Packages        []*AggPackage
-	Licenses        []*AggLicense
-	Projects        []*AggProject
+	Categories          []*AggCategory
+	Packages            []*AggPackage
+	Licenses            []*AggLicense
+	UnsupportedLicenses []*AggLicense
+	Projects            []*AggProject
 	Profiles        []*g2.AggProfile
 	Arches          []*AggArch
 	Moves           map[string]*AggPackageMove
@@ -1797,16 +1806,22 @@ func aggregateValidUseExpands(sites []*g2.SiteData) map[string]bool {
 	return validUseExpands
 }
 
-func sortLicenses(aggLicenses map[string]*AggLicense) ([]*AggLicense, map[string]bool) {
+func sortLicenses(aggLicenses map[string]*AggLicense) ([]*AggLicense, []*AggLicense, map[string]bool) {
 	validLicenses := make(map[string]bool)
-	var sortedLicenses []*AggLicense
+	var supportedLicenses []*AggLicense
+	var unsupportedLicenses []*AggLicense
 	for _, l := range aggLicenses {
 		sort.Strings(l.Aliases)
-		sortedLicenses = append(sortedLicenses, l)
+		if len(l.ProvidedByRepos) > 0 {
+			supportedLicenses = append(supportedLicenses, l)
+		} else {
+			unsupportedLicenses = append(unsupportedLicenses, l)
+		}
 		validLicenses[l.Name] = true
 	}
-	sort.Slice(sortedLicenses, func(i, j int) bool { return sortedLicenses[i].Name < sortedLicenses[j].Name })
-	return sortedLicenses, validLicenses
+	sort.Slice(supportedLicenses, func(i, j int) bool { return supportedLicenses[i].Name < supportedLicenses[j].Name })
+	sort.Slice(unsupportedLicenses, func(i, j int) bool { return unsupportedLicenses[i].Name < unsupportedLicenses[j].Name })
+	return supportedLicenses, unsupportedLicenses, validLicenses
 }
 
 func sortProjects(aggProjects map[string]*AggProject) []*AggProject {
@@ -1902,7 +1917,7 @@ func prepareAggregatedData(sites []*g2.SiteData) *AggregatedData {
 	sortedCategories := sortCategories(aggCategories)
 	sortedPackages := sortPackages(aggPackages)
 	validUseExpands := aggregateValidUseExpands(sites)
-	sortedLicenses, validLicenses := sortLicenses(aggLicenses)
+	sortedLicenses, unsupportedLicenses, validLicenses := sortLicenses(aggLicenses)
 	sortedProjects := sortProjects(aggProjects)
 	sortedProfiles := sortProfiles(aggProfiles)
 	sortedArches := sortArches(aggArches)
@@ -1913,10 +1928,11 @@ func prepareAggregatedData(sites []*g2.SiteData) *AggregatedData {
 	sortedUseFlags, _ := AggregateUseFlags(sites, aggPackages)
 
 	return &AggregatedData{
-		Categories:      sortedCategories,
-		Packages:        sortedPackages,
-		Licenses:        sortedLicenses,
-		Projects:        sortedProjects,
+		Categories:          sortedCategories,
+		Packages:            sortedPackages,
+		Licenses:            sortedLicenses,
+		UnsupportedLicenses: unsupportedLicenses,
+		Projects:            sortedProjects,
 		Profiles:        sortedProfiles,
 		Arches:          sortedArches,
 		Moves:           aggMoves,

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -256,7 +256,6 @@ type SiteServer struct {
 	AggCategories          []*AggCategory
 	AggPackages            []*AggPackage
 	AggLicenses            []*AggLicense
-	AggSupportedLicenses   []*AggLicense
 	AggUnsupportedLicenses []*AggLicense
 	AggProjects            []*AggProject
 
@@ -461,9 +460,14 @@ func newSiteServer(sites []*g2.SiteData, genInfo GenerationInfo) (*SiteServer, e
 
 	for _, l := range aggLicenses {
 		sort.Strings(l.Aliases)
-		server.AggLicenses = append(server.AggLicenses, l)
+		if len(l.ProvidedByRepos) > 0 {
+			server.AggLicenses = append(server.AggLicenses, l)
+		} else {
+			server.AggUnsupportedLicenses = append(server.AggUnsupportedLicenses, l)
+		}
 	}
 	sort.Slice(server.AggLicenses, func(i, j int) bool { return server.AggLicenses[i].Name < server.AggLicenses[j].Name })
+	sort.Slice(server.AggUnsupportedLicenses, func(i, j int) bool { return server.AggUnsupportedLicenses[i].Name < server.AggUnsupportedLicenses[j].Name })
 
 	for _, p := range aggProjects {
 		server.AggProjects = append(server.AggProjects, p)
@@ -529,7 +533,7 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"Repos":                  s.Sites,
 			"GlobalCategories":       s.AggCategories,
 			"GlobalPackages":         s.AggPackages,
-			"SupportedLicenses":      s.AggSupportedLicenses,
+			"Licenses":               s.AggLicenses,
 			"UnsupportedLicenses":    s.AggUnsupportedLicenses,
 			"UseFlags":               s.AggUseFlags,
 			"Projects":               s.AggProjects,
@@ -718,6 +722,42 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				"Title":       "License: " + lic.Name,
 				"BaseURL":     baseURL,
 				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Licenses", URL: "../"}, {Name: lic.Name}},
+				"License":     lic,
+				"Version":     version,
+				"GenInfo":     s.GenInfo,
+			})
+			return
+		}
+
+	case "unsupported-licenses":
+		if len(parts) == 1 {
+			s.renderPageHTTP(w, "licenses.html", map[string]interface{}{
+				"Title":       "Unsupported Licenses",
+				"BaseURL":     baseURL,
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Unsupported Licenses"}},
+				"Licenses":    s.AggUnsupportedLicenses,
+				"Version":     version,
+				"GenInfo":     s.GenInfo,
+			})
+			return
+		} else if len(parts) == 2 {
+			licNameSlug := parts[1]
+			var lic *AggLicense
+			for _, l := range s.AggUnsupportedLicenses {
+				if sanitizeFilename(l.Name) == licNameSlug {
+					lic = l
+					break
+				}
+			}
+			if lic == nil {
+				http.NotFound(w, r)
+				return
+			}
+
+			s.renderPageHTTP(w, "license.html", map[string]interface{}{
+				"Title":       "Unsupported License: " + lic.Name,
+				"BaseURL":     baseURL,
+				"Breadcrumbs": []g2.Breadcrumb{{Name: s.Title, URL: baseURL}, {Name: "Unsupported Licenses", URL: "../"}, {Name: lic.Name}},
 				"License":     lic,
 				"Version":     version,
 				"GenInfo":     s.GenInfo,

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -249,14 +249,16 @@ func isOverlayDir(dir string) bool {
 }
 
 type SiteServer struct {
-	GenInfo       GenerationInfo
-	tmpl          *template.Template
-	Title         string
-	Sites         []*g2.SiteData
-	AggCategories []*AggCategory
-	AggPackages   []*AggPackage
-	AggLicenses   []*AggLicense
-	AggProjects   []*AggProject
+	GenInfo                GenerationInfo
+	tmpl                   *template.Template
+	Title                  string
+	Sites                  []*g2.SiteData
+	AggCategories          []*AggCategory
+	AggPackages            []*AggPackage
+	AggLicenses            []*AggLicense
+	AggSupportedLicenses   []*AggLicense
+	AggUnsupportedLicenses []*AggLicense
+	AggProjects            []*AggProject
 
 	// Mappings for faster lookup
 	CatMap      map[string]*AggCategory
@@ -522,17 +524,20 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// 1. Root Dashboard
 	if len(parts) == 0 {
 		s.renderPageHTTP(w, "dashboard.html", map[string]interface{}{
-			"Title":            s.Title,
-			"BaseURL":          "",
-			"Repos":            s.Sites,
-			"GlobalCategories": s.AggCategories,
-			"GlobalPackages":   s.AggPackages,
-			"Licenses":         s.AggLicenses,
-			"UseFlags":         s.AggUseFlags,
-			"Projects":         s.AggProjects,
-			"Profiles":         []interface{}{},
-			"Version":          version,
-			"GenInfo":          s.GenInfo,
+			"Title":                  s.Title,
+			"BaseURL":                "",
+			"Repos":                  s.Sites,
+			"GlobalCategories":       s.AggCategories,
+			"GlobalPackages":         s.AggPackages,
+			"Licenses":               s.AggLicenses,
+			"SupportedLicenses":      s.AggSupportedLicenses,
+			"UnsupportedLicenses":    s.AggUnsupportedLicenses,
+			"UseFlags":               s.AggUseFlags,
+			"Projects":               s.AggProjects,
+			"Eclasses":               []*AggEclass{},
+			"Profiles":               []interface{}{},
+			"Version":                version,
+			"GenInfo":                s.GenInfo,
 		})
 		return
 	}

--- a/cmd/g2/site_serve.go
+++ b/cmd/g2/site_serve.go
@@ -529,7 +529,6 @@ func (s *SiteServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"Repos":                  s.Sites,
 			"GlobalCategories":       s.AggCategories,
 			"GlobalPackages":         s.AggPackages,
-			"Licenses":               s.AggLicenses,
 			"SupportedLicenses":      s.AggSupportedLicenses,
 			"UnsupportedLicenses":    s.AggUnsupportedLicenses,
 			"UseFlags":               s.AggUseFlags,

--- a/templates/views/dashboard.html
+++ b/templates/views/dashboard.html
@@ -23,6 +23,9 @@
         {{if and .Licenses (gt (len .Licenses) 0)}}
         <li><a href="licenses/">Licenses ({{len .Licenses}})</a></li>
         {{end}}
+        {{if and .UnsupportedLicenses (gt (len .UnsupportedLicenses) 0)}}
+        <li><a href="unsupported-licenses/">Unsupported Licenses ({{len .UnsupportedLicenses}})</a></li>
+        {{end}}
         {{if and .UseFlags (gt (len .UseFlags) 0)}}
         <li><a href="uses/">USE Flags ({{len .UseFlags}})</a></li>
         {{end}}

--- a/templates/views/index.html
+++ b/templates/views/index.html
@@ -31,3 +31,10 @@
     <li><a href="licenses/{{slugify .Name}}/packages/">{{.Name}} ({{.Count}})</a></li>
     {{end}}
 </ul>
+
+<h2>Unsupported Licenses</h2>
+<ul>
+    {{range .UnsupportedLicenses}}
+    <li><a href="unsupported-licenses/{{slugify .Name}}/packages/">{{.Name}} ({{.Count}})</a></li>
+    {{end}}
+</ul>


### PR DESCRIPTION
This PR filters out full-text licenses from the license database and separates licenses into supported (having a file in an overlay) and unsupported (not having a file in any overlay), generating a new `/unsupported-licenses/` page for the latter.

---
*PR created automatically by Jules for task [12987271553151114316](https://jules.google.com/task/12987271553151114316) started by @arran4*