### PR TITLE
feat: add DeduplicateStrings utility

### DIFF
--- a/slice_utils.go
+++ b/slice_utils.go
@@ -1,0 +1,17 @@
+package g2
+
+// DeduplicateStrings removes duplicate strings from a slice, preserving the order of first appearance.
+func DeduplicateStrings(s []string) []string {
+	if len(s) == 0 {
+		return s
+	}
+	seen := make(map[string]bool, len(s))
+	result := make([]string, 0, len(s))
+	for _, v := range s {
+		if !seen[v] {
+			seen[v] = true
+			result = append(result, v)
+		}
+	}
+	return result
+}

--- a/slice_utils_test.go
+++ b/slice_utils_test.go
@@ -1,0 +1,26 @@
+package g2
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDeduplicateStrings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{"empty", []string{}, []string{}},
+		{"no duplicates", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"duplicates", []string{"a", "b", "a", "c", "b"}, []string{"a", "b", "c"}},
+		{"all duplicates", []string{"a", "a", "a"}, []string{"a"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeduplicateStrings(tt.input); !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("DeduplicateStrings() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added `DeduplicateStrings` function to `g2` package to standardise string slice deduplication while preserving order and optimising memory allocation.

Resolves #396
Unblocks: https://github.com/arran4/arrans_binary_overlay_builder/pull/49/changes#r3697373583

---
*PR created automatically by Jules for task [3187343142226156578](https://jules.google.com/task/3187343142226156578) started by @arran4*