### PR TITLE
⚡ Optimize ebuild deduplicate hash logic

### DIFF
--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -76,14 +77,19 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 		}
 
 		lines := strings.Split(string(contentBytes), "\n")
-		var hashContent []string
+		hasher := md5.New()
 		slot := "0"
+		firstLine := true
 		for _, line := range lines {
 			trimmed := strings.TrimSpace(line)
 			if strings.HasPrefix(trimmed, "# Generated via:") {
 				continue
 			}
-			hashContent = append(hashContent, line)
+			if !firstLine {
+				io.WriteString(hasher, "\n")
+			}
+			io.WriteString(hasher, line)
+			firstLine = false
 
 			if strings.HasPrefix(trimmed, "SLOT=") {
 				parts := strings.SplitN(trimmed, "=", 2)
@@ -92,9 +98,6 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 				}
 			}
 		}
-
-		hasher := md5.New()
-		hasher.Write([]byte(strings.Join(hashContent, "\n")))
 		digest := hex.EncodeToString(hasher.Sum(nil))
 
 		grade := "release"

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -86,9 +86,9 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 				continue
 			}
 			if !firstLine {
-				io.WriteString(hasher, "\n")
+				_, _ = io.WriteString(hasher, "\n")
 			}
-			io.WriteString(hasher, line)
+			_, _ = io.WriteString(hasher, line)
 			firstLine = false
 
 			if strings.HasPrefix(trimmed, "SLOT=") {

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -86,9 +86,13 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 				continue
 			}
 			if !firstLine {
-				_, _ = io.WriteString(hasher, "\n")
+				if _, err := io.WriteString(hasher, "\n"); err != nil {
+					log.Printf("Warning: failed to write to hasher: %v", err)
+				}
 			}
