### PR TITLE
feat: Add sandbox functions usage lint rule

### DIFF
--- a/lints/ebuild/sandbox_functions.go
+++ b/lints/ebuild/sandbox_functions.go
@@ -1,0 +1,85 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleSandboxFunctions = lints.RuleMetadata{
+	ID:          "SandboxFunctions",
+	Title:       "Sandbox Functions Usage",
+	Description: "Warns about inappropriate usage of sandbox functions like addwrite, or using multiple arguments for addread, addwrite, adddeny, and addpredict.",
+	URL:         "https://devmanual.gentoo.org/function-reference/sandbox-functions/index.html",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "sandbox"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleSandboxFunctions)
+	lints.RegisterLintRule(&SandboxFunctionsLintRule{})
+}
+
+type SandboxFunctionsLintRule struct{}
+
+func (l *SandboxFunctionsLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, version := range pkgData.Versions {
+		if version.Ebuild == nil {
+			continue
+		}
+
+		// Parse the ebuild using sh syntax parser
+		parser := syntax.NewParser()
+		f, err := parser.Parse(strings.NewReader(version.Ebuild.RawText), "")
+		if err != nil {
+			continue
+		}
+
+		syntax.Walk(f, func(node syntax.Node) bool {
+			cmd, ok := node.(*syntax.CallExpr)
+			if !ok {
+				return true
+			}
+
+			if len(cmd.Args) > 0 {
+				var cmdName string
+				if len(cmd.Args[0].Parts) == 1 {
+					if lit, ok := cmd.Args[0].Parts[0].(*syntax.Lit); ok {
+						cmdName = lit.Value
+					}
+				}
+
+				if cmdName == "addwrite" {
+					res := lints.LintResult{
+						RuleMetadata: ruleSandboxFunctions,
+						Message:      fmt.Sprintf("[Error] Ebuild %s uses addwrite, which is not an appropriate alternative to making the package build sandbox-friendly. Use addpredict instead.", version.Ebuild.Path),
+						Package:      pkgData.Category + "/" + pkgData.Name,
+					}
+					results = append(results, res)
+				}
+
+				if cmdName == "addread" || cmdName == "addwrite" || cmdName == "adddeny" || cmdName == "addpredict" {
+					if len(cmd.Args) > 2 {
+						res := lints.LintResult{
+							RuleMetadata: ruleSandboxFunctions,
+							Message:      fmt.Sprintf("[Warning] Ebuild %s calls %s with multiple arguments. Sandbox functions do not accept multiple arguments in one call.", version.Ebuild.Path, cmdName),
+							Package:      pkgData.Category + "/" + pkgData.Name,
+						}
+						// Override severity for this specific case as per user request
+						res.RuleMetadata.Severity = lints.SeverityWarning
+						results = append(results, res)
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	return results
+}

--- a/lints/ebuild/sandbox_functions_test.go
+++ b/lints/ebuild/sandbox_functions_test.go
@@ -1,0 +1,100 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+func TestSandboxFunctionsLintRule(t *testing.T) {
+	rule := &SandboxFunctionsLintRule{}
+
+	tests := []struct {
+		name     string
+		ebuild   string
+		expected []lints.LintResult
+	}{
+		{
+			name: "Valid Usage",
+			ebuild: `
+src_compile() {
+	addpredict /foo
+	addread /bar
+}
+`,
+			expected: nil,
+		},
+		{
+			name: "Addwrite Error",
+			ebuild: `
+src_compile() {
+	addwrite /foo
+}
+`,
+			expected: []lints.LintResult{
+				{
+					Message: "[Error] Ebuild /path/to/ebuild uses addwrite, which is not an appropriate alternative to making the package build sandbox-friendly. Use addpredict instead.",
+				},
+			},
+		},
+		{
+			name: "Multiple Arguments Warning",
+			ebuild: `
+src_compile() {
+	addpredict /foo /bar
+}
+`,
+			expected: []lints.LintResult{
+				{
+					Message: "[Warning] Ebuild /path/to/ebuild calls addpredict with multiple arguments. Sandbox functions do not accept multiple arguments in one call.",
+				},
+			},
+		},
+		{
+			name: "Addwrite Error and Multiple Arguments Warning",
+			ebuild: `
+src_compile() {
+	addwrite /foo /bar
+}
+`,
+			expected: []lints.LintResult{
+				{
+					Message: "[Error] Ebuild /path/to/ebuild uses addwrite, which is not an appropriate alternative to making the package build sandbox-friendly. Use addpredict instead.",
+				},
+				{
+					Message: "[Warning] Ebuild /path/to/ebuild calls addwrite with multiple arguments. Sandbox functions do not accept multiple arguments in one call.",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkgData := &g2.PackageData{
+				Category: "sys-apps",
+				Name:     "test",
+				Versions: []g2.VersionData{
+					{
+						Ebuild: &g2.Ebuild{
+							Path:    "/path/to/ebuild",
+							RawText: tt.ebuild,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkgData)
+
+			if len(results) != len(tt.expected) {
+				t.Fatalf("expected %d results, got %d", len(tt.expected), len(results))
+			}
+
+			for i, res := range results {
+				if res.Message != tt.expected[i].Message {
+					t.Errorf("expected message '%s', got '%s'", tt.expected[i].Message, res.Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new ebuild lint rule to detect inappropriate usage of sandbox functions (`addread`, `addwrite`, `adddeny`, `addpredict`) according to the Gentoo Devmanual. It flags an error if `addwrite` is used (recommending `addpredict`) and warns if any of these functions are called with multiple arguments.

---
*PR created automatically by Jules for task [12135828840025852402](https://jules.google.com/task/12135828840025852402) started by @arran4*