### PR TITLE
feat(lint): add -disable-rule and -ignore-tag flags to explicitly ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ playwright-script.js
 doc/g2.1
 /*.exe
 _site
+vars-1.0.tar.gz

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -76,6 +76,8 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
+	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
+	ignoreTag := fs.String("ignore-tag", "", "Comma-separated list of tags to ignore")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -167,6 +169,35 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 						continue
 					}
 				}
+				isIgnored := false
+				if *disableRule != "" {
+					disabled := strings.Split(*disableRule, ",")
+					for _, dr := range disabled {
+						if strings.EqualFold(string(w.RuleMetadata.ID), strings.TrimSpace(dr)) {
+							isIgnored = true
+							break
+						}
+					}
+				}
+				if !isIgnored && *ignoreTag != "" {
+					ignoredTags := strings.Split(*ignoreTag, ",")
+					for _, it := range ignoredTags {
+						it = strings.TrimSpace(it)
+						for _, t := range w.RuleMetadata.Tags {
+							if strings.EqualFold(t, it) {
+								isIgnored = true
+								break
+							}
+						}
+						if isIgnored {
+							break
+						}
+					}
+				}
+				if isIgnored {
+					continue
+				}
+
 				filteredWarnings = append(filteredWarnings, w)
 			}
 
@@ -286,7 +317,7 @@ type LintQuery struct {
 	VWildcard string // e.g. "3." for "v3"
 }
 
-func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool, query *LintQuery, format, severityFilter, sourceFilter, tagFilter string) error {
+func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool, query *LintQuery, format, severityFilter, sourceFilter, tagFilter, disableRule, ignoreTag string) error {
 	siteData, err := parseRepo(os.DirFS(location), ".", "Linting", true, nil)
 	if err != nil {
 		return fmt.Errorf("parsing repo: %w", err)
@@ -391,6 +422,35 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 						continue
 					}
 				}
+				isIgnored := false
+				if disableRule != "" {
+					disabled := strings.Split(disableRule, ",")
+					for _, dr := range disabled {
+						if strings.EqualFold(string(w.RuleMetadata.ID), strings.TrimSpace(dr)) {
+							isIgnored = true
+							break
+						}
+					}
+				}
+				if !isIgnored && ignoreTag != "" {
+					ignoredTags := strings.Split(ignoreTag, ",")
+					for _, it := range ignoredTags {
+						it = strings.TrimSpace(it)
+						for _, t := range w.RuleMetadata.Tags {
+							if strings.EqualFold(t, it) {
+								isIgnored = true
+								break
+							}
+						}
+						if isIgnored {
+							break
+						}
+					}
+				}
+				if isIgnored {
+					continue
+				}
+
 				filteredWarnings = append(filteredWarnings, w)
 			}
 
@@ -452,6 +512,8 @@ func (cfg *MainArgConfig) cmdLintRepo(args []string) error {
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
+	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
+	ignoreTag := fs.String("ignore-tag", "", "Comma-separated list of tags to ignore")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -462,7 +524,7 @@ func (cfg *MainArgConfig) cmdLintRepo(args []string) error {
 		location = fs.Arg(0)
 	}
 
-	return cfg.runLintCore(location, nil, nil, *format, *severityFilter, *sourceFilter, *tagFilter)
+	return cfg.runLintCore(location, nil, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
 }
 
 func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
@@ -478,6 +540,8 @@ func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
+	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
+	ignoreTag := fs.String("ignore-tag", "", "Comma-separated list of tags to ignore")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -515,7 +579,7 @@ func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
 		targetMap[cleanP] = true
 	}
 
-	return cfg.runLintCore(location, targetMap, nil, *format, *severityFilter, *sourceFilter, *tagFilter)
+	return cfg.runLintCore(location, targetMap, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
 }
 
 func parseLintQuery(queryStr string, defaultLocation string) (*LintQuery, error) {
@@ -633,6 +697,8 @@ func (cfg *MainArgConfig) cmdLintQuery(args []string) error {
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
+	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
+	ignoreTag := fs.String("ignore-tag", "", "Comma-separated list of tags to ignore")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -655,5 +721,5 @@ func (cfg *MainArgConfig) cmdLintQuery(args []string) error {
 		return fmt.Errorf("parsing query: %w", err)
 	}
 
-	return cfg.runLintCore(query.RepoPath, nil, query, *format, *severityFilter, *sourceFilter, *tagFilter)
+	return cfg.runLintCore(query.RepoPath, nil, query, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
 }

--- a/lints/ebuild/eapi_deprecated.go
+++ b/lints/ebuild/eapi_deprecated.go
@@ -14,7 +14,7 @@ var ruleEAPIDeprecated = lints.RuleMetadata{
 	URL:         "https://devmanual.gentoo.org/ebuild-writing/eapi/",
 	Severity:    lints.SeverityWarning,
 	Source:      lints.SourceG2,
-	Tags:        []string{"ebuild", "gentoo-policy"},
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0803"},
 }
 
 func init() {
@@ -33,6 +33,9 @@ func (r *EAPIDeprecatedLintRule) LintWithQA(repoDir string, pkg *g2.PackageData,
 	severity := lints.SeverityWarning
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0803"]; ok {
+			if val == "ignore" {
+				return nil
+			}
 			if val == "notice" || val == "error" || val == "warning" {
 				// Convert val to lints.Severity (simple mapping)
 				switch val {

--- a/lints/ebuild/iuse_documented.go
+++ b/lints/ebuild/iuse_documented.go
@@ -17,7 +17,7 @@ var ruleIUSEDocumented = lints.RuleMetadata{
 	URL:         "https://devmanual.gentoo.org/general-concepts/use-flags/",
 	Severity:    lints.SeverityWarning,
 	Source:      lints.SourceG2,
-	Tags:        []string{"metadata.xml", "ebuild", "site-quality"},
+	Tags:        []string{"metadata.xml", "ebuild", "site-quality", "PG0701"},
 }
 
 func init() {
@@ -37,6 +37,9 @@ func (r *IUSELintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QA
 
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0701"]; ok {
+			if val == "ignore" {
+				return nil
+			}
 			if val == "notice" || val == "error" || val == "warning" {
 				switch val {
 				case "notice":

--- a/lints/ebuild/license_sanity.go
+++ b/lints/ebuild/license_sanity.go
@@ -17,7 +17,7 @@ var ruleLicenseSanity = lints.RuleMetadata{
 	URL:         "https://devmanual.gentoo.org/ebuild-writing/variables/index.html#license",
 	Severity:    lints.SeverityError,
 	Source:      lints.SourceG2,
-	Tags:        []string{"ebuild", "site-quality", "gentoo-policy"},
+	Tags:        []string{"ebuild", "site-quality", "gentoo-policy", "PG0804"},
 }
 
 func init() {
@@ -36,6 +36,9 @@ func (r *LicenseSanityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, 
 	severity := lints.SeverityError
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0804"]; ok {
+			if val == "ignore" {
+				return nil
+			}
 			if val == "notice" || val == "error" || val == "warning" {
 				switch val {
 				case "notice":

--- a/lints/ebuild/missing_slot.go
+++ b/lints/ebuild/missing_slot.go
@@ -17,7 +17,7 @@ var ruleMissingSlot = lints.RuleMetadata{
 	URL:         "https://devmanual.gentoo.org/ebuild-writing/variables/#ebuild-defined-variables",
 	Severity:    lints.SeverityWarning,
 	Source:      lints.SourceG2,
-	Tags:        []string{"ebuild", "gentoo-policy", "metadata"},
+	Tags:        []string{"ebuild", "gentoo-policy", "metadata", "PG0804"},
 }
 
 func init() {
@@ -36,6 +36,9 @@ func (r *MissingSlotLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa
 	severity := ruleMissingSlot.Severity
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0804"]; ok { // Assign a pseudo-QA policy code or omit
+			if val == "ignore" {
+				return nil
+			}
 			if val == "notice" || val == "error" || val == "warning" {
 				switch val {
 				case "notice":

--- a/lints/md5cache/md5cache_missing.go
+++ b/lints/md5cache/md5cache_missing.go
@@ -16,7 +16,7 @@ var ruleMD5CacheMissing = lints.RuleMetadata{
 	URL:         "https://devmanual.gentoo.org/general-concepts/overlay-layout/#md5-cache",
 	Severity:    lints.SeverityWarning,
 	Source:      lints.SourceG2,
-	Tags:        []string{"md5-cache", "site-quality"},
+	Tags:        []string{"md5-cache", "site-quality", "PG0802"},
 }
 
 func init() {
@@ -35,6 +35,9 @@ func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 	severity := lints.SeverityWarning
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0802"]; ok {
+			if val == "ignore" {
+				return nil
+			}
 			if val == "notice" || val == "error" || val == "warning" {
 				switch val {
 				case "notice":

--- a/lints/metadata/maintainer_missing.go
+++ b/lints/metadata/maintainer_missing.go
@@ -16,7 +16,7 @@ var ruleMaintainerMissing = lints.RuleMetadata{
 	URL:         "https://devmanual.gentoo.org/ebuild-writing/misc-files/metadata.xml/index.html#maintainer-field",
 	Severity:    lints.SeverityError,
 	Source:      lints.SourceG2,
-	Tags:        []string{"metadata.xml", "site-quality"},
+	Tags:        []string{"metadata.xml", "site-quality", "PG0702"},
 }
 
 func init() {
@@ -35,6 +35,9 @@ func (r *MaintainerLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa 
 	severity := lints.SeverityError
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0702"]; ok {
+			if val == "ignore" {
+				return nil
+			}
 			if val == "notice" || val == "error" || val == "warning" {
 				switch val {
 				case "notice":

--- a/lints/metadata/metadata_missing_invalid.go
+++ b/lints/metadata/metadata_missing_invalid.go
@@ -16,7 +16,7 @@ var ruleMetadataMissing = lints.RuleMetadata{
 	URL:         "https://devmanual.gentoo.org/ebuild-writing/misc-files/metadata.xml/",
 	Severity:    lints.SeverityError,
 	Source:      lints.SourceG2,
-	Tags:        []string{"metadata.xml", "site-quality"},
+	Tags:        []string{"metadata.xml", "site-quality", "PG0701"},
 }
 
 func init() {
@@ -35,6 +35,9 @@ func (r *MetadataLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 	severity := lints.SeverityError
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0701"]; ok {
+			if val == "ignore" {
+				return nil
+			}
 			if val == "notice" || val == "error" || val == "warning" {
 				switch val {
 				case "notice":


### PR DESCRIPTION
Fixes #409

Adds CLI flags to explicitly ignore certain lint rules and appropriately handle `"ignore"` configured inside `qa-policy.conf`.

Changes:
- Adds `-disable-rule` flag for filtering by `RuleMetadata.ID`.
- Adds `-ignore-tag` flag for filtering by `RuleMetadata.Tags`.
- Tags are now injected with corresponding `PG*` QA policy codes to easily target them.
- If a rule yields `"ignore"` via `qa.Policies`, the rule halts execution and immediately returns `nil`.
- Excluded warnings no longer trip the `hasErrors` flag natively avoiding unwanted `exit 255` behavior in CI.

---
*PR created automatically by Jules for task [14280206364312117601](https://jules.google.com/task/14280206364312117601) started by @arran4*