### PR TITLE
Group USE flags into Global, Category, and Local tiers

### DIFF
--- a/cmd/g2/template_funcs.go
+++ b/cmd/g2/template_funcs.go
@@ -48,6 +48,8 @@ func getTemplateFuncMap() template.FuncMap {
 		"formatPkgLinkBody":      formatPkgLinkBodyFunc,
 		"formatQualifiedPackage": formatQualifiedPackageFunc,
 		"resolveBreadcrumbs":     resolveBreadcrumbsFunc,
+		"groupUseFlags":          groupUseFlagsFunc,
+		"getBestDesc":            getBestDescFunc,
 	}
 }
 
@@ -368,4 +370,167 @@ func formatQualifiedPackageFunc(category, name, version, overlay string) string 
 		return fmt.Sprintf("=%s/%s-%s", category, name, version)
 	}
 	return fmt.Sprintf("%s/%s", category, name)
+}
+type UseFlagGroups struct {
+	GlobalFlags []UseFlagDisplay
+	CategoryGroups []CategoryUseFlagGroup
+	PackageGroups []CategoryPackageUseFlagGroup
+}
+
+type UseFlagDisplay struct {
+	Name string
+	Desc string
+	Count int
+}
+
+type CategoryUseFlagGroup struct {
+	Category string
+	Flags []UseFlagDisplay
+}
+
+type CategoryPackageUseFlagGroup struct {
+	Category string
+	Packages []PackageUseFlagGroup
+}
+
+type PackageUseFlagGroup struct {
+	Package string
+	Flags []UseFlagDisplay
+}
+
+func getBestDescFunc(flag *AggUseFlag, preferredPkg string) string {
+	if preferredPkg != "" {
+		if desc, ok := flag.MetadataDescs[preferredPkg]; ok && desc != "" {
+			return desc
+		}
+		if desc, ok := flag.LocalDescs[preferredPkg]; ok && desc != "" {
+			return desc
+		}
+	}
+	if flag.GlobalDesc != "" {
+		return flag.GlobalDesc
+	}
+
+	// Fallback to any local description if it exists
+	if len(flag.MetadataDescs) > 0 {
+		for _, desc := range flag.MetadataDescs {
+			if desc != "" {
+				return desc
+			}
+		}
+	}
+	if len(flag.LocalDescs) > 0 {
+		for _, desc := range flag.LocalDescs {
+			if desc != "" {
+				return desc
+			}
+		}
+	}
+	return ""
+}
+
+func groupUseFlagsFunc(flags []*AggUseFlag) UseFlagGroups {
+	var globalFlags []UseFlagDisplay
+
+	catFlagsMap := make(map[string][]UseFlagDisplay)
+	pkgFlagsCatMap := make(map[string]map[string][]UseFlagDisplay)
+
+	for _, flag := range flags {
+		uniqueCats := make(map[string]bool)
+		for _, pkg := range flag.Packages {
+			uniqueCats[pkg.Category] = true
+		}
+
+		if len(uniqueCats) > 1 || (len(uniqueCats) == 0 && flag.GlobalDesc != "") {
+			// Global flag
+			globalFlags = append(globalFlags, UseFlagDisplay{
+				Name: flag.Name,
+				Desc: getBestDescFunc(flag, ""),
+				Count: flag.Count,
+			})
+		} else if len(uniqueCats) == 1 {
+			// Used in exactly 1 category
+			var catName string
+			for c := range uniqueCats {
+				catName = c
+			}
+
+			if len(flag.Packages) > 1 {
+				// Multiple packages in the same category
+				catFlagsMap[catName] = append(catFlagsMap[catName], UseFlagDisplay{
+					Name: flag.Name,
+					// For category-level, we can just grab a representative description
+					Desc: getBestDescFunc(flag, ""),
+					Count: flag.Count,
+				})
+			} else if len(flag.Packages) == 1 {
+				// Single package in a single category
+				pkg := flag.Packages[0]
+				if pkgFlagsCatMap[pkg.Category] == nil {
+					pkgFlagsCatMap[pkg.Category] = make(map[string][]UseFlagDisplay)
+				}
+				pkgKey := pkg.Category + "/" + pkg.Name
+				pkgFlagsCatMap[pkg.Category][pkg.Name] = append(pkgFlagsCatMap[pkg.Category][pkg.Name], UseFlagDisplay{
+					Name: flag.Name,
+					Desc: getBestDescFunc(flag, pkgKey),
+					Count: flag.Count,
+				})
+			}
+		} else {
+			// Used in 0 packages but no global desc. Still add it to global list for visibility?
+			globalFlags = append(globalFlags, UseFlagDisplay{
+				Name: flag.Name,
+				Desc: getBestDescFunc(flag, ""),
+				Count: flag.Count,
+			})
+		}
+	}
+
+	sort.Slice(globalFlags, func(i, j int) bool {
+		return globalFlags[i].Name < globalFlags[j].Name
+	})
+
+	var catGroups []CategoryUseFlagGroup
+	for cat, cFlags := range catFlagsMap {
+		sort.Slice(cFlags, func(i, j int) bool {
+			return cFlags[i].Name < cFlags[j].Name
+		})
+		catGroups = append(catGroups, CategoryUseFlagGroup{
+			Category: cat,
+			Flags: cFlags,
+		})
+	}
+	sort.Slice(catGroups, func(i, j int) bool {
+		return catGroups[i].Category < catGroups[j].Category
+	})
+
+	var pkgGroups []CategoryPackageUseFlagGroup
+	for cat, pMap := range pkgFlagsCatMap {
+		var pkgList []PackageUseFlagGroup
+		for pkg, pFlags := range pMap {
+			sort.Slice(pFlags, func(i, j int) bool {
+				return pFlags[i].Name < pFlags[j].Name
+			})
+			pkgList = append(pkgList, PackageUseFlagGroup{
+				Package: pkg,
+				Flags: pFlags,
+			})
+		}
+		sort.Slice(pkgList, func(i, j int) bool {
+			return pkgList[i].Package < pkgList[j].Package
+		})
+		pkgGroups = append(pkgGroups, CategoryPackageUseFlagGroup{
+			Category: cat,
+			Packages: pkgList,
+		})
+	}
+	sort.Slice(pkgGroups, func(i, j int) bool {
+		return pkgGroups[i].Category < pkgGroups[j].Category
+	})
+
+	return UseFlagGroups{
+		GlobalFlags: globalFlags,
+		CategoryGroups: catGroups,
+		PackageGroups: pkgGroups,
+	}
 }

