### PR TITLE
🧪 [testing improvement] Add tests for ParseThirdPartyMirrorsFS and ParseThirdPartyMirrors

### DIFF
--- a/thirdpartymirrors_test.go
+++ b/thirdpartymirrors_test.go
@@ -1,9 +1,12 @@
 package g2
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 func TestParseThirdPartyMirrorsFromReader(t *testing.T) {
@@ -30,5 +33,67 @@ gentoo          https://distfiles.gentoo.org/distfiles
 
 	if !reflect.DeepEqual(mirrors, expected) {
 		t.Errorf("expected %v, got %v", expected, mirrors)
+	}
+}
+
+func TestParseThirdPartyMirrorsFS(t *testing.T) {
+	content := `
+apache          https://dlcdn.apache.org/
+`
+	sysFS := fstest.MapFS{
+		"profiles/thirdpartymirrors": &fstest.MapFile{
+			Data: []byte(content),
+		},
+	}
+
+	expected := map[string][]string{
+		"apache": {"https://dlcdn.apache.org/"},
+	}
+
+	mirrors, err := ParseThirdPartyMirrorsFS(sysFS, "profiles/thirdpartymirrors")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(mirrors, expected) {
+		t.Errorf("expected %v, got %v", expected, mirrors)
+	}
+
+	// Test missing file
+	_, err = ParseThirdPartyMirrorsFS(sysFS, "missing/file")
+	if err == nil {
+		t.Fatalf("expected error for missing file, got nil")
+	}
+}
+
+func TestParseThirdPartyMirrors(t *testing.T) {
+	content := `
+apache          https://dlcdn.apache.org/
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thirdpartymirrors")
+
+	err := os.WriteFile(path, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	expected := map[string][]string{
+		"apache": {"https://dlcdn.apache.org/"},
+	}
+
+	mirrors, err := ParseThirdPartyMirrors(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(mirrors, expected) {
+		t.Errorf("expected %v, got %v", expected, mirrors)
+	}
+
+	// Test missing file
+	_, err = ParseThirdPartyMirrors(filepath.Join(dir, "missing"))
+	if err == nil {
+		t.Fatalf("expected error for missing file, got nil")
 	}
 }


### PR DESCRIPTION
🎯 What: The testing gap for the untested public functions `ParseThirdPartyMirrorsFS` and `ParseThirdPartyMirrors` in `thirdpartymirrors.go`.
📊 Coverage: Added tests for both functions covering successful parsing and file not found errors using `testing/fstest.MapFS` and `t.TempDir()`.
✨ Result: Improved test coverage and ensuring correctness of parsing mirror configurations.

---
*PR created automatically by Jules for task [8788239977678830807](https://jules.google.com/task/8788239977678830807) started by @arran4*