### PR TITLE
🔒 Fix command injection vulnerability in git clone

### DIFF
--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -171,6 +171,13 @@ func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip
 		}
 	}
 
+	if strings.HasPrefix(gitUrl, "-") {
+		return fmt.Errorf("invalid git url: cannot start with '-'")
+	}
+	if !strings.HasPrefix(gitUrl, "http://") && !strings.HasPrefix(gitUrl, "https://") && !strings.HasPrefix(gitUrl, "git://") && !strings.HasPrefix(gitUrl, "ssh://") && !strings.HasPrefix(gitUrl, "git@") && !strings.HasPrefix(gitUrl, "file://") {
+		return fmt.Errorf("invalid git url protocol: %s", gitUrl)
+	}
+
 	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", gitUrl, destDir)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	cmd.Stdout = os.Stdout

--- a/cmd/g2/fetch_test.go
+++ b/cmd/g2/fetch_test.go
@@ -157,3 +157,46 @@ malicious
 		t.Errorf("expected zip slip error message, got: %v", err)
 	}
 }
+
+func TestGitUrlValidation(t *testing.T) {
+	ctx := context.Background()
+	destDir := "/tmp/test-dest"
+
+	tests := []struct {
+		url      string
+		wantErr  bool
+		errMatch string
+	}{
+		{"--upload-pack=sleep 10", true, "invalid git url: cannot start with '-'"},
+		{"-foo", true, "invalid git url: cannot start with '-'"},
+		{"invalid://foo", true, "invalid git url protocol: invalid://foo"},
+		{"http://github.com/foo/bar", false, ""},
+		{"https://github.com/foo/bar", false, ""},
+		{"git://github.com/foo/bar", false, ""},
+		{"ssh://git@github.com/foo/bar", false, ""},
+		{"git@github.com:foo/bar", false, ""},
+		{"file:///path/to/repo", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			// We only want to test validation, not actual cloning
+			// fetchRepoAttempt with valid url will try to run 'git clone' and fail since the url is fake/unreachable
+			err := fetchRepoAttempt(ctx, tt.url, destDir, false, "")
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				} else if !strings.Contains(err.Error(), tt.errMatch) {
+					t.Errorf("expected error containing %q, got: %v", tt.errMatch, err)
+				}
+			} else {
+				if err != nil {
+					// Since it's a dummy valid URL, git clone will likely fail, but it shouldn't fail due to our validation
+					if strings.Contains(err.Error(), "invalid git url") {
+						t.Errorf("did not expect validation error, got: %v", err)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** The `git clone` command in `fetchRepoAttempt` previously accepted any URL format.
⚠️ **Risk:** An attacker could supply a `gitUrl` starting with `-` (e.g. `--upload-pack=sleep 10`), causing `git clone` to execute arbitrary commands on the system.
🛡️ **Solution:** Added explicit prefix validation in `cmd/g2/fetch.go` to reject strings starting with `-` and verify the protocol is allowed (`http://`, `https://`, `git://`, `ssh://`, `git@`, `file://`). Also added validation tests to `cmd/g2/fetch_test.go` to prevent regressions.

---
*PR created automatically by Jules for task [16707820370609416791](https://jules.google.com/task/16707820370609416791) started by @arran4*