--- a/templates/views/repo_uses.html
+++ b/templates/views/repo_uses.html
@@ -1,9 +1,62 @@
-<h2>All USE Flags</h2>
-<ul>
-    {{range .UseFlags}}
-    <li>
-        <a href="{{.Name}}/">{{.Name}}</a> - {{.Count}} package(s)
-        {{if .Desc}}<br><small>{{.Desc}}</small>{{end}}
-    </li>
+{{$groups := groupUseFlags .UseFlags}}
+
+{{if $groups.GlobalFlags}}
+<h2>Global USE flags</h2>
+<table>
+    <tr>
+        <th>Flag</th>
+        <th>Description</th>
+        <th>Packages</th>
+    </tr>
+    {{range $groups.GlobalFlags}}
+    <tr>
+        <td><a href="{{.Name}}/">{{.Name}}</a></td>
+        <td>{{.Desc}}</td>
+        <td>{{.Count}}</td>
+    </tr>
     {{end}}
-</ul>
+</table>
+{{end}}
+
+{{if $groups.CategoryGroups}}
+<h2>Category USE flags</h2>
+{{range $groups.CategoryGroups}}
+<h3>{{.Category}}</h3>
+<table>
+    <tr>
+        <th>Flag</th>
+        <th>Description</th>
+        <th>Packages</th>
+    </tr>
+    {{range .Flags}}
+    <tr>
+        <td><a href="{{.Name}}/">{{.Name}}</a></td>
+        <td>{{.Desc}}</td>
+        <td>{{.Count}}</td>
+    </tr>
+    {{end}}
+</table>
+{{end}}
+{{end}}
+
+{{if $groups.PackageGroups}}
+<h2>Local USE flags</h2>
+{{range $groups.PackageGroups}}
+<h3>{{.Category}}</h3>
+{{range .Packages}}
+<h4>{{.Package}}</h4>
+<table>
+    <tr>
+        <th>Flag</th>
+        <th>Description</th>
+    </tr>
+    {{range .Flags}}
+    <tr>
+        <td><a href="{{.Name}}/">{{.Name}}</a></td>
+        <td>{{.Desc}}</td>
+    </tr>
+    {{end}}
+</table>
+{{end}}
+{{end}}
+{{end}}

