### PR TITLE
feat(lints): Add missing_manifest rule

### DIFF
--- a/lints/ebuild/missing_manifest.go
+++ b/lints/ebuild/missing_manifest.go
@@ -1,0 +1,94 @@
+package ebuild
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var ruleMissingManifest = lints.RuleMetadata{
+	ID:          "MissingManifest",
+	Title:       "Missing Manifest entry for distfile",
+	Description: "Checks for distfiles that are required by an ebuild but not listed in the Manifest.",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourcePkgcheck,
+	Tags:        []string{"ebuild", "manifest"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleMissingManifest)
+	lints.RegisterLintRule(&MissingManifestLintRule{})
+}
+
+type MissingManifestLintRule struct{}
+
+func (r *MissingManifestLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *MissingManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	manifestFiles := make(map[string]bool)
+	if pkg.Manifest != nil {
+		for _, entry := range pkg.Manifest.Entries {
+			if entry.Type == "DIST" {
+				manifestFiles[entry.Filename] = true
+			}
+		}
+	}
+
+	pkgDir := filepath.Join(repoDir, pkg.Category, pkg.Name)
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		return results
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".ebuild") {
+			ebuildName := entry.Name()
+			version := strings.TrimSuffix(ebuildName, ".ebuild")
+			if strings.HasPrefix(version, pkg.Name+"-") {
+				version = strings.TrimPrefix(version, pkg.Name+"-")
+			}
+
+			parsedEbuild, err := g2.ParseEbuild(os.DirFS(pkgDir), ebuildName, g2.ParseFull)
+			if err != nil {
+				continue
+			}
+
+			srcUriVar := parsedEbuild.Vars["SRC_URI"]
+			if srcUriVar == "" {
+				continue
+			}
+			dummyContent := fmt.Sprintf("SRC_URI=\"%s\"", srcUriVar)
+			uris, err := g2.ExtractURIs(dummyContent, parsedEbuild.Vars)
+			if err != nil {
+				continue
+			}
+
+			var missingFiles []string
+			for _, uri := range uris {
+				if !manifestFiles[uri.Filename] {
+					missingFiles = append(missingFiles, uri.Filename)
+				}
+			}
+
+			if len(missingFiles) > 0 {
+				res := lints.LintResult{
+					RuleMetadata: ruleMissingManifest,
+					Message:      fmt.Sprintf("[%s] version %s: distfile missing from Manifest: [ %s ]", ruleMissingManifest.Severity, version, strings.Join(missingFiles, ", ")),
+					Package:      pkg.Category + "/" + pkg.Name,
+					File:         ebuildName,
+				}
+				results = append(results, res)
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/missing_manifest.go
+++ b/lints/ebuild/missing_manifest.go
@@ -2,6 +2,7 @@ package ebuild
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,6 +32,10 @@ func (r *MissingManifestLintRule) Lint(repoDir string, pkg *g2.PackageData) []li
 }
 
 func (r *MissingManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	return r.lintWithFS(os.DirFS(repoDir), filepath.Join(pkg.Category, pkg.Name), pkg, qa)
+}
+
+func (r *MissingManifestLintRule) lintWithFS(repoFS fs.FS, pkgDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
 	var results []lints.LintResult
 
 	manifestFiles := make(map[string]bool)
@@ -42,8 +47,12 @@ func (r *MissingManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData
 		}
 	}
 
-	pkgDir := filepath.Join(repoDir, pkg.Category, pkg.Name)
-	entries, err := os.ReadDir(pkgDir)
+	entries, err := fs.ReadDir(repoFS, pkgDir)
+	if err != nil {
+		return results
+	}
+
+	pkgFS, err := fs.Sub(repoFS, pkgDir)
 	if err != nil {
 		return results
 	}
@@ -56,7 +65,7 @@ func (r *MissingManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData
 				version = strings.TrimPrefix(version, pkg.Name+"-")
 			}
 
-			parsedEbuild, err := g2.ParseEbuild(os.DirFS(pkgDir), ebuildName, g2.ParseFull)
+			parsedEbuild, err := g2.ParseEbuild(pkgFS, ebuildName, g2.ParseFull)
 			if err != nil {
 				continue
 			}

--- a/lints/ebuild/missing_manifest_test.go
+++ b/lints/ebuild/missing_manifest_test.go
@@ -1,0 +1,65 @@
+package ebuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestMissingManifestLintRule(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "missing-manifest-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	category := "app-test"
+	name := "testpkg"
+	pkgDir := filepath.Join(tempDir, category, name)
+
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatalf("failed to create package dir: %v", err)
+	}
+
+	ebuildContent1 := `SRC_URI="https://example.com/file1.tar.gz"`
+	if err := os.WriteFile(filepath.Join(pkgDir, "testpkg-1.0.ebuild"), []byte(ebuildContent1), 0644); err != nil {
+		t.Fatalf("failed to write ebuild: %v", err)
+	}
+
+	ebuildContent2 := `SRC_URI="https://example.com/file2.tar.gz"`
+	if err := os.WriteFile(filepath.Join(pkgDir, "testpkg-2.0.ebuild"), []byte(ebuildContent2), 0644); err != nil {
+		t.Fatalf("failed to write ebuild: %v", err)
+	}
+
+	pkgData := &g2.PackageData{
+		Category: category,
+		Name:     name,
+		Manifest: &g2.Manifest{
+			Entries: []*g2.ManifestEntry{
+				{
+					Type:     "DIST",
+					Filename: "file1.tar.gz",
+				},
+			},
+		},
+	}
+
+	rule := &MissingManifestLintRule{}
+	results := rule.Lint(tempDir, pkgData)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	expectedMsg := "[Error] version 2.0: distfile missing from Manifest: [ file2.tar.gz ]"
+	if results[0].Message != expectedMsg {
+		t.Errorf("expected message '%s', got '%s'", expectedMsg, results[0].Message)
+	}
+	if results[0].File != "testpkg-2.0.ebuild" {
+		t.Errorf("expected file 'testpkg-2.0.ebuild', got '%s'", results[0].File)
+	}
+}

