### PR TITLE
feat: implement g2 ebuild delete and install

### DIFF
--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -41,6 +41,8 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 		fmt.Printf("\t\t %s \t\t %s\n", "next-revision", "Generate the next revision name and optionally inspect contents")
 		fmt.Printf("\t\t %s \t\t %s\n", "upsert", "Upsert an ebuild revision from stdin or file")
 		fmt.Printf("\t\t %s \t\t %s\n", "deduplicate", "Deduplicate and clean up old or redundant ebuilds")
+		fmt.Printf("\t\t %s \t\t %s\n", "delete", "Delete an ebuild and clean up associated files")
+		fmt.Printf("\t\t %s \t\t %s\n", "install", "Install an ebuild into a repository")
 	}
 
 	config := &CmdEbuildArgConfig{
@@ -111,6 +113,14 @@ func (cfg *MainArgConfig) cmdEbuild(args []string) error {
 	case "upsert":
 		if err := config.cmdEbuildUpsert(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("ebuild upsert: %w", err)
+		}
+	case "install":
+		if err := cfg.cmdEbuildInstall(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild install: %w", err)
+		}
+	case "delete":
+		if err := config.cmdEbuildDelete(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("ebuild delete: %w", err)
 		}
 	case "deduplicate":
 		if err := config.cmdEbuildDeduplicate(fs.Args()[1:]); err != nil {

--- a/cmd/g2/ebuild_delete.go
+++ b/cmd/g2/ebuild_delete.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/g2"
+)
+
+func (cfg *CmdEbuildArgConfig) cmdEbuildDelete(args []string) error {
+	fset := flag.NewFlagSet("delete", flag.ExitOnError)
+	repoDir := fset.String("repo", ".", "Repository directory (default: current directory)")
+
+	if err := fset.Parse(args); err != nil {
+		return err
+	}
+
+	if fset.NArg() == 0 {
+		return fmt.Errorf("usage: g2 ebuild delete <ebuild file | ebuild name + version range> [--repo <name / dir>]")
+	}
+
+	target := fset.Arg(0)
+
+	var removedFiles []string
+
+	if strings.HasSuffix(target, ".ebuild") {
+		// Specific file
+		absPath, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("resolving target path: %w", err)
+		}
+
+		if err := os.Remove(absPath); err != nil {
+			return fmt.Errorf("failed to remove %s: %w", absPath, err)
+		}
+		removedFiles = append(removedFiles, absPath)
+	} else {
+		// Package atom or name + version range
+		atom := g2.ParsePackageAtom(target)
+
+		repoPath := *repoDir
+		if repoPath == "" {
+			repoPath = "."
+		}
+
+		// Find matching ebuilds
+		var ebuildsToRemove []string
+
+		err := filepath.WalkDir(repoPath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && strings.HasSuffix(path, ".ebuild") {
+				vars := g2.ParseEbuildVariables(filepath.Base(path))
+				if vars != nil {
+					cat := ""
+					// Extract category from path
+					relPath, err := filepath.Rel(repoPath, path)
+					if err == nil {
+						parts := strings.Split(relPath, string(filepath.Separator))
+						if len(parts) >= 3 {
+							cat = parts[len(parts)-3]
+						}
+					}
+
+					match := true
+					if atom.Category != "" && cat != "" && atom.Category != cat {
+						match = false
+					}
+					if atom.Name != "" && vars["PN"] != atom.Name {
+						match = false
+					}
+
+					// Basic version matching if specified
+					if atom.Version != "" {
+						cmp := g2.CompareVersions(vars["PV"], atom.Version)
+
+						switch atom.Operator {
+						case "=":
+							if cmp != 0 {
+								match = false
+							}
+						case "<":
+							if cmp >= 0 {
+								match = false
+							}
+						case "<=":
+							if cmp > 0 {
+								match = false
+							}
+						case ">":
+							if cmp <= 0 {
+								match = false
+							}
+						case ">=":
+							if cmp < 0 {
+								match = false
+							}
+						case "~":
+							// Roughly same base version
+							pvParts := strings.Split(vars["PV"], ".")
+							avParts := strings.Split(atom.Version, ".")
+							if len(pvParts) > 0 && len(avParts) > 0 && pvParts[0] != avParts[0] {
+								match = false
+							}
+						default:
+							// If no operator is given but version is, default to exact match or prefix
+							if vars["PV"] != atom.Version {
+								match = false
+							}
+						}
+					}
+
+					if match {
+						ebuildsToRemove = append(ebuildsToRemove, path)
+					}
+				}
+			}
+			return nil
+		})
+
+		if err != nil {
+			return fmt.Errorf("walking repo: %w", err)
+		}
+
+		if len(ebuildsToRemove) == 0 {
+			return fmt.Errorf("no matching ebuilds found for %s", target)
+		}
+
+		for _, path := range ebuildsToRemove {
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("failed to remove %s: %w", path, err)
+			}
+			removedFiles = append(removedFiles, path)
+		}
+	}
+
+	repoPath := *repoDir
+	if repoPath == "" {
+		repoPath = "."
+	}
+
+	// Clean up for each removed file's directory
+	pkgDirs := make(map[string]bool)
+	for _, rem := range removedFiles {
+		pkgDirs[filepath.Dir(rem)] = true
+	}
+
+	for pkgDir := range pkgDirs {
+		entries, _ := os.ReadDir(pkgDir)
+		ebuildCount := 0
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".ebuild") {
+				ebuildCount++
+			}
+		}
+
+		manifestPath := filepath.Join(pkgDir, "Manifest")
+		if ebuildCount > 0 {
+			if manifest, err := g2.ParseManifest(manifestPath); err == nil {
+				_ = g2.CleanManifest(os.DirFS(pkgDir), ".", manifest)
+				_ = os.WriteFile(manifestPath, []byte(manifest.String()), 0644)
+			}
+		} else {
+			_ = os.Remove(manifestPath)
+			_ = os.Remove(filepath.Join(pkgDir, "metadata.xml"))
+
+			// Attempt to remove md5-cache
+			parts := strings.Split(filepath.ToSlash(pkgDir), "/")
+			if len(parts) >= 2 {
+				category := parts[len(parts)-2]
+				pkg := parts[len(parts)-1]
+
+				var repoRoot string
+				if filepath.IsAbs(pkgDir) {
+					repoRoot = filepath.Join(parts[:len(parts)-2]...)
+					repoRoot = "/" + repoRoot
+				} else {
+					repoRoot = filepath.Join(parts[:len(parts)-2]...)
+				}
+
+				md5CacheDir := filepath.Join(repoRoot, "metadata", "md5-cache", category)
+				if cacheEntries, err := os.ReadDir(md5CacheDir); err == nil {
+					for _, ce := range cacheEntries {
+						if strings.HasPrefix(ce.Name(), pkg+"-") && len(ce.Name()) > len(pkg)+1 && (ce.Name()[len(pkg)] == '-' && ce.Name()[len(pkg)+1] >= '0' && ce.Name()[len(pkg)+1] <= '9') {
+							_ = os.Remove(filepath.Join(md5CacheDir, ce.Name()))
+						}
+					}
+				}
+			}
+
+			_ = os.RemoveAll(pkgDir)
+		}
+	}
+
+	// Re-run manifest check for all modified packages
+	manifestCfg := &CmdManifestArgConfig{MainArgConfig: cfg.MainArgConfig}
+	for pkgDir := range pkgDirs {
+		if _, err := os.Stat(pkgDir); err == nil {
+			if err := manifestCfg.cmdVerify([]string{"-fix", pkgDir}, g2.AllHashes); err != nil {
+				log.Printf("Warning: updating manifest: %v", err)
+			}
+		}
+	}
+
+	if err := cfg.MainArgConfig.cmdUseDiscover([]string{repoPath}); err != nil {
+		log.Printf("Warning: updating use.desc/use.local.desc: %v", err)
+	}
+
+	if err := cfg.MainArgConfig.cmdPkgDescIndexGenerate([]string{repoPath}); err != nil {
+		log.Printf("Warning: generating pkg_desc_index: %v", err)
+	}
+
+	if err := cfg.MainArgConfig.cmdCacheGenerate([]string{repoPath}); err != nil {
+		log.Printf("Warning: generating md5-cache: %v", err)
+	}
+
+	fmt.Printf("Deleted %d ebuild(s) and cleaned up associated files.\n", len(removedFiles))
+	return nil
+}

