### PR TITLE
Fix repository name fallback to avoid `.` names

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 
-	"encoding/xml"
 	"flag"
 	"fmt"
 	"html/template"
@@ -2040,8 +2039,8 @@ func (cfg *MainArgConfig) cmdSiteRemote(repositoriesFile string, outDir string, 
 			}
 		}
 
-		var fileRepos g2.Repositories
-		if err := xml.Unmarshal(data, &fileRepos); err != nil {
+		fileRepos, err := g2.ParseRepositoriesBytes(data)
+		if err != nil {
 			return fmt.Errorf("parsing repositories.xml: %w", err)
 		}
 		repos.Repositories = append(repos.Repositories, fileRepos.Repositories...)

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -573,7 +573,13 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		title = strings.TrimSpace(string(repoNameBytes))
 		repoName = title
 	} else {
-		repoName = filepath.Base(repoDir)
+		if repoInfo != nil && repoInfo.Name != "" {
+			repoName = repoInfo.Name
+		} else if base := filepath.Base(repoDir); base != "." && base != "" {
+			repoName = base
+		} else {
+			repoName = defaultTitle
+		}
 	}
 
 	var eapi string


### PR DESCRIPTION
The user reported an issue where repositories with the name `.` were appearing in the dashboard, making them unclickable and not making sense contextually. During site generation, repositories missing a `profiles/repo_name` file were falling back to `filepath.Base(repoDir)`. Since `repoDir` can be `.`, this evaluated to `.` causing the problem.

This PR addresses the issue by modifying `parseRepo` in `cmd/g2/site.go` to use `repoInfo.Name` if available. If not, it falls back to `filepath.Base(repoDir)` but explicitly rejects `.` and empty strings. Finally, it uses `defaultTitle` if all else fails.

---
*PR created automatically by Jules for task [5508381942915224192](https://jules.google.com/task/5508381942915224192) started by @arran4*