### PR TITLE
fix(lint): gracefully handle missing md5-cache for PG0802

### DIFF
--- a/lints/md5cache/md5cache_missing.go
+++ b/lints/md5cache/md5cache_missing.go
@@ -21,10 +21,22 @@ var ruleMD5CacheMissing = lints.RuleMetadata{
 
 func init() {
 	lints.RegisterRuleMetadata(ruleMD5CacheMissing)
-	lints.RegisterLintRule(&MD5CacheLintRule{})
+	lints.RegisterLintRule(&MD5CacheLintRule{fs: osFileStat{}})
 }
 
-type MD5CacheLintRule struct{}
+type FileStat interface {
+	Stat(name string) (os.FileInfo, error)
+}
+
+type osFileStat struct{}
+
+func (osFileStat) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+type MD5CacheLintRule struct {
+	fs FileStat
+}
 
 func (r *MD5CacheLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
 	return r.LintWithQA(repoDir, pkg, nil)
@@ -55,7 +67,7 @@ func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 	}
 
 	if !policySet {
-		if _, err := os.Stat(filepath.Join(repoDir, "metadata", "md5-cache")); os.IsNotExist(err) {
+		if _, err := r.fs.Stat(filepath.Join(repoDir, "metadata", "md5-cache")); os.IsNotExist(err) {
 			return nil
 		}
 	}
@@ -63,7 +75,7 @@ func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 	for _, ver := range pkg.Versions {
 		if ver.Ebuild != nil {
 			cachePath := filepath.Join(repoDir, "metadata", "md5-cache", pkg.Category, pkg.Name+"-"+ver.Version)
-			if _, err := os.Stat(cachePath); os.IsNotExist(err) {
+			if _, err := r.fs.Stat(cachePath); os.IsNotExist(err) {
 				sevStr := string(severity)
 				sevTitle := strings.ToUpper(sevStr[:1]) + sevStr[1:]
 				res := lints.LintResult{

--- a/lints/md5cache/md5cache_missing.go
+++ b/lints/md5cache/md5cache_missing.go
@@ -33,8 +33,11 @@ func (r *MD5CacheLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.Lin
 func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityWarning
+
+	policySet := false
 	if qa != nil && qa.Policies != nil {
 		if val, ok := qa.Policies["PG0802"]; ok {
+			policySet = true
 			if val == "ignore" {
 				return nil
 			}
@@ -48,6 +51,12 @@ func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g
 					severity = lints.SeverityWarning
 				}
 			}
+		}
+	}
+
+	if !policySet {
+		if _, err := os.Stat(filepath.Join(repoDir, "metadata", "md5-cache")); os.IsNotExist(err) {
+			return nil
 		}
 	}
 

--- a/lints/md5cache/md5cache_missing_test.go
+++ b/lints/md5cache/md5cache_missing_test.go
@@ -9,8 +9,19 @@ import (
 	"github.com/arran4/g2/lints"
 )
 
+type mockFileStat struct {
+	paths map[string]bool
+}
+
+func (m mockFileStat) Stat(name string) (os.FileInfo, error) {
+	if _, ok := m.paths[name]; ok {
+		return nil, nil // Return a fake file info, not used by code anyway.
+	}
+	return nil, os.ErrNotExist
+}
+
 func TestMD5CacheMissing(t *testing.T) {
-	tempDir := t.TempDir()
+	repoDir := "/mock/repo"
 
 	pkg := &g2.PackageData{
 		Category: "app-misc",
@@ -23,11 +34,9 @@ func TestMD5CacheMissing(t *testing.T) {
 		},
 	}
 
-	rule := &MD5CacheLintRule{}
-
 	// Test case 1: md5-cache directory does not exist, default QA policy
-	// Expect no results because rule should be dynamically disabled.
-	results := rule.LintWithQA(tempDir, pkg, nil)
+	rule := &MD5CacheLintRule{fs: mockFileStat{paths: map[string]bool{}}}
+	results := rule.LintWithQA(repoDir, pkg, nil)
 	if len(results) != 0 {
 		t.Errorf("Expected 0 results when md5-cache dir is missing, got %d", len(results))
 	}
@@ -38,7 +47,7 @@ func TestMD5CacheMissing(t *testing.T) {
 			"PG0802": "error",
 		},
 	}
-	results = rule.LintWithQA(tempDir, pkg, qaPolicy)
+	results = rule.LintWithQA(repoDir, pkg, qaPolicy)
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result when explicitly enforced, got %d", len(results))
 	} else if results[0].RuleMetadata.Severity != lints.SeverityError {
@@ -46,12 +55,10 @@ func TestMD5CacheMissing(t *testing.T) {
 	}
 
 	// Test case 3: md5-cache directory exists, but cache for package is missing
-	md5CacheDir := filepath.Join(tempDir, "metadata", "md5-cache")
-	if err := os.MkdirAll(md5CacheDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	results = rule.LintWithQA(tempDir, pkg, nil)
+	rule = &MD5CacheLintRule{fs: mockFileStat{paths: map[string]bool{
+		filepath.Join(repoDir, "metadata", "md5-cache"): true,
+	}}}
+	results = rule.LintWithQA(repoDir, pkg, nil)
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result when md5-cache dir exists but file is missing, got %d", len(results))
 	} else if results[0].RuleMetadata.Severity != lints.SeverityWarning {
@@ -59,16 +66,11 @@ func TestMD5CacheMissing(t *testing.T) {
 	}
 
 	// Test case 4: cache file exists
-	pkgCacheDir := filepath.Join(md5CacheDir, "app-misc")
-	if err := os.MkdirAll(pkgCacheDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	cacheFile := filepath.Join(pkgCacheDir, "foo-1.0")
-	if err := os.WriteFile(cacheFile, []byte(""), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	results = rule.LintWithQA(tempDir, pkg, nil)
+	rule = &MD5CacheLintRule{fs: mockFileStat{paths: map[string]bool{
+		filepath.Join(repoDir, "metadata", "md5-cache"): true,
+		filepath.Join(repoDir, "metadata", "md5-cache", "app-misc", "foo-1.0"): true,
+	}}}
+	results = rule.LintWithQA(repoDir, pkg, nil)
 	if len(results) != 0 {
 		t.Errorf("Expected 0 results when cache file exists, got %d", len(results))
 	}

--- a/lints/md5cache/md5cache_missing_test.go
+++ b/lints/md5cache/md5cache_missing_test.go
@@ -1,0 +1,75 @@
+package md5cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+func TestMD5CacheMissing(t *testing.T) {
+	tempDir := t.TempDir()
+
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "foo",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild:  &g2.Ebuild{},
+			},
+		},
+	}
+
+	rule := &MD5CacheLintRule{}
+
+	// Test case 1: md5-cache directory does not exist, default QA policy
+	// Expect no results because rule should be dynamically disabled.
+	results := rule.LintWithQA(tempDir, pkg, nil)
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results when md5-cache dir is missing, got %d", len(results))
+	}
+
+	// Test case 2: md5-cache directory does not exist, but explicitly enforced via QA policy
+	qaPolicy := &g2.QAPolicy{
+		Policies: map[string]string{
+			"PG0802": "error",
+		},
+	}
+	results = rule.LintWithQA(tempDir, pkg, qaPolicy)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result when explicitly enforced, got %d", len(results))
+	} else if results[0].RuleMetadata.Severity != lints.SeverityError {
+		t.Errorf("Expected severity to be error, got %v", results[0].RuleMetadata.Severity)
+	}
+
+	// Test case 3: md5-cache directory exists, but cache for package is missing
+	md5CacheDir := filepath.Join(tempDir, "metadata", "md5-cache")
+	if err := os.MkdirAll(md5CacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	results = rule.LintWithQA(tempDir, pkg, nil)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result when md5-cache dir exists but file is missing, got %d", len(results))
+	} else if results[0].RuleMetadata.Severity != lints.SeverityWarning {
+		t.Errorf("Expected severity to be warning, got %v", results[0].RuleMetadata.Severity)
+	}
+
+	// Test case 4: cache file exists
+	pkgCacheDir := filepath.Join(md5CacheDir, "app-misc")
+	if err := os.MkdirAll(pkgCacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cacheFile := filepath.Join(pkgCacheDir, "foo-1.0")
+	if err := os.WriteFile(cacheFile, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	results = rule.LintWithQA(tempDir, pkg, nil)
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results when cache file exists, got %d", len(results))
+	}
+}


### PR DESCRIPTION
This fixes an issue where the missing md5-cache lint rule `PG0802` was overly strict. If the repository does not have the `metadata/md5-cache` directory, `g2 lint` will now skip enforcing the rule unless explicitly mandated via the QA policy. A unit test is also provided to assert this behavior.

---
*PR created automatically by Jules for task [16440172670214438005](https://jules.google.com/task/16440172670214438005) started by @arran4*