### PR TITLE
⚡ Optimize PadVersionTokens to use strings.Builder

### DIFF
--- a/ebuild.go
+++ b/ebuild.go
@@ -970,17 +970,50 @@ func CompareVersions(v1, v2 string) int {
 	return strings.Compare(v1, v2)
 }
 
-var (
-	reRevisionMatch = regexp.MustCompile(`-r(\d+)$`)
-	reDigitMatch    = regexp.MustCompile(`(\d+)`)
-)
-
 // PadVersionTokens produces a sortable string representation of a gentoo version.
 func PadVersionTokens(v string) string {
-	v = reRevisionMatch.ReplaceAllString(v, "+r$1")
-	return reDigitMatch.ReplaceAllStringFunc(v, func(s string) string {
-		return fmt.Sprintf("%010s", s)
-	})
+	replaceRIndex := -1
+	for i := len(v) - 1; i >= 0; i-- {
+		if v[i] >= '0' && v[i] <= '9' {
+			continue
+		}
+		if v[i] == 'r' && i > 0 && v[i-1] == '-' {
+			if i < len(v)-1 {
+				replaceRIndex = i - 1
+			}
+		}
+		break
+	}
+
+	var sb strings.Builder
+	// Over-allocate slightly to avoid resizing during padding
+	sb.Grow(len(v) + 30)
+
+	for i := 0; i < len(v); {
+		if i == replaceRIndex {
+			sb.WriteString("+r")
+			i += 2
+			continue
+		}
+
+		if v[i] >= '0' && v[i] <= '9' {
+			start := i
+			for i < len(v) && v[i] >= '0' && v[i] <= '9' {
+				i++
+			}
+			pad := 10 - (i - start)
+			if pad > 0 {
+				for j := 0; j < pad; j++ {
+					sb.WriteByte('0')
+				}
+			}
+			sb.WriteString(v[start:i])
+		} else {
+			sb.WriteByte(v[i])
+			i++
+		}
+	}
+	return sb.String()
 }
 
 // PackageAtom represents a parsed Gentoo package dependency specification.

--- a/pad_bench_test.go
+++ b/pad_bench_test.go
@@ -65,17 +65,37 @@ func padVersionTokensBuilder(v string) string {
 }
 
 func BenchmarkPadVersionTokensRegex(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		padVersionTokensRegex("1.2.3-r4")
-		padVersionTokensRegex("2.0_alpha1")
-		padVersionTokensRegex("3.0_beta2-r10")
+	benchmarks := []struct {
+		name string
+		v    string
+	}{
+		{"WithRevision", "1.2.3-r4"},
+		{"WithAlpha", "2.0_alpha1"},
+		{"Complex", "3.0_beta2-r10"},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				padVersionTokensRegex(bm.v)
+			}
+		})
 	}
 }
 
 func BenchmarkPadVersionTokensBuilder(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		padVersionTokensBuilder("1.2.3-r4")
-		padVersionTokensBuilder("2.0_alpha1")
-		padVersionTokensBuilder("3.0_beta2-r10")
+	benchmarks := []struct {
+		name string
+		v    string
+	}{
+		{"WithRevision", "1.2.3-r4"},
+		{"WithAlpha", "2.0_alpha1"},
+		{"Complex", "3.0_beta2-r10"},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				padVersionTokensBuilder(bm.v)
+			}
+		})
 	}
 }

--- a/pad_bench_test.go
+++ b/pad_bench_test.go
@@ -1,0 +1,81 @@
+package g2
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var (
+	reRevisionMatchB = regexp.MustCompile(`-r(\d+)$`)
+	reDigitMatchB    = regexp.MustCompile(`(\d+)`)
+)
+
+func padVersionTokensRegex(v string) string {
+	v = reRevisionMatchB.ReplaceAllString(v, "+r$1")
+	return reDigitMatchB.ReplaceAllStringFunc(v, func(s string) string {
+		return fmt.Sprintf("%010s", s)
+	})
+}
+
+func padVersionTokensBuilder(v string) string {
+	replaceRIndex := -1
+	for i := len(v) - 1; i >= 0; i-- {
+		if v[i] >= '0' && v[i] <= '9' {
+			continue
+		}
+		if v[i] == 'r' && i > 0 && v[i-1] == '-' {
+			if i < len(v)-1 {
+				replaceRIndex = i - 1
+			}
+		}
+		break
+	}
+
+	var sb strings.Builder
+	// Over-allocate slightly to avoid resizing during padding
+	sb.Grow(len(v) + 30)
+
+	for i := 0; i < len(v); {
+		if i == replaceRIndex {
+			sb.WriteString("+r")
+			i += 2
+			continue
+		}
+
+		if v[i] >= '0' && v[i] <= '9' {
+			start := i
+			for i < len(v) && v[i] >= '0' && v[i] <= '9' {
+				i++
+			}
+			pad := 10 - (i - start)
+			if pad > 0 {
+				for j := 0; j < pad; j++ {
+					sb.WriteByte('0')
+				}
+			}
+			sb.WriteString(v[start:i])
+		} else {
+			sb.WriteByte(v[i])
+			i++
+		}
+	}
+	return sb.String()
+}
+
+func BenchmarkPadVersionTokensRegex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		padVersionTokensRegex("1.2.3-r4")
+		padVersionTokensRegex("2.0_alpha1")
+		padVersionTokensRegex("3.0_beta2-r10")
+	}
+}
+
+func BenchmarkPadVersionTokensBuilder(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		padVersionTokensBuilder("1.2.3-r4")
+		padVersionTokensBuilder("2.0_alpha1")
+		padVersionTokensBuilder("3.0_beta2-r10")
+	}
+}


### PR DESCRIPTION
💡 **What:** Replaced regex-based string manipulation and `fmt.Sprintf` with a fast, low-allocation custom `strings.Builder` logic in `PadVersionTokens`.
🎯 **Why:** Regex and `fmt.Sprintf` overhead in an inner loop / heavily used helper function like `PadVersionTokens` leads to excessive allocations and high CPU time. The manual `strings.Builder` parses digits directly, avoiding regex execution and string formatting overhead, greatly speeding up version comparisons.
📊 **Measured Improvement:**
BenchmarkPadVersionTokensRegex-4     	  155853	      7505 ns/op	    1078 B/op	      48 allocs/op
BenchmarkPadVersionTokensBuilder-4   	 2537792	       473.7 ns/op	     144 B/op	       3 allocs/op
This results in a ~15x latency improvement (7500ns -> 470ns) and ~90% reduction in memory allocations (48 -> 3 per op).

---
*PR created automatically by Jules for task [14111586520125584806](https://jules.google.com/task/14111586520125584806) started by @arran4*