### PR TITLE
fix: clarify eclass terminology and fix IsDefinedLocally bug

### DIFF
--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -1058,7 +1058,6 @@ func getRepoEclasses(site *g2.SiteData, aggPackages map[string]*AggPackage) []*A
 									Name:  ec,
 									Repos: make(map[string]*g2.SiteData),
 								}
-								eclassMap[ec].Repos[site.RepoName] = site
 								seenPackages[ec] = make(map[string]bool)
 							}
 

--- a/templates/views/eclasses.html
+++ b/templates/views/eclasses.html
@@ -14,7 +14,7 @@
                     <tr>
                         <th>Eclass Name</th>
                         <th>Packages Using It</th>
-                        <th>Overlays Defining It</th>
+                        <th>Overlays Providing It</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/templates/views/repo_eclass.html
+++ b/templates/views/repo_eclass.html
@@ -20,8 +20,8 @@
                 </div>
                 {{if not (.Eclass.IsDefinedLocally $.Repo.RepoName)}}
                 <div class="alert alert-info mt-3 mb-0" role="alert">
-                    <i class="fas fa-info-circle me-2"></i> This eclass is not defined in this overlay. It is inherited from other overlays.
-                    View the <a href="{{$.BaseURL}}eclasses/{{.Eclass.Name}}/" class="alert-link">global eclass page</a> to see where it is defined.
+                    <i class="fas fa-info-circle me-2"></i> This eclass is not provided by this overlay. It is inherited / used from other overlays.
+                    View the <a href="{{$.BaseURL}}eclasses/{{.Eclass.Name}}/" class="alert-link">global eclass page</a> to see where it is provided.
                 </div>
                 {{end}}
             </div>

--- a/templates/views/repo_eclasses.html
+++ b/templates/views/repo_eclasses.html
@@ -20,8 +20,10 @@
                     </tr>
                 </thead>
                 <tbody>
+                {{$hasDefined := false}}
                 {{range .Eclasses}}
                     {{if .IsDefinedLocally $.Repo.RepoName}}
+                    {{$hasDefined = true}}
                     <tr>
                         <td>
                             <a href="{{$.BaseURL}}repos/{{$.Repo.RepoName}}/eclasses/{{.Name}}/" class="fw-bold">{{.Name}}</a>
@@ -31,6 +33,11 @@
                         </td>
                     </tr>
                     {{end}}
+                {{end}}
+                {{if not $hasDefined}}
+                    <tr>
+                        <td colspan="2" class="text-center text-muted fst-italic">No eclasses provided by this overlay.</td>
+                    </tr>
                 {{end}}
                 </tbody>
             </table>

--- a/templates/views/repo_eclasses.html
+++ b/templates/views/repo_eclasses.html
@@ -2,13 +2,13 @@
 <div class="row mb-3">
     <div class="col-12">
         <h1 class="h3">{{.Repo.RepoName}} - Eclasses</h1>
-        <p class="text-muted">Eclasses used by packages in this overlay.</p>
+        <p class="text-muted">Eclasses provided by this overlay and inherited/used by its packages.</p>
     </div>
 </div>
 
 <div class="card shadow-sm mb-4">
     <div class="card-header bg-light">
-        <h5 class="mb-0">Defined in this Overlay</h5>
+        <h5 class="mb-0">Provided by this Overlay</h5>
     </div>
     <div class="card-body">
         <div class="table-responsive">
@@ -40,7 +40,7 @@
 
 <div class="card shadow-sm">
     <div class="card-header bg-light">
-        <h5 class="mb-0">Inherited from Other Overlays</h5>
+        <h5 class="mb-0">Inherited / Used from Other Overlays</h5>
     </div>
     <div class="card-body">
         <div class="table-responsive">

--- a/templates/views/repo_index.html
+++ b/templates/views/repo_index.html
@@ -156,7 +156,7 @@
     <li><a href="uses/">USE Flags ({{len_or_zero .Repo.AggUseFlags}})</a></li>
     {{end}}
     {{if gt (len_or_zero .Repo.AggEclasses) 0}}
-    <li><a href="eclasses/">Eclasses ({{len_or_zero .Repo.AggEclasses}})</a></li>
+    <li><a href="eclasses/">Eclasses provided and used ({{len_or_zero .Repo.AggEclasses}})</a></li>
     {{end}}
     {{if gt (len .Repo.InfoPkgs) 0}}
     <li><a href="info_pkgs/">Info Packages ({{len .Repo.InfoPkgs}})</a></li>


### PR DESCRIPTION
Fixes a bug where all eclasses were being marked as locally defined in the `g2` static site generator, and updates template terminology from "defined" to "provided" vs "inherited / used".

---
*PR created automatically by Jules for task [17829423533588732481](https://jules.google.com/task/17829423533588732481) started by @arran4*