-			_, _ = io.WriteString(hasher, line)
+			if _, err := io.WriteString(hasher, line); err != nil {
+				log.Printf("Warning: failed to write to hasher: %v", err)
+			}
 			firstLine = false
 
 			if strings.HasPrefix(trimmed, "SLOT=") {

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -79,13 +79,12 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 		lines := strings.Split(string(contentBytes), "\n")
 		hasher := md5.New()
 		slot := "0"
-		firstLine := true
-		for _, line := range lines {
+		for i, line := range lines {
 			trimmed := strings.TrimSpace(line)
 			if strings.HasPrefix(trimmed, "# Generated via:") {
 				continue
 			}
-			if !firstLine {
+			if i > 0 {
 				if _, err := io.WriteString(hasher, "\n"); err != nil {
 					log.Printf("Warning: failed to write to hasher: %v", err)
 				}
@@ -93,7 +92,6 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 			if _, err := io.WriteString(hasher, line); err != nil {
 				log.Printf("Warning: failed to write to hasher: %v", err)
 			}
-			firstLine = false
 
 			if strings.HasPrefix(trimmed, "SLOT=") {
 				parts := strings.SplitN(trimmed, "=", 2)

--- a/ebuild_deduplicate_bench_test.go
+++ b/ebuild_deduplicate_bench_test.go
@@ -56,13 +56,12 @@ func BenchmarkHashNew(b *testing.B) {
 		lines := strings.Split(string(contentBytes), "\n")
 		hasher := md5.New()
 		slot := "0"
-		firstLine := true
-		for _, line := range lines {
+		for j, line := range lines {
 			trimmed := strings.TrimSpace(line)
 			if strings.HasPrefix(trimmed, "# Generated via:") {
 				continue
 			}
-			if !firstLine {
+			if j > 0 {
 				if _, err := io.WriteString(hasher, "\n"); err != nil {
 					b.Fatalf("failed to write newline to hasher: %v", err)
 				}
@@ -70,7 +69,6 @@ func BenchmarkHashNew(b *testing.B) {
 			if _, err := io.WriteString(hasher, line); err != nil {
 				b.Fatalf("failed to write line to hasher: %v", err)
 			}
-			firstLine = false
 
 			if strings.HasPrefix(trimmed, "SLOT=") {
 				parts := strings.SplitN(trimmed, "=", 2)

--- a/ebuild_deduplicate_bench_test.go
+++ b/ebuild_deduplicate_bench_test.go
@@ -64,11 +64,11 @@ func BenchmarkHashNew(b *testing.B) {
 			}
 			if !firstLine {
 				if _, err := io.WriteString(hasher, "\n"); err != nil {
-					// Handle error
+					b.Fatalf("failed to write newline to hasher: %v", err)
 				}
 			}
 			if _, err := io.WriteString(hasher, line); err != nil {
-				// Handle error
+				b.Fatalf("failed to write line to hasher: %v", err)
 			}
 			firstLine = false
 

--- a/ebuild_deduplicate_bench_test.go
+++ b/ebuild_deduplicate_bench_test.go
@@ -1,0 +1,81 @@
+package g2
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"strings"
+	"io"
+	"testing"
+)
+
+var ebuildContent = `EAPI=8
+# Generated via: some tool
+DESCRIPTION="A test ebuild"
+SLOT="0"
+KEYWORDS="~amd64"
+DEPEND="dev-libs/foo"
+RDEPEND="${DEPEND}"
+src_compile() {
+	emake
+}
+`
+
+func BenchmarkHashOld(b *testing.B) {
+	contentBytes := []byte(strings.Repeat(ebuildContent, 100))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lines := strings.Split(string(contentBytes), "\n")
+		var hashContent []string
+		slot := "0"
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "# Generated via:") {
+				continue
+			}
+			hashContent = append(hashContent, line)
+
+			if strings.HasPrefix(trimmed, "SLOT=") {
+				parts := strings.SplitN(trimmed, "=", 2)
+				if len(parts) == 2 {
+					slot = strings.Trim(parts[1], `"'`)
+				}
+			}
+		}
+
+		hasher := md5.New()
+		hasher.Write([]byte(strings.Join(hashContent, "\n")))
+		_ = hex.EncodeToString(hasher.Sum(nil))
+		_ = slot
+	}
+}
+
+func BenchmarkHashNew(b *testing.B) {
+	contentBytes := []byte(strings.Repeat(ebuildContent, 100))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lines := strings.Split(string(contentBytes), "\n")
+		hasher := md5.New()
+		slot := "0"
+		firstLine := true
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "# Generated via:") {
+				continue
+			}
+			if !firstLine {
+				io.WriteString(hasher, "\n")
+			}
+			io.WriteString(hasher, line)
+			firstLine = false
+
+			if strings.HasPrefix(trimmed, "SLOT=") {
+				parts := strings.SplitN(trimmed, "=", 2)
+				if len(parts) == 2 {
+					slot = strings.Trim(parts[1], `"'`)
+				}
+			}
+		}
+		_ = hex.EncodeToString(hasher.Sum(nil))
+		_ = slot
+	}
+}

--- a/ebuild_deduplicate_bench_test.go
+++ b/ebuild_deduplicate_bench_test.go
@@ -63,9 +63,13 @@ func BenchmarkHashNew(b *testing.B) {
 				continue
 			}
 			if !firstLine {
-				_, _ = io.WriteString(hasher, "\n")
+				if _, err := io.WriteString(hasher, "\n"); err != nil {
+					// Handle error
+				}
 			}
-			_, _ = io.WriteString(hasher, line)
+			if _, err := io.WriteString(hasher, line); err != nil {
+				// Handle error
+			}
 			firstLine = false
 
 			if strings.HasPrefix(trimmed, "SLOT=") {

--- a/ebuild_deduplicate_bench_test.go
+++ b/ebuild_deduplicate_bench_test.go
@@ -3,8 +3,8 @@ package g2
 import (
 	"crypto/md5"
 	"encoding/hex"
-	"strings"
 	"io"
+	"strings"
 	"testing"
 )
 
@@ -63,9 +63,9 @@ func BenchmarkHashNew(b *testing.B) {
 				continue
 			}
 			if !firstLine {
-				io.WriteString(hasher, "\n")
+				_, _ = io.WriteString(hasher, "\n")
 			}
-			io.WriteString(hasher, line)
+			_, _ = io.WriteString(hasher, line)
 			firstLine = false
 
 			if strings.HasPrefix(trimmed, "SLOT=") {


### PR DESCRIPTION
💡 **What:** The optimization stream lines directly to the MD5 hasher within the parsing loop using `io.WriteString` instead of accumulating them into a slice to join later.
🎯 **Why:** Reduces memory allocations and avoids the overhead of creating a slice and joining strings before hashing.
📊 **Measured Improvement:** The benchmark results confirm that the new logic significantly reduces allocations per operation, providing an improvement in memory usage and execution time.

---
*PR created automatically by Jules for task [2308209894000412344](https://jules.google.com/task/2308209894000412344) started by @arran4*