### PR TITLE
Fix broken global news link in dashboard

### DIFF
--- a/templates/views/dashboard.html
+++ b/templates/views/dashboard.html
@@ -50,7 +50,7 @@
 <h2>Recent News</h2>
 <ul>
     {{range .RecentGlobalNews}}
-    <li><a href="news/archive/{{.DirName}}/">{{.Title}}</a> - {{.Posted.Format "Jan 02, 2006"}} {{if .RepoName}}({{.RepoName}}){{end}}</li>
+    <li><a href="news/archive/{{.ArchivePath}}/">{{.Title}}</a> - {{.Posted.Format "Jan 02, 2006"}} {{if .RepoName}}({{.RepoName}}){{end}}</li>
     {{end}}
 </ul>
 <p><a href="news/archive/">More... (Archive)</a></p>


### PR DESCRIPTION
Fixes a 404 error in the "Recent News" section of the site's dashboard by changing the template variable from `{{.DirName}}` to `{{.ArchivePath}}`.

---
*PR created automatically by Jules for task [14907273593103554126](https://jules.google.com/task/14907273593103554126) started by @arran4*