### PR TITLE
Refactor cmd/g2 filesystem implementations to use a unified interface

### DIFF
--- a/cmd/g2/overlay_init.go
+++ b/cmd/g2/overlay_init.go
@@ -4,39 +4,15 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
-	"path/filepath"
 )
 
 type OverlayInitArgs struct {
 	Name          string
 	EapiVersion   string
 	LayoutConfUrl string
-}
-
-// SimpleFS provides a minimal interface for file system operations needed by overlay init.
-type SimpleFS interface {
-	MkdirAll(path string, perm os.FileMode) error
-	Stat(name string) (os.FileInfo, error)
-	WriteFile(name string, data []byte, perm os.FileMode) error
-}
-
-// osSimpleFS implements SimpleFS using the os package.
-type osSimpleFS struct {
-	baseDir string
-}
-
-func (fs *osSimpleFS) MkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(filepath.Join(fs.baseDir, path), perm)
-}
-
-func (fs *osSimpleFS) Stat(name string) (os.FileInfo, error) {
-	return os.Stat(filepath.Join(fs.baseDir, name))
-}
-
-func (fs *osSimpleFS) WriteFile(name string, data []byte, perm os.FileMode) error {
-	return os.WriteFile(filepath.Join(fs.baseDir, name), data, perm)
 }
 
 func (cfg *MainArgConfig) cmdOverlayInit(args []string) error {
@@ -71,20 +47,20 @@ func (cfg *MainArgConfig) cmdOverlayInit(args []string) error {
 		return fmt.Errorf("failed to get current working directory: %w", err)
 	}
 
-	targetFs := &osSimpleFS{baseDir: cwd}
+	targetFs := NewOSFS(cwd)
 
 	return InitOverlay(targetFs, initArgs)
 }
 