--- a/templates/views/uses.html
+++ b/templates/views/uses.html
@@ -1,9 +1,62 @@
-<h2>All USE Flags</h2>
-<ul>
-    {{range .UseFlags}}
-    <li>
-        <a href="{{.Name}}/">{{.Name}}</a> - {{.Count}} package(s)
-        {{if .Desc}}<br><small>{{.Desc}}</small>{{end}}
-    </li>
+{{$groups := groupUseFlags .UseFlags}}
+
+{{if $groups.GlobalFlags}}
+<h2>Global USE flags</h2>
+<table>
+    <tr>
+        <th>Flag</th>
+        <th>Description</th>
+        <th>Packages</th>
+    </tr>
+    {{range $groups.GlobalFlags}}
+    <tr>
+        <td><a href="{{.Name}}/">{{.Name}}</a></td>
+        <td>{{.Desc}}</td>
+        <td>{{.Count}}</td>
+    </tr>
     {{end}}
-</ul>
+</table>
+{{end}}
+
+{{if $groups.CategoryGroups}}
+<h2>Category USE flags</h2>
+{{range $groups.CategoryGroups}}
+<h3>{{.Category}}</h3>
+<table>
+    <tr>
+        <th>Flag</th>
+        <th>Description</th>
+        <th>Packages</th>
+    </tr>
+    {{range .Flags}}
+    <tr>
+        <td><a href="{{.Name}}/">{{.Name}}</a></td>
+        <td>{{.Desc}}</td>
+        <td>{{.Count}}</td>
+    </tr>
+    {{end}}
+</table>
+{{end}}
+{{end}}
+
+{{if $groups.PackageGroups}}
+<h2>Local USE flags</h2>
+{{range $groups.PackageGroups}}
+<h3>{{.Category}}</h3>
+{{range .Packages}}
+<h4>{{.Package}}</h4>
+<table>
+    <tr>
+        <th>Flag</th>
+        <th>Description</th>
+    </tr>
+    {{range .Flags}}
+    <tr>
+        <td><a href="{{.Name}}/">{{.Name}}</a></td>
+        <td>{{.Desc}}</td>
+    </tr>
+    {{end}}
+</table>
+{{end}}
+{{end}}
+{{end}}


### PR DESCRIPTION
This submission enhances the display of USE flags on the generated site. Instead of presenting a single, flat list of all USE flags, they are now grouped into three logical tiers:
1.  **Global USE Flags:** Flags that apply across multiple categories or have a global description.
2.  **Category USE Flags:** Flags that are used by multiple packages but are restricted to a single category.
3.  **Local USE Flags:** Flags that are unique to a single package within a category.

This is implemented by adding new categorization logic (`groupUseFlags`) to the template functions and updating the relevant HTML templates (`uses.html` and `repo_uses.html`) to render the structured data appropriately. This aligns the site's presentation more closely with Gentoo's own USE flag documentation.

---
*PR created automatically by Jules for task [1336644976295843179](https://jules.google.com/task/1336644976295843179) started by @arran4*