### PR TITLE
🧪 Add tests for ParsePackageDeprecatedFS

### DIFF
--- a/package_deprecated_test.go
+++ b/package_deprecated_test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"reflect"
 	"testing"
+	"testing/fstest"
 )
 
 //go:embed testdata/package.deprecated
@@ -90,5 +91,58 @@ func TestSerializePackageDeprecated(t *testing.T) {
 		if !reflect.DeepEqual(parsed[i], data[i]) {
 			t.Errorf("mismatch after serialization at index %d:\nExpected: %+v\nGot:      %+v", i, data[i], parsed[i])
 		}
+	}
+}
+
+func TestParsePackageDeprecatedFS(t *testing.T) {
+	fsys := fstest.MapFS{
+		"profiles/package.deprecated": &fstest.MapFile{
+			Data: []byte(packageDeprecatedTestInput),
+		},
+	}
+
+	res, err := ParsePackageDeprecatedFS(fsys, "profiles/package.deprecated")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []PackageDeprecated{
+		{
+			Reason:      "Backwards compatibility package for pkg_resources that have been removed from >=dev-python/setuptools-82. Please migrate to importlib.{metadata,resources} and/or dev-python/packaging.",
+			Date:        "2026-03-25",
+			Author:      "Jane Doe",
+			AuthorEmail: "jane.doe@example.com",
+			Entries: []PackageDeprecatedEntry{
+				{Package: "dev-python/pkg-resources"},
+			},
+		},
+		{
+			Reason:      "The package has turned into complete AI slop. Every subsequent release introduces serious quality issues, and potential security concerns. Please ask upstreams to move away from it.",
+			Date:        "2025-11-25",
+			Author:      "John Smith",
+			AuthorEmail: "john.smith@example.com",
+			Entries: []PackageDeprecatedEntry{
+				{Package: "dev-python/autobahn"},
+			},
+		},
+	}
+
+	if len(res) != len(expected) {
+		t.Fatalf("expected %d entries, got %d", len(expected), len(res))
+	}
+
+	for i := range expected {
+		if !reflect.DeepEqual(res[i], expected[i]) {
+			t.Errorf("mismatch at index %d:\nExpected: %+v\nGot: %+v", i, expected[i], res[i])
+		}
+	}
+
+	// Test non-existent file
+	resMissing, errMissing := ParsePackageDeprecatedFS(fsys, "profiles/missing.deprecated")
+	if errMissing != nil {
+		t.Fatalf("expected no error for missing file, got %v", errMissing)
+	}
+	if resMissing != nil {
+		t.Fatalf("expected nil result for missing file, got %v", resMissing)
 	}
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the public function `ParsePackageDeprecatedFS` in `package_deprecated.go` had no tests covering its functionality.
📊 **Coverage:** Added test case `TestParsePackageDeprecatedFS` which successfully tests:
- Mocks a filesystem using `fstest.MapFS` and tests that parsing works appropriately and returns valid parsed outputs from simulated `profiles/package.deprecated` files.
- Checks edge case error-handling, verifying that an `os.IsNotExist` issue handles as expected (returning `nil, nil` with no error) when reading non-existent files.
✨ **Result:** Improved test coverage and reliability of the codebase.

---
*PR created automatically by Jules for task [4085254086998318245](https://jules.google.com/task/4085254086998318245) started by @arran4*