--- a/lints/ebuild/missing_manifest_test.go
+++ b/lints/ebuild/missing_manifest_test.go
@@ -1,39 +1,25 @@
 package ebuild
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/arran4/g2"
+	"testing/fstest"
 )
 
 func TestMissingManifestLintRule(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "missing-manifest-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
+	mockFS := fstest.MapFS{
+		filepath.Join("app-test", "testpkg", "testpkg-1.0.ebuild"): &fstest.MapFile{
+			Data: []byte(`SRC_URI="https://example.com/file1.tar.gz"`),
+		},
+		filepath.Join("app-test", "testpkg", "testpkg-2.0.ebuild"): &fstest.MapFile{
+			Data: []byte(`SRC_URI="https://example.com/file2.tar.gz"`),
+		},
 	}
-	defer func() {
-		_ = os.RemoveAll(tempDir)
-	}()
 
 	category := "app-test"
 	name := "testpkg"
-	pkgDir := filepath.Join(tempDir, category, name)
-
-	if err := os.MkdirAll(pkgDir, 0755); err != nil {
-		t.Fatalf("failed to create package dir: %v", err)
-	}
-
-	ebuildContent1 := `SRC_URI="https://example.com/file1.tar.gz"`
-	if err := os.WriteFile(filepath.Join(pkgDir, "testpkg-1.0.ebuild"), []byte(ebuildContent1), 0644); err != nil {
-		t.Fatalf("failed to write ebuild: %v", err)
-	}
-
-	ebuildContent2 := `SRC_URI="https://example.com/file2.tar.gz"`
-	if err := os.WriteFile(filepath.Join(pkgDir, "testpkg-2.0.ebuild"), []byte(ebuildContent2), 0644); err != nil {
-		t.Fatalf("failed to write ebuild: %v", err)
-	}
 
 	pkgData := &g2.PackageData{
 		Category: category,
@@ -49,10 +35,10 @@ func TestMissingManifestLintRule(t *testing.T) {
 	}
 
 	rule := &MissingManifestLintRule{}
-	results := rule.Lint(tempDir, pkgData)
+	results := rule.lintWithFS(mockFS, filepath.Join(category, name), pkgData, nil)
 
 	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
+		t.Fatalf("expected 1 result, got %d: %v", len(results), results)
 	}
 
 	expectedMsg := "[Error] version 2.0: distfile missing from Manifest: [ file2.tar.gz ]"


### PR DESCRIPTION
Added `MissingManifestLintRule` to detect when distfiles referenced in `SRC_URI` are missing from the `Manifest` file, matching pkgcheck's `MissingManifest` warning.

---
*PR created automatically by Jules for task [17366582229754886753](https://jules.google.com/task/17366582229754886753) started by @arran4*