--- a/cmd/g2/ebuild_delete.go
+++ b/cmd/g2/ebuild_delete.go
@@ -208,15 +208,15 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildDelete(args []string) error {
 		}
 	}
 
-	if err := cfg.MainArgConfig.cmdUseDiscover([]string{repoPath}); err != nil {
+	if err := cfg.cmdUseDiscover([]string{repoPath}); err != nil {
 		log.Printf("Warning: updating use.desc/use.local.desc: %v", err)
 	}
 
-	if err := cfg.MainArgConfig.cmdPkgDescIndexGenerate([]string{repoPath}); err != nil {
+	if err := cfg.cmdPkgDescIndexGenerate([]string{repoPath}); err != nil {
 		log.Printf("Warning: generating pkg_desc_index: %v", err)
 	}
 
-	if err := cfg.MainArgConfig.cmdCacheGenerate([]string{repoPath}); err != nil {
+	if err := cfg.cmdCacheGenerate([]string{repoPath}); err != nil {
 		log.Printf("Warning: generating md5-cache: %v", err)
 	}
 

--- a/cmd/g2/ebuild_install.go
+++ b/cmd/g2/ebuild_install.go
@@ -76,14 +76,13 @@ func (cfg *MainArgConfig) cmdEbuildInstall(args []string) error {
 
 	// ebuild is missing EAPI / doesn't get fully parsed by ParseEbuildVariablesFromReader, so we can try to parse it via parser to get CATEGORY if it's there
 	var ebuildParsed *g2.Ebuild
-	var err error
+
 	if ebuildPath != "-" {
-		ebuildParsed, err = g2.ParseEbuild(os.DirFS(filepath.Dir(ebuildPath)), filepath.Base(ebuildPath), g2.ParseVariables)
+		ebuildParsed, _ = g2.ParseEbuild(os.DirFS(filepath.Dir(ebuildPath)), filepath.Base(ebuildPath), g2.ParseVariables)
 	}
-	err = nil
 
 	category := *categoryFlag
-	if category == "" && err == nil && ebuildParsed != nil {
+	if category == "" && ebuildParsed != nil {
 		if c, ok := ebuildParsed.Vars["CATEGORY"]; ok && c != "" {
 			category = c
 		}
@@ -135,12 +134,12 @@ func (cfg *MainArgConfig) cmdEbuildInstall(args []string) error {
 				if err != nil {
 					return err
 				}
-				defer source.Close()
+				defer func() { _ = source.Close() }()
 				destination, err := os.Create(dest)
 				if err != nil {
 					return err
 				}
-				defer destination.Close()
+				defer func() { _ = destination.Close() }()
 				_, err = io.Copy(destination, source)
 				return err
 			}(); err != nil {

--- a/cmd/g2/ebuild_install.go
+++ b/cmd/g2/ebuild_install.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/arran4/g2"
+)
+
+func (cfg *MainArgConfig) cmdEbuildInstall(args []string) error {
+	fs := flag.NewFlagSet("install", flag.ExitOnError)
+	repoFlag := fs.String("repo", ".", "Repository directory (default: current directory)")
+	categoryFlag := fs.String("category", "", "The category for the ebuild (optional, auto-detected if possible)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: g2 ebuild install --repo <repo name / dir> <ebuild fn | - for stdin> [-- [FILES..]]")
+	}
+
+	var positionalArgs []string
+	var fileArgs []string
+	foundDashDash := false
+
+	fsArgs := fs.Args()
+	for i, arg := range fsArgs {
+		if arg == "--" {
+			positionalArgs = fsArgs[:i]
+			fileArgs = fsArgs[i+1:]
+			foundDashDash = true
+			break
+		}
+	}
+
+	if !foundDashDash {
+		positionalArgs = fsArgs
+	}
+
+	if len(positionalArgs) == 0 {
+		return fmt.Errorf("usage: g2 ebuild install --repo <repo name / dir> <ebuild fn | - for stdin> [-- [FILES..]]")
+	}
+
+	ebuildPath := positionalArgs[0]
+	repoPath := *repoFlag
+
+	var inputContent []byte
+	var readErr error
+	if ebuildPath == "-" {
+		inputContent, readErr = io.ReadAll(os.Stdin)
+	} else {
+		inputContent, readErr = os.ReadFile(ebuildPath)
+	}
+
+	if readErr != nil {
+		return fmt.Errorf("failed to read input: %w", readErr)
+	}
+
+	vars := g2.ParseEbuildVariablesFromReader(bytes.NewReader(inputContent))
+	if vars == nil || vars["PN"] == "" || vars["PV"] == "" {
+		if ebuildPath != "-" {
+			vars = g2.ParseEbuildVariables(filepath.Base(ebuildPath))
+		}
+		if vars == nil || vars["PN"] == "" || vars["PV"] == "" {
+			return fmt.Errorf("could not parse PN and PV from ebuild")
+		}
+	}
+
+	pn := vars["PN"]
+	pv := vars["PV"]
+
+	// ebuild is missing EAPI / doesn't get fully parsed by ParseEbuildVariablesFromReader, so we can try to parse it via parser to get CATEGORY if it's there
+	var ebuildParsed *g2.Ebuild
+	var err error
+	if ebuildPath != "-" {
+		ebuildParsed, err = g2.ParseEbuild(os.DirFS(filepath.Dir(ebuildPath)), filepath.Base(ebuildPath), g2.ParseVariables)
+	}
+	err = nil
+
+	category := *categoryFlag
+	if category == "" && err == nil && ebuildParsed != nil {
+		if c, ok := ebuildParsed.Vars["CATEGORY"]; ok && c != "" {
+			category = c
+		}
+	}
+
+	if category == "" && ebuildPath != "-" {
+		absEbuildPath, err := filepath.Abs(ebuildPath)
+		if err == nil {
+			dir1 := filepath.Dir(absEbuildPath)
+			dir2 := filepath.Dir(dir1)
+			catInfer := filepath.Base(dir2)
+			if catInfer != "." && catInfer != "/" {
+				category = catInfer
+			}
+		}
+	}
+
+	if category == "" {
+		return fmt.Errorf("could not determine category for ebuild, please specify with -category")
+	}
+
+	targetPkgDir := filepath.Join(repoPath, category, pn)
+	if err := os.MkdirAll(targetPkgDir, 0755); err != nil {
+		return fmt.Errorf("creating target package directory: %w", err)
+	}
+
+	targetEbuildPath := filepath.Join(targetPkgDir, fmt.Sprintf("%s-%s.ebuild", pn, pv))
+	if err := os.WriteFile(targetEbuildPath, inputContent, 0644); err != nil {
+		return fmt.Errorf("writing ebuild: %w", err)
+	}
+
+	if len(fileArgs) > 0 {
+		filesDir := filepath.Join(targetPkgDir, "files")
+		if err := os.MkdirAll(filesDir, 0755); err != nil {
+			return fmt.Errorf("creating files directory: %w", err)
+		}
+
+		for _, f := range fileArgs {
+			dest := filepath.Join(filesDir, filepath.Base(f))
+			if err := func() error {
+				sourceFileStat, err := os.Stat(f)
+				if err != nil {
+					return err
+				}
+				if !sourceFileStat.Mode().IsRegular() {
+					return fmt.Errorf("%s is not a regular file", f)
+				}
+				source, err := os.Open(f)
+				if err != nil {
+					return err
+				}
+				defer source.Close()
+				destination, err := os.Create(dest)
+				if err != nil {
+					return err
+				}
+				defer destination.Close()
+				_, err = io.Copy(destination, source)
+				return err
+			}(); err != nil {
+				return fmt.Errorf("copying file %s: %w", f, err)
+			}
+		}
+	}
+
+	manifestCfg := &CmdManifestArgConfig{MainArgConfig: cfg}
+	if err := manifestCfg.cmdVerify([]string{"-fix", targetPkgDir}, g2.AllHashes); err != nil {
+		log.Printf("Warning: updating manifest: %v", err)
+	}
+
+	if err := cfg.cmdUseDiscover([]string{repoPath}); err != nil {
+		log.Printf("Warning: updating use.desc/use.local.desc: %v", err)
+	}
+
+	if err := cfg.cmdPkgDescIndexGenerate([]string{repoPath}); err != nil {
+		log.Printf("Warning: generating pkg_desc_index: %v", err)
+	}
+
+	if err := cfg.cmdCacheGenerate([]string{repoPath}); err != nil {
+		log.Printf("Warning: generating md5-cache: %v", err)
+	}
+
+	fmt.Printf("Installed %s to %s\n", filepath.Base(targetEbuildPath), targetPkgDir)
+
+	return nil
+}


### PR DESCRIPTION
Implements the `g2 ebuild delete` and `g2 ebuild install` subcommands to allow for robust insertion or deletion of ebuilds and associated repository caches/metadata.

---
*PR created automatically by Jules for task [11548396294861140295](https://jules.google.com/task/11548396294861140295) started by @arran4*