### PR TITLE
feat: add GetLatestMatchingPackageRevision for direct querying

### DIFF
--- a/ebuild.go
+++ b/ebuild.go
@@ -968,3 +968,53 @@ func ExtractPackageNameFromDep(dep string) string {
 	}
 	return atom.Name
 }
+
+// GetLatestMatchingPackageRevision finds the highest revision for a given package and base version.
+// It looks for ebuilds in `category/pkgName` directory within the provided `fs.FS`.
+// The version argument is the base version to match against (e.g. "2.17.0").
+// Returns the full version string (including the highest revision, e.g. "2.17.0-r2").
+func GetLatestMatchingPackageRevision(overlayFS fs.FS, category, pkgName, version string) (string, error) {
+	dir := filepath.Join(category, pkgName)
+	entries, err := fs.ReadDir(overlayFS, dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read directory %s: %w", dir, err)
+	}
+
+	var highestRevGV GentooVersion
+	found := false
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".ebuild") {
+			continue
+		}
+
+		vars := ParseEbuildVariables(name)
+		if vars == nil || vars["PV"] == "" {
+			continue
+		}
+
+		gv := ParseGentooVersion(vars["PV"])
+		origRev := gv.Revision
+		gv.Revision = 0
+		base := gv.String()
+		gv.Revision = origRev
+
+		if base == version {
+			if !found || gv.Revision > highestRevGV.Revision {
+				highestRevGV = gv
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		return "", nil
+	}
+
+	return highestRevGV.String(), nil
+}

--- a/ebuild_test.go
+++ b/ebuild_test.go
@@ -962,3 +962,41 @@ func TestParsePackageAtom(t *testing.T) {
 		})
 	}
 }
+
+func TestGetLatestMatchingPackageRevision(t *testing.T) {
+	mockFS := fstest.MapFS{
+		"app-misc/goreleaser-bin/goreleaser-bin-2.17.0.ebuild":    {},
+		"app-misc/goreleaser-bin/goreleaser-bin-2.17.0-r1.ebuild": {},
+		"app-misc/goreleaser-bin/goreleaser-bin-2.17.0-r3.ebuild": {},
+		"app-misc/goreleaser-bin/goreleaser-bin-2.17.0-r2.ebuild": {},
+		"app-misc/goreleaser-bin/goreleaser-bin-1.0.0.ebuild":     {},
+		"app-misc/goreleaser-bin/metadata.xml":                    {},
+	}
+
+	tests := []struct {
+		name     string
+		category string
+		pkgName  string
+		version  string
+		want     string
+		wantErr  bool
+	}{
+		{"latest_revision", "app-misc", "goreleaser-bin", "2.17.0", "2.17.0-r3", false},
+		{"no_revision", "app-misc", "goreleaser-bin", "1.0.0", "1.0.0", false},
+		{"not_found_version", "app-misc", "goreleaser-bin", "9.9.9", "", false},
+		{"not_found_pkg", "app-misc", "not-exist", "1.0", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetLatestMatchingPackageRevision(mockFS, tt.category, tt.pkgName, tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLatestMatchingPackageRevision() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetLatestMatchingPackageRevision() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements `GetLatestMatchingPackageRevision` in the root `g2` module as requested in #371. The function directly reads the package directory inside a given `fs.FS` overlay, scans `.ebuild` files using `g2.ParseEbuildVariables` and `g2.ParseGentooVersion`, and returns the highest revision found for the specific base version provided.

This approach was chosen because it allows external consumers (like `arrans_binary_overlay_builder` / `abob`) to query for the latest revision cleanly via the top-level API without being forced to build out and use the full `SearchEngine` struct (which resides in `cmd/g2`). 

Extensive tests using `fstest` have been added to verify its behavior for various scenarios (e.g. tracking latest revisions, missing versions, missing package directories).

---
*PR created automatically by Jules for task [17687277471250938262](https://jules.google.com/task/17687277471250938262) started by @arran4*