### PR TITLE
fix: lower md5cache missing severity to warning

### DIFF
--- a/lints/md5cache/md5cache_missing.go
+++ b/lints/md5cache/md5cache_missing.go
@@ -14,7 +14,7 @@ var ruleMD5CacheMissing = lints.RuleMetadata{
 	Title:       "Missing MD5 Cache",
 	Description: "Verifies that an md5-cache entry exists for every ebuild version.",
 	URL:         "https://devmanual.gentoo.org/general-concepts/overlay-layout/#md5-cache",
-	Severity:    lints.SeverityError,
+	Severity:    lints.SeverityWarning,
 	Source:      lints.SourceG2,
 	Tags:        []string{"md5-cache", "site-quality"},
 }
@@ -32,7 +32,7 @@ func (r *MD5CacheLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.Lin
 
 func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
 	var results []lints.LintResult
-	severity := lints.SeverityError
+	severity := lints.SeverityWarning
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0802"]; ok {
 			if val == "notice" || val == "error" || val == "warning" {


### PR DESCRIPTION
Lower the default severity of the Md5CacheMissing rule from Error to Warning. This addresses the feedback that missing md5-cache is not an error condition.

---
*PR created automatically by Jules for task [16974224269159784627](https://jules.google.com/task/16974224269159784627) started by @arran4*