### PR TITLE
Fix parsing of multiple Gentoo version suffixes according to PMS 8

### DIFF
--- a/cmd/g2/versions.go
+++ b/cmd/g2/versions.go
@@ -199,11 +199,9 @@ func GentooToSemantic(v string) string {
 	if gv.Letter != "" {
 		res += gv.Letter
 	}
-	if gv.Suffix != "" {
-		res += "-" + gv.Suffix
-		if gv.SuffixNoStr != "" {
-			res += gv.SuffixNoStr
-		}
+	for _, s := range gv.Suffixes {
+		res += "-" + s.Name
+		res += s.ValueStr
 	}
 	if gv.Revision > 0 {
 		res += fmt.Sprintf("-r%d", gv.Revision)
@@ -338,8 +336,7 @@ func bumpVersionString(target string, bumpType string, suffix string, forceNum i
 		}
 		v.Revision = 0
 		v.Letter = ""
-		v.Suffix = ""
-		v.SuffixNoStr = ""
+		v.Suffixes = nil
 	case "minor":
 		if len(v.Nums) > 1 {
 			v.Nums[1]++
@@ -351,8 +348,7 @@ func bumpVersionString(target string, bumpType string, suffix string, forceNum i
 		}
 		v.Revision = 0
 		v.Letter = ""
-		v.Suffix = ""
-		v.SuffixNoStr = ""
+		v.Suffixes = nil
 	case "patch":
 		if len(v.Nums) > 2 {
 			v.Nums[2]++
@@ -364,20 +360,21 @@ func bumpVersionString(target string, bumpType string, suffix string, forceNum i
 		}
 		v.Revision = 0
 		v.Letter = ""
-		v.Suffix = ""
-		v.SuffixNoStr = ""
+		v.Suffixes = nil
 	case "revision", "rev":
 		v.Revision++
 	}
 
 	if suffix != "" {
-		v.Suffix = suffix
+		v.Suffixes = []g2.GentooSuffix{
+			{Name: suffix},
+		}
 		if forceNum != -1 {
-			v.SuffixNo = forceNum
-			v.SuffixNoStr = strconv.Itoa(forceNum)
+			v.Suffixes[0].Value = forceNum
+			v.Suffixes[0].ValueStr = strconv.Itoa(forceNum)
 		} else {
-			v.SuffixNo = 1 // default
-			v.SuffixNoStr = "1"
+			v.Suffixes[0].Value = 1 // default
+			v.Suffixes[0].ValueStr = "1"
 		}
 	}
 

--- a/ebuild.go
+++ b/ebuild.go
@@ -580,16 +580,19 @@ func ExtractURIs(content string, variables map[string]string) ([]URIEntry, error
 	return uris, nil
 }
 
-var versionRegex = regexp.MustCompile(`^(\d+(?:\.\d+)*)(?:([a-z]))?(?:_(alpha|beta|pre|rc|p)(\d*))?(?:-r(\d+))?$`)
 
 // GentooVersion represents a parsed Gentoo package version strictly adhering to PMS rules.
+type GentooSuffix struct {
+	Name     string
+	Value    int
+	ValueStr string
+}
+
 type GentooVersion struct {
 	Nums        []int
 	NumStrs     []string
 	Letter      string
-	Suffix      string
-	SuffixNoStr string
-	SuffixNo    int
+	Suffixes    []GentooSuffix
 	Revision    int
 	IsValid     bool
 }
@@ -608,12 +611,10 @@ func (gv *GentooVersion) String() string {
 		sb.WriteString(gv.Letter)
 	}
 
-	if gv.Suffix != "" {
+	for _, s := range gv.Suffixes {
 		sb.WriteString("_")
-		sb.WriteString(gv.Suffix)
-		if gv.SuffixNoStr != "" {
-			sb.WriteString(gv.SuffixNoStr)
-		}
+		sb.WriteString(s.Name)
+		sb.WriteString(s.ValueStr)
 	}
 
 	if gv.Revision > 0 {
@@ -666,9 +667,7 @@ func (gv *GentooVersion) IncrementPart(parts ...any) {
 			}
 			gv.Revision = 0
 			gv.Letter = ""
-			gv.Suffix = ""
-			gv.SuffixNoStr = ""
-			gv.SuffixNo = 0
+			gv.Suffixes = nil
 		case "minor":
 			if len(gv.Nums) > 1 {
 				gv.Nums[1]++
@@ -684,9 +683,7 @@ func (gv *GentooVersion) IncrementPart(parts ...any) {
 			}
 			gv.Revision = 0
 			gv.Letter = ""
-			gv.Suffix = ""
-			gv.SuffixNoStr = ""
-			gv.SuffixNo = 0
+			gv.Suffixes = nil
 		case "patch":
 			if len(gv.Nums) > 2 {
 				gv.Nums[2]++
@@ -705,13 +702,12 @@ func (gv *GentooVersion) IncrementPart(parts ...any) {
 			}
 			gv.Revision = 0
 			gv.Letter = ""
-			gv.Suffix = ""
-			gv.SuffixNoStr = ""
-			gv.SuffixNo = 0
+			gv.Suffixes = nil
 		case "suffix":
-			if gv.Suffix != "" {
-				gv.SuffixNo++
-				gv.SuffixNoStr = strconv.Itoa(gv.SuffixNo)
+			if len(gv.Suffixes) > 0 {
+				lastIdx := len(gv.Suffixes) - 1
+				gv.Suffixes[lastIdx].Value++
+				gv.Suffixes[lastIdx].ValueStr = strconv.Itoa(gv.Suffixes[lastIdx].Value)
 			}
 			gv.Revision = 0
 		case "revision":
@@ -727,8 +723,7 @@ func (gv *GentooVersion) IncrementRevision() {
 
 // ParseGentooVersion parses a gentoo version into parts
 func ParseGentooVersion(v string) GentooVersion {
-	m := versionRegex.FindStringSubmatch(v)
-	if m == nil {
+	if v == "" {
 		return GentooVersion{IsValid: false}
 	}
 
@@ -740,20 +735,92 @@ func ParseGentooVersion(v string) GentooVersion {
 		return i
 	}
 
-	numStrs := strings.Split(m[1], ".")
 	var nums []int
-	for _, n := range numStrs {
-		nums = append(nums, toInt(n))
+	var numStrs []string
+
+	// Start parsing Nums
+	i := 0
+	for ; i < len(v); i++ {
+		start := i
+		for i < len(v) && v[i] >= '0' && v[i] <= '9' {
+			i++
+		}
+		if i == start {
+			return GentooVersion{IsValid: false}
+		}
+		numStrs = append(numStrs, v[start:i])
+		nums = append(nums, toInt(v[start:i]))
+
+		if i < len(v) && v[i] == '.' {
+			// Expect another number part
+            // But if it's the last character, it's invalid
+            if i + 1 == len(v) {
+                return GentooVersion{IsValid: false}
+            }
+			continue
+		} else {
+			break
+		}
+	}
+
+	var letter string
+	if i < len(v) && v[i] >= 'a' && v[i] <= 'z' {
+		letter = string(v[i])
+		i++
+	}
+
+	var suffixes []GentooSuffix
+	for i < len(v) && v[i] == '_' {
+		i++
+		start := i
+		var suffixName string
+		// valid suffixes: alpha, beta, pre, rc, p
+		validSuffixes := []string{"alpha", "beta", "pre", "rc", "p"}
+		for _, s := range validSuffixes {
+			if strings.HasPrefix(v[start:], s) {
+				suffixName = s
+				i += len(s)
+				break
+			}
+		}
+		if suffixName == "" {
+			return GentooVersion{IsValid: false}
+		}
+		startNum := i
+		for i < len(v) && v[i] >= '0' && v[i] <= '9' {
+			i++
+		}
+		valStr := v[startNum:i]
+		suffixes = append(suffixes, GentooSuffix{
+			Name:     suffixName,
+			Value:    toInt(valStr),
+			ValueStr: valStr,
+		})
+	}
+
+	var revision int
+	if i < len(v) && strings.HasPrefix(v[i:], "-r") {
+		i += 2
+		start := i
+		for i < len(v) && v[i] >= '0' && v[i] <= '9' {
+			i++
+		}
+		if i == start {
+			return GentooVersion{IsValid: false}
+		}
+		revision = toInt(v[start:i])
+	}
+
+	if i < len(v) {
+		return GentooVersion{IsValid: false} // Trailing characters
 	}
 
 	return GentooVersion{
 		Nums:        nums,
 		NumStrs:     numStrs,
-		Letter:      m[2],
-		Suffix:      m[3],
-		SuffixNoStr: m[4],
-		SuffixNo:    toInt(m[4]),
-		Revision:    toInt(m[5]),
+		Letter:      letter,
+		Suffixes:    suffixes,
+		Revision:    revision,
 		IsValid:     true,
 	}
 }
@@ -848,16 +915,40 @@ func compareGentooVersionParts(v1, v2 GentooVersion) int {
 		"beta":  2,
 		"pre":   3,
 		"rc":    4,
-		"":      5, // no suffix
 		"p":     6,
 	}
 
-	if c := cmpInt(suffixOrder[v1.Suffix], suffixOrder[v2.Suffix]); c != 0 {
-		return c
+	maxSuffixLen := len(v1.Suffixes)
+	if len(v2.Suffixes) > maxSuffixLen {
+		maxSuffixLen = len(v2.Suffixes)
 	}
 
-	if c := cmpInt(v1.SuffixNo, v2.SuffixNo); c != 0 {
-		return c
+	for i := 0; i < maxSuffixLen; i++ {
+		var s1, s2 GentooSuffix
+
+		if i >= len(v1.Suffixes) {
+			s2 = v2.Suffixes[i]
+			if s2.Name == "p" {
+				return -1
+			}
+			return 1
+		} else if i >= len(v2.Suffixes) {
+			s1 = v1.Suffixes[i]
+			if s1.Name == "p" {
+				return 1
+			}
+			return -1
+		}
+
+		s1 = v1.Suffixes[i]
+		s2 = v2.Suffixes[i]
+
+		if c := cmpInt(suffixOrder[s1.Name], suffixOrder[s2.Name]); c != 0 {
+			return c
+		}
+		if c := cmpInt(s1.Value, s2.Value); c != 0 {
+			return c
+		}
 	}
 
 	if c := cmpInt(v1.Revision, v2.Revision); c != 0 {

--- a/ebuild_test.go
+++ b/ebuild_test.go
@@ -634,6 +634,25 @@ func TestCompareVersions(t *testing.T) {
 		// Unparseable versions fallback to string compare
 		{"invalid1", "invalid2", -1},
 		{"invalid2", "invalid1", 1},
+		{"1.0_alpha1_beta2_p3-r1", "1.0_alpha1_beta2_p3-r1", 0},
+		{"1.0_alpha1_beta2_p3-r1", "1.0_alpha1_beta2_p4-r1", -1},
+		{"1.0_alpha1_beta2_p3-r1", "1.0_alpha1_beta2_p3-r2", -1},
+		{"1.0_alpha", "1.0_alpha_beta", 1},
+		{"1.0_alpha_beta", "1.0_alpha", -1},
+		{"1.0_alpha_p1", "1.0_alpha", 1},
+		{"1.0_alpha", "1.0_alpha_p1", -1},
+		{"1.0_alpha1_beta2", "1.0_alpha1_beta3", -1},
+		{"1.2.3_alpha1", "1.2.3_alpha1", 0},
+		{"1.2.3_alpha1", "1.2.3_alpha2", -1},
+		{"1.2.3_beta1", "1.2.3_alpha2", 1},
+		{"1.2.3_pre1", "1.2.3_beta2", 1},
+		{"1.2.3_rc1", "1.2.3_pre2", 1},
+		{"1.2.3_p1", "1.2.3", 1},
+		{"1.2.3", "1.2.3_p1", -1},
+		{"1.2.3-r1", "1.2.3", 1},
+		{"1.2.3", "1.2.3-r1", -1},
+		{"1.000.2", "1.0.2", 0},
+		{"1.000.2-r1", "1.0.2-r1", 0},
 	}
 
 	for _, tt := range tests {
@@ -998,5 +1017,29 @@ func TestGetLatestMatchingPackageRevision(t *testing.T) {
 				t.Errorf("GetLatestMatchingPackageRevision() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGentooVersion_Roundtrip(t *testing.T) {
+	versions := []string{
+		"1.2.3",
+		"1.2.3-r1",
+		"1.2.3_alpha1",
+		"1.2.3_beta2-r1",
+		"1.2.3-alpha1",
+		"1.2.3_alpha1_beta2_p3-r4",
+	}
+
+	for _, v := range versions {
+		parsed := ParseGentooVersion(v)
+		if !parsed.IsValid {
+			// Some of these might be invalid Gentoo versions but valid semver,
+			// like 1.2.3-alpha1. Let's just test if String() matches original for valid ones.
+			continue
+		}
+		str := parsed.String()
+		if str != v {
+			t.Errorf("Roundtrip failed for %s: got %s", v, str)
+		}
 	}
 }


### PR DESCRIPTION
Fixes the parsing, stringification, and comparison of Gentoo versions that have multiple suffixes (like `1.0_alpha1_beta2_p3-r1`) according to PMS 8 Section 3.2. Also transitions the parsing logic away from complex regular expressions to a procedural parser as preferred by project coding patterns. Includes exhaustive unit testing of the versions comparison feature.

---
*PR created automatically by Jules for task [12958183997501386208](https://jules.google.com/task/12958183997501386208) started by @arran4*