### PR TITLE
Fix cache-formats evaluation in layout.conf to support disabling cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -78,8 +78,8 @@ func GenerateCacheFS(cfs CacheFS, repoDir string, targetPkgs []string, genEclass
 
 	cacheFormats := []string{"md5-dict"} // Default if not found
 	if lc != nil {
-		if formats := lc.GetValuesAsSlice("cache-formats"); len(formats) > 0 {
-			cacheFormats = formats
+		if lc.HasKey("cache-formats") {
+			cacheFormats = lc.GetValuesAsSlice("cache-formats")
 		}
 	}
 

--- a/cmd/g2/cache.go
+++ b/cmd/g2/cache.go
@@ -82,8 +82,8 @@ func doCacheVerify(cfs g2.CacheFS, repoDir string) error {
 
 	cacheFormats := []string{"md5-dict"} // Default if not found
 	if lc != nil {
-		if formats := lc.GetValuesAsSlice("cache-formats"); len(formats) > 0 {
-			cacheFormats = formats
+		if lc.HasKey("cache-formats") {
+			cacheFormats = lc.GetValuesAsSlice("cache-formats")
 		}
 	}
 
@@ -218,8 +218,8 @@ func doCacheClean(cfs g2.CacheFS, repoDir string) error {
 
 	cacheFormats := []string{"md5-dict", "pms"} // check common ones during clean
 	if lc != nil {
-		if formats := lc.GetValuesAsSlice("cache-formats"); len(formats) > 0 {
-			cacheFormats = formats
+		if lc.HasKey("cache-formats") {
+			cacheFormats = lc.GetValuesAsSlice("cache-formats")
 		}
 	}
 

--- a/layout_conf.go
+++ b/layout_conf.go
@@ -100,6 +100,17 @@ func WriteLayoutConf(lc *LayoutConf, path string) error {
 	return nil
 }
 
+
+// HasKey returns true if a specific key exists
+func (lc *LayoutConf) HasKey(key string) bool {
+	for _, entry := range lc.Entries {
+		if entry.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
 // GetValue returns the value for a specific key
 func (lc *LayoutConf) GetValue(key string) string {
 	for _, entry := range lc.Entries {

--- a/layout_conf_test.go
+++ b/layout_conf_test.go
@@ -78,3 +78,25 @@ update-changelog = false`
 		}
 	}
 }
+
+func TestHasKey(t *testing.T) {
+	content := `masters = gentoo
+cache-formats =
+`
+	lc, err := ParseLayoutConfFromReader(strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !lc.HasKey("masters") {
+		t.Errorf("expected true for masters")
+	}
+
+	if !lc.HasKey("cache-formats") {
+		t.Errorf("expected true for cache-formats")
+	}
+
+	if lc.HasKey("non-existent") {
+		t.Errorf("expected false for non-existent")
+	}
+}


### PR DESCRIPTION
Fix cache-formats evaluation in layout.conf to support disabling cache

The previous implementation used `len(lc.GetValuesAsSlice("cache-formats")) > 0`
to check if cache formats were defined, falling back to the default `md5-dict`
if not. However, this prevented users from explicitly disabling the cache format
by specifying `cache-formats = ` in their `layout.conf` because an empty value
resulted in a length of 0.

This introduces a `HasKey` method to `LayoutConf` to explicitly check if the
configuration was provided, allowing an empty value to successfully override
the default fallback.

---
*PR created automatically by Jules for task [9427908692146564337](https://jules.google.com/task/9427908692146564337) started by @arran4*