### PR TITLE
🔒 Fix command injection risk in git clone

### DIFF
--- a/cmd/g2/fetch.go
+++ b/cmd/g2/fetch.go
@@ -132,6 +132,34 @@ func (osWriteFS) MkdirAll(path string, perm os.FileMode) error { return os.Mkdir
 func (osWriteFS) Create(name string) (io.WriteCloser, error)   { return os.Create(name) }
 
 func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip bool, workMode string) error {
+	if strings.HasPrefix(gitUrl, "-") {
+		return fmt.Errorf("invalid git URL: cannot start with '-'")
+	}
+
+	isValidScheme := false
+	validPrefixes := []string{"http://", "https://", "git://", "ssh://", "git@", "file://"}
+	for _, p := range validPrefixes {
+		if strings.HasPrefix(gitUrl, p) {
+			isValidScheme = true
+			break
+		}
+	}
+
+	// For local paths, we must be careful not to allow ext:: or similar schemes.
+	// We allow absolute paths (/) or explicit relative paths (./ or ../).
+	if !isValidScheme {
+		if strings.HasPrefix(gitUrl, "/") || strings.HasPrefix(gitUrl, "./") || strings.HasPrefix(gitUrl, "../") {
+			isValidScheme = true
+		} else if !strings.Contains(gitUrl, "::") && !strings.Contains(gitUrl, "://") {
+			// If there are no scheme markers, we can assume it might be a valid local path or simple ssh like host:path
+			isValidScheme = true
+		}
+	}
+
+	if !isValidScheme {
+		return fmt.Errorf("invalid git URL scheme")
+	}
+
 	if workMode == "persistent" {
 		gitDir := filepath.Join(destDir, ".git")
 		if info, err := os.Stat(gitDir); err == nil && info.IsDir() {
@@ -171,7 +199,7 @@ func fetchRepoAttempt(ctx context.Context, gitUrl string, destDir string, useZip
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", gitUrl, destDir)
+	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--", gitUrl, destDir)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/g2/fetch_test.go
+++ b/cmd/g2/fetch_test.go
@@ -157,3 +157,39 @@ malicious
 		t.Errorf("expected zip slip error message, got: %v", err)
 	}
 }
+
+func TestFetchRepoAttemptValidation(t *testing.T) {
+	ctx := context.Background()
+	destDir := "/tmp/mock-dest"
+
+	invalidUrls := []string{
+		"--upload-pack=malicious",
+		"-ext::malicious",
+		"ftp://malicious.com",
+		"smb://network/share",
+	}
+
+	for _, u := range invalidUrls {
+		err := fetchRepoAttempt(ctx, u, destDir, false, "")
+		if err == nil {
+			t.Errorf("Expected error for URL: %s, got nil", u)
+		} else if !strings.Contains(err.Error(), "invalid git URL scheme") && !strings.Contains(err.Error(), "invalid git URL: cannot start with '-'") {
+			t.Errorf("Unexpected error for URL: %s, got %v", u, err)
+		}
+	}
+
+	// Just for test, check a valid-looking but unresolvable one doesn't fail early with our custom error
+	validUrls := []string{
+		"http://github.com/a/b",
+		"git://github.com/a/b",
+		"ssh://github.com/a/b",
+	}
+
+	for _, u := range validUrls {
+		err := fetchRepoAttempt(ctx, u, destDir, false, "")
+		// We expect an error from the actual git clone failing, but NOT our custom validation error
+		if err != nil && (strings.Contains(err.Error(), "invalid git URL scheme") || strings.Contains(err.Error(), "invalid git URL: cannot start with '-'")) {
+			t.Errorf("Unexpected validation error for valid URL: %s, got %v", u, err)
+		}
+	}
+}

--- a/ebuild.go
+++ b/ebuild.go
@@ -580,7 +580,6 @@ func ExtractURIs(content string, variables map[string]string) ([]URIEntry, error
 	return uris, nil
 }
 
-
 // GentooVersion represents a parsed Gentoo package version strictly adhering to PMS rules.
 type GentooSuffix struct {
 	Name     string
@@ -589,12 +588,12 @@ type GentooSuffix struct {
 }
 
 type GentooVersion struct {
-	Nums        []int
-	NumStrs     []string
-	Letter      string
-	Suffixes    []GentooSuffix
-	Revision    int
-	IsValid     bool
+	Nums     []int
+	NumStrs  []string
+	Letter   string
+	Suffixes []GentooSuffix
+	Revision int
+	IsValid  bool
 }
 
 // String reassembles and serializes the parsed GentooVersion back into a string.
@@ -753,10 +752,10 @@ func ParseGentooVersion(v string) GentooVersion {
 
 		if i < len(v) && v[i] == '.' {
 			// Expect another number part
-            // But if it's the last character, it's invalid
-            if i + 1 == len(v) {
-                return GentooVersion{IsValid: false}
-            }
+			// But if it's the last character, it's invalid
+			if i+1 == len(v) {
+				return GentooVersion{IsValid: false}
+			}
 			continue
 		} else {
 			break
@@ -816,12 +815,12 @@ func ParseGentooVersion(v string) GentooVersion {
 	}
 
 	return GentooVersion{
-		Nums:        nums,
-		NumStrs:     numStrs,
-		Letter:      letter,
-		Suffixes:    suffixes,
-		Revision:    revision,
-		IsValid:     true,
+		Nums:     nums,
+		NumStrs:  numStrs,
+		Letter:   letter,
+		Suffixes: suffixes,
+		Revision: revision,
+		IsValid:  true,
 	}
 }
 


### PR DESCRIPTION
🎯 What: Prevents command injection and arbitrary protocol execution in fetchRepoAttempt.
⚠️ Risk: An attacker could pass a malicious git URL (e.g. starting with '-' or 'ext::') to execute arbitrary commands during git clone operations.
🛡️ Solution: Validates gitUrls against an explicit allowlist of schemes (http://, https://, git://, ssh://, git@, file://) and safe local paths. Additionally, injects '--' into the git clone command to force treating the URL as a positional argument rather than a flag.

---
*PR created automatically by Jules for task [13613900948118849869](https://jules.google.com/task/13613900948118849869) started by @arran4*