### PR TITLE
feat: add python-single-r1 PYTHON_USEDEP lint rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-git/go-git/v5 v5.19.2
+	github.com/google/go-cmp v0.7.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/text v0.40.0
 	golang.org/x/tools v0.48.0

--- a/lints/ebuild/python_single_r1_usedep.go
+++ b/lints/ebuild/python_single_r1_usedep.go
@@ -1,0 +1,121 @@
+package ebuild
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var rulePythonSingleR1UseDep = lints.RuleMetadata{
+	ID:          "PythonSingleR1UseDep",
+	Title:       "Invalid PYTHON_USEDEP with python-single-r1",
+	Description: "inherit python-single-r1 and PYTHON_USEDEP shouldn't be used together without python_gen_cond_dep.",
+	URL:         "https://devmanual.gentoo.org/eclass-reference/python-single-r1.eclass/index.html",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy"},
+}
+
+var (
+	useDepRe           = regexp.MustCompile(`\$\{?PYTHON_USEDEP\}?`)
+	pythonGenCondDepRe = regexp.MustCompile(`\$\(\s*python_gen_cond_dep\b`)
+)
+
+func init() {
+	lints.RegisterRuleMetadata(rulePythonSingleR1UseDep)
+	lints.RegisterLintRule(&PythonSingleR1UseDepLintRule{})
+}
+
+type PythonSingleR1UseDepLintRule struct{}
+
+func (r *PythonSingleR1UseDepLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *PythonSingleR1UseDepLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PythonSingleR1UseDep"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			inherited := ver.Ebuild.Vars["INHERITED"]
+			inheritsPythonSingleR1 := false
+			for _, eclass := range strings.Fields(inherited) {
+				if eclass == "python-single-r1" {
+					inheritsPythonSingleR1 = true
+					break
+				}
+			}
+
+			if inheritsPythonSingleR1 && ver.Ebuild.RawText != "" {
+				// Strip $(python_gen_cond_dep ...) to check if PYTHON_USEDEP is used incorrectly outside
+				strippedText := stripPythonGenCondDep(ver.Ebuild.RawText)
+
+				if useDepRe.MatchString(strippedText) {
+					res := lints.LintResult{
+						RuleMetadata: rulePythonSingleR1UseDep,
+						Message:      fmt.Sprintf("[%s] Ebuild %s inherits python-single-r1 and uses PYTHON_USEDEP without python_gen_cond_dep.", severity, ver.Version),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+				}
+			}
+		}
+	}
+
+	return results
+}
+
+func stripPythonGenCondDep(val string) string {
+	for {
+		loc := pythonGenCondDepRe.FindStringIndex(val)
+		if loc == nil {
+			break
+		}
+
+		idx := loc[0]
+
+		// find matching parenthesis
+		parenCount := 0
+		endIdx := idx
+		for i := idx; i < len(val); i++ {
+			if val[i] == '(' {
+				parenCount++
+			} else if val[i] == ')' {
+				parenCount--
+				if parenCount == 0 {
+					endIdx = i
+					break
+				}
+			}
+		}
+
+		if endIdx == idx { // Unbalanced or unexpected
+			break
+		}
+
+		val = val[:idx] + val[endIdx+1:]
+	}
+	return val
+}

--- a/lints/ebuild/python_single_r1_usedep_test.go
+++ b/lints/ebuild/python_single_r1_usedep_test.go
@@ -1,0 +1,104 @@
+package ebuild
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestPythonSingleR1UseDep(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		content  string
+		expected []lints.LintResult
+	}{
+		{
+			name:     "Valid python_gen_cond_dep usage",
+			filename: "foo-1.0.ebuild",
+			content: `EAPI=8
+inherit python-single-r1
+RDEPEND="$(python_gen_cond_dep 'dev-python/bar[${PYTHON_USEDEP}]')"
+`,
+			expected: nil,
+		},
+		{
+			name:     "Invalid PYTHON_USEDEP usage",
+			filename: "foo-2.0.ebuild",
+			content: `EAPI=8
+inherit python-single-r1
+RDEPEND="dev-python/bar[${PYTHON_USEDEP}]"
+`,
+			expected: []lints.LintResult{
+				{
+					RuleMetadata: rulePythonSingleR1UseDep,
+					Message:      "[Error] Ebuild 2.0 inherits python-single-r1 and uses PYTHON_USEDEP without python_gen_cond_dep.",
+					Package:      "app-misc/foo",
+				},
+			},
+		},
+		{
+			name:     "Both valid and invalid usage",
+			filename: "foo-3.0.ebuild",
+			content: `EAPI=8
+inherit python-single-r1
+RDEPEND="
+	$(python_gen_cond_dep 'dev-python/valid[${PYTHON_USEDEP}]')
+	dev-python/invalid[${PYTHON_USEDEP}]
+"
+`,
+			expected: []lints.LintResult{
+				{
+					RuleMetadata: rulePythonSingleR1UseDep,
+					Message:      "[Error] Ebuild 3.0 inherits python-single-r1 and uses PYTHON_USEDEP without python_gen_cond_dep.",
+					Package:      "app-misc/foo",
+				},
+			},
+		},
+		{
+			name:     "No python-single-r1 inheritance",
+			filename: "foo-4.0.ebuild",
+			content: `EAPI=8
+inherit python-r1
+RDEPEND="dev-python/bar[${PYTHON_USEDEP}]"
+`,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memFS := fstest.MapFS{
+				tt.filename: &fstest.MapFile{Data: []byte(tt.content)},
+			}
+
+			ebuildData, err := g2.ParseEbuild(memFS, tt.filename, g2.ParseFull)
+			if err != nil {
+				t.Fatalf("Failed to parse ebuild %s: %v", tt.filename, err)
+			}
+
+			pkg := &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: strings.TrimSuffix(tt.filename[4:], ".ebuild"),
+						Ebuild:  ebuildData,
+					},
+				},
+			}
+
+			rule := &PythonSingleR1UseDepLintRule{}
+			results := rule.Lint(".", pkg)
+
+			if diff := cmp.Diff(tt.expected, results, cmpopts.IgnoreFields(lints.RuleMetadata{}, "Tags")); diff != "" {
+				t.Errorf("Lint results mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added a new ebuild lint rule (`PythonSingleR1UseDep`) to detect cases where `PYTHON_USEDEP` is improperly used in ebuilds that inherit `python-single-r1`. The placeholder should only be used inside `python_gen_cond_dep()`.

The rule properly strips correctly formed `$(python_gen_cond_dep ...)` usages and flags any trailing or raw usages of the variable.

Fixes #823

---
*PR created automatically by Jules for task [7294018338394073029](https://jules.google.com/task/7294018338394073029) started by @arran4*