-func InitOverlay(fs SimpleFS, args OverlayInitArgs) error {
+func InitOverlay(targetFs WritableFS, args OverlayInitArgs) error {
 	// Create profiles directory
-	if err := fs.MkdirAll("profiles", 0755); err != nil {
+	if err := targetFs.MkdirAll("profiles", 0755); err != nil {
 		return fmt.Errorf("failed to create profiles directory: %w", err)
 	}
 
 	// Create profiles/repo_name
-	if _, err := fs.Stat("profiles/repo_name"); os.IsNotExist(err) {
-		if err := fs.WriteFile("profiles/repo_name", []byte(args.Name+"\n"), 0644); err != nil {
+	if _, err := fs.Stat(targetFs, "profiles/repo_name"); os.IsNotExist(err) {
+		if err := targetFs.WriteFile("profiles/repo_name", []byte(args.Name+"\n"), 0644); err != nil {
 			return fmt.Errorf("failed to write profiles/repo_name: %w", err)
 		}
 		fmt.Printf("Created profiles/repo_name with '%s'\n", args.Name)
@@ -93,8 +69,8 @@ func InitOverlay(fs SimpleFS, args OverlayInitArgs) error {
 	}
 
 	// Create profiles/eapi
-	if _, err := fs.Stat("profiles/eapi"); os.IsNotExist(err) {
-		if err := fs.WriteFile("profiles/eapi", []byte(args.EapiVersion+"\n"), 0644); err != nil {
+	if _, err := fs.Stat(targetFs, "profiles/eapi"); os.IsNotExist(err) {
+		if err := targetFs.WriteFile("profiles/eapi", []byte(args.EapiVersion+"\n"), 0644); err != nil {
 			return fmt.Errorf("failed to write profiles/eapi: %w", err)
 		}
 		fmt.Printf("Created profiles/eapi with '%s'\n", args.EapiVersion)
@@ -103,12 +79,12 @@ func InitOverlay(fs SimpleFS, args OverlayInitArgs) error {
 	}
 
 	// Create metadata directory
-	if err := fs.MkdirAll("metadata", 0755); err != nil {
+	if err := targetFs.MkdirAll("metadata", 0755); err != nil {
 		return fmt.Errorf("failed to create metadata directory: %w", err)
 	}
 
 	// Create metadata/layout.conf
-	if _, err := fs.Stat("metadata/layout.conf"); os.IsNotExist(err) {
+	if _, err := fs.Stat(targetFs, "metadata/layout.conf"); os.IsNotExist(err) {
 		var content []byte
 		if args.LayoutConfUrl != "" {
 			fmt.Printf("Downloading layout.conf from %s...\n", args.LayoutConfUrl)
@@ -126,7 +102,7 @@ func InitOverlay(fs SimpleFS, args OverlayInitArgs) error {
 			}
 		}
 		if len(content) > 0 {
-			if err := fs.WriteFile("metadata/layout.conf", content, 0644); err != nil {
+			if err := targetFs.WriteFile("metadata/layout.conf", content, 0644); err != nil {
 				return fmt.Errorf("failed to write metadata/layout.conf: %w", err)
 			}
 			fmt.Printf("Created metadata/layout.conf\n")

--- a/cmd/g2/overlay_init_test.go
+++ b/cmd/g2/overlay_init_test.go
@@ -5,48 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
-	"time"
 )
 
-type mockFS struct {
-	files map[string][]byte
-}
-
-func newMockFS() *mockFS {
-	return &mockFS{files: make(map[string][]byte)}
-}
-
-func (m *mockFS) MkdirAll(path string, perm os.FileMode) error {
-	return nil
-}
-
-func (m *mockFS) Stat(name string) (os.FileInfo, error) {
-	if _, ok := m.files[name]; ok {
-		return mockFileInfo{name: name}, nil
-	}
-	return nil, os.ErrNotExist
-}
-
-func (m *mockFS) WriteFile(name string, data []byte, perm os.FileMode) error {
-	m.files[name] = data
-	return nil
-}
-
-type mockFileInfo struct {
-	name string
-}
-
-func (m mockFileInfo) Name() string       { return m.name }
-func (m mockFileInfo) Size() int64        { return 0 }
-func (m mockFileInfo) Mode() os.FileMode  { return 0 }
-func (m mockFileInfo) ModTime() time.Time { return time.Time{} }
-func (m mockFileInfo) IsDir() bool        { return false }
-func (m mockFileInfo) Sys() interface{}   { return nil }
-
 func TestInitOverlay(t *testing.T) {
-	fs := newMockFS()
+	fs := NewMockFS()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "masters = gentoo\n")
@@ -65,29 +28,29 @@ func TestInitOverlay(t *testing.T) {
 	}
 
 	// check profiles/repo_name
-	content, ok := fs.files["profiles/repo_name"]
+	fileInfo, ok := fs.MapFS["profiles/repo_name"]
 	if !ok {
 		t.Fatalf("Failed to find profiles/repo_name")
 	}
-	if string(content) != "test-overlay\n" {
-		t.Errorf("Unexpected content in profiles/repo_name: %s", content)
+	if string(fileInfo.Data) != "test-overlay\n" {
+		t.Errorf("Unexpected content in profiles/repo_name: %s", fileInfo.Data)
 	}
 
 	// check profiles/eapi
-	content, ok = fs.files["profiles/eapi"]
+	fileInfo, ok = fs.MapFS["profiles/eapi"]
 	if !ok {
 		t.Fatalf("Failed to find profiles/eapi")
 	}
-	if string(content) != "8\n" {
-		t.Errorf("Unexpected content in profiles/eapi: %s", content)
+	if string(fileInfo.Data) != "8\n" {
+		t.Errorf("Unexpected content in profiles/eapi: %s", fileInfo.Data)
 	}
 
 	// check metadata/layout.conf
-	content, ok = fs.files["metadata/layout.conf"]
+	fileInfo, ok = fs.MapFS["metadata/layout.conf"]
 	if !ok {
 		t.Fatalf("Failed to find metadata/layout.conf")
 	}
-	if !bytes.Contains(content, []byte("masters = gentoo\n")) {
-		t.Errorf("Unexpected content in metadata/layout.conf: %s", content)
+	if !bytes.Contains(fileInfo.Data, []byte("masters = gentoo\n")) {
+		t.Errorf("Unexpected content in metadata/layout.conf: %s", fileInfo.Data)
 	}
 }


### PR DESCRIPTION
The user requested merging `MockFS`, `OSFS`, and `SimpleFS`. Currently, `SimpleFS` is used in `cmd/g2/overlay_init.go`, while `WritableFS`, `OSFS`, and `MockFS` are used elsewhere. This PR consolidates all file system operations in `cmd/g2/overlay_init.go` to use the unified `WritableFS` interface, effectively resolving the redundant duplication of FS abstraction.

---
*PR created automatically by Jules for task [8367874514409675210](https://jules.google.com/task/8367874514409675210) started by @arran4*