### PR TITLE
feat: Add Flutter to Gentoo version conversion

### DIFF
--- a/cmd/g2/versions.go
+++ b/cmd/g2/versions.go
@@ -31,7 +31,7 @@ func (cfg *MainArgConfig) CmdVersions(args []string) error {
 		return compareVersions(args[1:])
 	case "convert":
 		if len(args) < 3 {
-			return fmt.Errorf("usage: versions convert <semantic-to-gentoo|gentoo-to-semantic> <version string | ->")
+			return fmt.Errorf("usage: versions convert <semantic-to-gentoo|gentoo-to-semantic|flutter-to-gentoo|gentoo-to-flutter> <version string | ->")
 		}
 		mode := args[1]
 		input := args[2]
@@ -42,8 +42,12 @@ func (cfg *MainArgConfig) CmdVersions(args []string) error {
 			processFunc = SemanticToGentoo
 		case "gentoo-to-semantic":
 			processFunc = GentooToSemantic
+		case "flutter-to-gentoo":
+			processFunc = FlutterToGentoo
+		case "gentoo-to-flutter":
+			processFunc = GentooToFlutter
 		default:
-			return fmt.Errorf("unknown convert mode: %s, must be semantic-to-gentoo or gentoo-to-semantic", mode)
+			return fmt.Errorf("unknown convert mode: %s, must be semantic-to-gentoo, gentoo-to-semantic, flutter-to-gentoo, or gentoo-to-flutter", mode)
 		}
 
 		if input == "-" {
@@ -186,6 +190,50 @@ func SemanticToGentoo(v string) string {
 	}
 
 	return res
+}
+
+// FlutterToGentoo converts a Flutter version string to a Gentoo version string.
+func FlutterToGentoo(v string) string {
+	if !strings.HasSuffix(v, ".pre") {
+		return v
+	}
+
+	// strip .pre
+	v = strings.TrimSuffix(v, ".pre")
+
+	// split by -
+	parts := strings.Split(v, "-")
+	if len(parts) != 2 {
+		return v // fallback
+	}
+
+	base := parts[0]
+	preParts := strings.Split(parts[1], ".")
+	if len(preParts) == 2 {
+		return fmt.Sprintf("%s_pre%s_p%s", base, preParts[0], preParts[1])
+	} else if len(preParts) == 1 {
+		return fmt.Sprintf("%s_pre%s", base, preParts[0])
+	}
+
+	return v
+}
+
+// GentooToFlutter converts a Gentoo version string to a Flutter version string.
+func GentooToFlutter(v string) string {
+	// looking for _preX_pY or _preX
+	if !strings.Contains(v, "_pre") {
+		return v
+	}
+
+	parts := strings.SplitN(v, "_pre", 2)
+	base := parts[0]
+
+	if strings.Contains(parts[1], "_p") {
+		subParts := strings.SplitN(parts[1], "_p", 2)
+		return fmt.Sprintf("%s-%s.%s.pre", base, subParts[0], subParts[1])
+	}
+
+	return fmt.Sprintf("%s-%s.0.pre", base, parts[1])
 }
 
 // GentooToSemantic converts a Gentoo version string to a semantic version string.

--- a/cmd/g2/versions.go
+++ b/cmd/g2/versions.go
@@ -251,16 +251,17 @@ func GentooToFlutter(v string) string {
 	var buildParts []string
 
 	for _, suf := range gv.Suffixes {
-		if suf.Name == "pre" {
+		switch suf.Name {
+		case "pre":
 			preParts = append(preParts, suf.ValueStr)
-		} else if suf.Name == "p" {
+		case "p":
 			// If we already have a 'pre' but no patch for it, this '_p' acts as the pre-release's minor patch
 			if len(preParts) > 0 && len(preParts) < 2 {
 				preParts = append(preParts, suf.ValueStr)
 			} else {
 				buildParts = append(buildParts, suf.ValueStr)
 			}
-		} else {
+		default:
 			preParts = append(preParts, suf.Name+suf.ValueStr)
 		}
 	}

--- a/cmd/g2/versions.go
+++ b/cmd/g2/versions.go
@@ -194,6 +194,14 @@ func SemanticToGentoo(v string) string {
 
 // FlutterToGentoo converts a Flutter version string to a Gentoo version string.
 func FlutterToGentoo(v string) string {
+	v = strings.TrimPrefix(v, "v")
+
+	if strings.Contains(v, "+hotfix.") {
+		v = strings.ReplaceAll(v, "+hotfix.", "_p")
+	} else if strings.Contains(v, "+") {
+		v = strings.ReplaceAll(v, "+", "_p")
+	}
+
 	if !strings.HasSuffix(v, ".pre") {
 		return v
 	}
@@ -222,6 +230,9 @@ func FlutterToGentoo(v string) string {
 func GentooToFlutter(v string) string {
 	// looking for _preX_pY or _preX
 	if !strings.Contains(v, "_pre") {
+		if strings.Contains(v, "_p") {
+			return strings.ReplaceAll(v, "_p", "+")
+		}
 		return v
 	}
 

--- a/cmd/g2/versions.go
+++ b/cmd/g2/versions.go
@@ -192,59 +192,100 @@ func SemanticToGentoo(v string) string {
 	return res
 }
 
-// FlutterToGentoo converts a Flutter version string to a Gentoo version string.
-func FlutterToGentoo(v string) string {
+// ParseFlutterVersion parses a flutter version string into its components.
+func ParseFlutterVersion(v string) (base string, pre string, build string) {
 	v = strings.TrimPrefix(v, "v")
 
-	if strings.Contains(v, "+hotfix.") {
-		v = strings.ReplaceAll(v, "+hotfix.", "_p")
-	} else if strings.Contains(v, "+") {
-		v = strings.ReplaceAll(v, "+", "_p")
+	if idx := strings.Index(v, "+"); idx != -1 {
+		build = v[idx+1:]
+		v = v[:idx]
 	}
 
-	if !strings.HasSuffix(v, ".pre") {
-		return v
+	if idx := strings.Index(v, "-"); idx != -1 {
+		pre = v[idx+1:]
+		v = v[:idx]
 	}
 
-	// strip .pre
-	v = strings.TrimSuffix(v, ".pre")
+	base = v
+	return
+}
 
-	// split by -
-	parts := strings.Split(v, "-")
-	if len(parts) != 2 {
-		return v // fallback
+// FlutterToGentoo converts a Flutter version string to a Gentoo version string.
+func FlutterToGentoo(v string) string {
+	base, pre, build := ParseFlutterVersion(v)
+	res := base
+
+	if pre != "" {
+		pre = strings.TrimSuffix(pre, ".pre")
+		parts := strings.Split(pre, ".")
+		if len(parts) >= 2 {
+			res += fmt.Sprintf("_pre%s_p%s", parts[0], parts[1])
+		} else if len(parts) == 1 {
+			res += fmt.Sprintf("_pre%s", parts[0])
+		} else {
+			res += "_pre" + pre
+		}
 	}
 
-	base := parts[0]
-	preParts := strings.Split(parts[1], ".")
-	if len(preParts) == 2 {
-		return fmt.Sprintf("%s_pre%s_p%s", base, preParts[0], preParts[1])
-	} else if len(preParts) == 1 {
-		return fmt.Sprintf("%s_pre%s", base, preParts[0])
+	if build != "" {
+		build = strings.TrimPrefix(build, "hotfix.")
+		res += fmt.Sprintf("_p%s", build)
 	}
 
-	return v
+	return res
 }
 
 // GentooToFlutter converts a Gentoo version string to a Flutter version string.
 func GentooToFlutter(v string) string {
-	// looking for _preX_pY or _preX
-	if !strings.Contains(v, "_pre") {
-		if strings.Contains(v, "_p") {
-			return strings.ReplaceAll(v, "_p", "+")
-		}
+	gv := g2.ParseGentooVersion(v)
+	if !gv.IsValid {
 		return v
 	}
 
-	parts := strings.SplitN(v, "_pre", 2)
-	base := parts[0]
-
-	if strings.Contains(parts[1], "_p") {
-		subParts := strings.SplitN(parts[1], "_p", 2)
-		return fmt.Sprintf("%s-%s.%s.pre", base, subParts[0], subParts[1])
+	res := strings.Join(gv.NumStrs, ".")
+	if gv.Letter != "" {
+		res += gv.Letter
 	}
 
-	return fmt.Sprintf("%s-%s.0.pre", base, parts[1])
+	var preParts []string
+	var buildParts []string
+
+	for _, suf := range gv.Suffixes {
+		if suf.Name == "pre" {
+			preParts = append(preParts, suf.ValueStr)
+		} else if suf.Name == "p" {
+			// If we already have a 'pre' but no patch for it, this '_p' acts as the pre-release's minor patch
+			if len(preParts) > 0 && len(preParts) < 2 {
+				preParts = append(preParts, suf.ValueStr)
+			} else {
+				buildParts = append(buildParts, suf.ValueStr)
+			}
+		} else {
+			preParts = append(preParts, suf.Name+suf.ValueStr)
+		}
+	}
+
+	if len(preParts) > 0 {
+		if len(preParts) == 1 {
+			res += fmt.Sprintf("-%s.0.pre", preParts[0])
+		} else {
+			res += fmt.Sprintf("-%s.%s.pre", preParts[0], preParts[1])
+		}
+	}
+
+	if len(buildParts) > 0 {
+		res += "+" + buildParts[0]
+	}
+
+	if gv.Revision > 0 {
+		if len(buildParts) == 0 {
+			res += fmt.Sprintf("+%d", gv.Revision)
+		} else {
+			res += fmt.Sprintf(".%d", gv.Revision)
+		}
+	}
+
+	return res
 }
 
 // GentooToSemantic converts a Gentoo version string to a semantic version string.

--- a/cmd/g2/versions_test.go
+++ b/cmd/g2/versions_test.go
@@ -44,6 +44,7 @@ func TestFlutterToGentoo(t *testing.T) {
 		{"3.47.0-0.4.pre", "3.47.0_pre0_p4"},
 		{"3.19.0+1", "3.19.0_p1"},
 		{"1.12.13+hotfix.9", "1.12.13_p9"},
+		{"3.48.0-0.1.pre+1", "3.48.0_pre0_p1_p1"},
 		{"invalid", "invalid"},
 	}
 
@@ -68,6 +69,7 @@ func TestGentooToFlutter(t *testing.T) {
 		{"3.48.0_pre2", "3.48.0-2.0.pre"},
 		{"3.47.0_pre0_p4", "3.47.0-0.4.pre"},
 		{"3.19.0_p1", "3.19.0+1"},
+		{"3.48.0_pre0_p1_p1", "3.48.0-0.1.pre+1"},
 		{"invalid", "invalid"},
 	}
 

--- a/cmd/g2/versions_test.go
+++ b/cmd/g2/versions_test.go
@@ -32,6 +32,52 @@ func TestSemanticToGentoo(t *testing.T) {
 	}
 }
 
+func TestFlutterToGentoo(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"3.48.0", "3.48.0"},
+		{"3.48.0-0.1.pre", "3.48.0_pre0_p1"},
+		{"3.48.0-1.0.pre", "3.48.0_pre1_p0"},
+		{"3.48.0-2.pre", "3.48.0_pre2"},
+		{"3.47.0-0.4.pre", "3.47.0_pre0_p4"},
+		{"invalid", "invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			actual := FlutterToGentoo(tt.input)
+			if actual != tt.expected {
+				t.Errorf("FlutterToGentoo(%q) = %q, expected %q", tt.input, actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGentooToFlutter(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"3.48.0", "3.48.0"},
+		{"3.48.0_pre0_p1", "3.48.0-0.1.pre"},
+		{"3.48.0_pre1_p0", "3.48.0-1.0.pre"},
+		{"3.48.0_pre2", "3.48.0-2.0.pre"},
+		{"3.47.0_pre0_p4", "3.47.0-0.4.pre"},
+		{"invalid", "invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			actual := GentooToFlutter(tt.input)
+			if actual != tt.expected {
+				t.Errorf("GentooToFlutter(%q) = %q, expected %q", tt.input, actual, tt.expected)
+			}
+		})
+	}
+}
+
 func TestGentooToSemantic(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/cmd/g2/versions_test.go
+++ b/cmd/g2/versions_test.go
@@ -42,6 +42,8 @@ func TestFlutterToGentoo(t *testing.T) {
 		{"3.48.0-1.0.pre", "3.48.0_pre1_p0"},
 		{"3.48.0-2.pre", "3.48.0_pre2"},
 		{"3.47.0-0.4.pre", "3.47.0_pre0_p4"},
+		{"3.19.0+1", "3.19.0_p1"},
+		{"1.12.13+hotfix.9", "1.12.13_p9"},
 		{"invalid", "invalid"},
 	}
 
@@ -65,6 +67,7 @@ func TestGentooToFlutter(t *testing.T) {
 		{"3.48.0_pre1_p0", "3.48.0-1.0.pre"},
 		{"3.48.0_pre2", "3.48.0-2.0.pre"},
 		{"3.47.0_pre0_p4", "3.47.0-0.4.pre"},
+		{"3.19.0_p1", "3.19.0+1"},
 		{"invalid", "invalid"},
 	}
 


### PR DESCRIPTION
This PR adds support for `flutter-to-gentoo` and `gentoo-to-flutter` version conversions in the `g2 versions convert` command. 

Flutter versions with `.pre` suffixes are cleanly mapped to Gentoo's `_preX_pY` format and vice-versa, making it easier to integrate flutter projects with Gentoo. 

- Handles standard cases (`3.48.0` <-> `3.48.0`)
- Handles base pre-release mappings (`3.48.0-2.pre` <-> `3.48.0_pre2`)
- Handles patch pre-release mappings (`3.48.0-0.1.pre` <-> `3.48.0_pre0_p1`)

---
*PR created automatically by Jules for task [10149303466127017895](https://jules.google.com/task/10149303466127017895) started by @arran4*