### PR TITLE
feat: add linter rule for common ebuild dependency pitfalls

### DIFF
--- a/lints/ebuild/dependency_pitfalls.go
+++ b/lints/ebuild/dependency_pitfalls.go
@@ -1,0 +1,116 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleDependencyPitfalls = lints.RuleMetadata{
+	ID:          "DependencyPitfalls",
+	Title:       "Dependency Pitfalls",
+	Description: "Checks for common dependency pitfalls such as := inside any-of groups or weak blockers in DEPEND.",
+	URL:         "https://devmanual.gentoo.org/general-concepts/dependencies/index.html#common-pitfalls",
+	Severity:    lints.SeverityWarning, // Usually warnings
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleDependencyPitfalls)
+	lints.RegisterLintRule(&DependencyPitfallsLintRule{})
+}
+
+type DependencyPitfallsLintRule struct{}
+
+func (r *DependencyPitfallsLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *DependencyPitfallsLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := ruleDependencyPitfalls.Severity
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			// Check DEPEND, RDEPEND, PDEPEND, BDEPEND
+			for _, depVar := range []string{"DEPEND", "RDEPEND", "PDEPEND", "BDEPEND"} {
+				depStr, ok := ver.Ebuild.Vars[depVar]
+				if !ok || depStr == "" {
+					continue
+				}
+
+				r.walkDependencies(depStr, func(atomStr string, insideAnyOf bool) {
+					atom := g2.ParsePackageAtom(atomStr)
+
+					// Pitfall 1: := slot operator inside any-of groups (|| ( ... ))
+					// Warning: Do not place := dependency specifications inside || ( ... ) groups.
+					if insideAnyOf && atom.Slot != "" && strings.HasSuffix(atom.Slot, "=") {
+						res := lints.LintResult{
+							RuleMetadata: ruleDependencyPitfalls,
+							Message:      fmt.Sprintf("[%s] Ebuild %s has ':=' slot operator inside an any-of group (||) in %s: %s", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, depVar, atomStr),
+							Package:      pkg.Category + "/" + pkg.Name,
+						}
+						results = append(results, res)
+					}
+
+					// Pitfall 2: Weak blockers in DEPEND.
+					// Weak blockers (!) are primarily meaningful in RDEPEND.
+					// "Remember the general caveat from above: weak blockers should be included in RDEPEND rather than used purely in DEPEND."
+					// Actually, "Weak blockers that are pure DEPEND do not work correctly. Always include your weak blockers in RDEPEND!"
+					// The rule is typically: weak blocker in DEPEND is bad, unless it's a strong blocker (!!)
+					if depVar == "DEPEND" && atom.Operator == "!" {
+						res := lints.LintResult{
+							RuleMetadata: ruleDependencyPitfalls,
+							Message:      fmt.Sprintf("[%s] Ebuild %s uses a weak blocker (!) purely in DEPEND. Use strong blockers (!!) in DEPEND or weak blockers in RDEPEND: %s", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, atomStr),
+							Package:      pkg.Category + "/" + pkg.Name,
+						}
+						results = append(results, res)
+					}
+				})
+			}
+		}
+	}
+	return results
+}
+
+func (r *DependencyPitfallsLintRule) walkDependencies(depStr string, cb func(atomStr string, insideAnyOf bool)) {
+	tokens := strings.Fields(depStr)
+	var stateStack []string
+	pendingAnyOf := false
+
+	for _, token := range tokens {
+		if token == "||" {
+			pendingAnyOf = true
+		} else if token == "(" {
+			if pendingAnyOf {
+				stateStack = append(stateStack, "||")
+				pendingAnyOf = false
+			} else {
+				stateStack = append(stateStack, "OTHER")
+			}
+		} else if token == ")" {
+			if len(stateStack) > 0 {
+				stateStack = stateStack[:len(stateStack)-1]
+			}
+		} else if strings.HasSuffix(token, "?") {
+			// It's a USE flag condition, ignored
+			pendingAnyOf = false
+		} else {
+			// This is a package atom
+			inAnyOf := false
+			for _, state := range stateStack {
+				if state == "||" {
+					inAnyOf = true
+					break
+				}
+			}
+			cb(token, inAnyOf)
+			pendingAnyOf = false
+		}
+	}
+}

--- a/lints/ebuild/dependency_pitfalls_test.go
+++ b/lints/ebuild/dependency_pitfalls_test.go
@@ -1,0 +1,128 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestDependencyPitfallsLintRule(t *testing.T) {
+	rule := &DependencyPitfallsLintRule{}
+
+	tests := []struct {
+		name     string
+		pkg      *g2.PackageData
+		qaPolicy *g2.QAPolicy
+		expected int // Number of expected errors
+	}{
+		{
+			name: "Valid deps",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"DEPEND":  "|| ( dev-libs/A dev-libs/B ) !!sys-libs/bar",
+								"RDEPEND": "|| ( dev-libs/A dev-libs/B ) !app-misc/foo",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0,
+		},
+		{
+			name: "Slot operator inside any-of group",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RDEPEND": "|| ( dev-libs/A:= dev-libs/B )",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 1, // 1 warning for dev-libs/A:=
+		},
+		{
+			name: "Weak blocker in DEPEND",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"DEPEND": "!app-misc/foo",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 1, // 1 warning
+		},
+		{
+			name: "Nested any-of group",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RDEPEND": "a? ( || ( dev-libs/A:= dev-libs/B:= ) )",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 2, // 2 warnings
+		},
+		{
+			name: "Any-of inside another group",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"DEPEND": "|| ( a? ( dev-libs/A:= ) )",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 1, // 1 warning
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			results := rule.LintWithQA("", tc.pkg, tc.qaPolicy)
+
+			if len(results) != tc.expected {
+				t.Errorf("Expected %d results, got %d", tc.expected, len(results))
+				for _, res := range results {
+					t.Logf("Result: %s", res.Message)
+				}
+			}
+		})
+	}
+}

--- a/lints/ebuild/dependency_pitfalls_test.go
+++ b/lints/ebuild/dependency_pitfalls_test.go
@@ -111,6 +111,141 @@ func TestDependencyPitfallsLintRule(t *testing.T) {
 			qaPolicy: nil,
 			expected: 1, // 1 warning
 		},
+		{
+			name: "Valid := outside any-of",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"DEPEND":  "dev-libs/A:=",
+								"RDEPEND": "dev-libs/A:=",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0,
+		},
+		{
+			name: "Any-of with normal slot dependency",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RDEPEND": "|| ( dev-libs/A:5 dev-libs/B )",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0,
+		},
+		{
+			name: "Any-of with slot ignore dependency",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RDEPEND": "|| ( dev-libs/A:* dev-libs/B )",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0,
+		},
+		{
+			name: "Weak blocker in RDEPEND",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RDEPEND": "!app-misc/foo",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0,
+		},
+		{
+			name: "Weak blocker in PDEPEND",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"PDEPEND": "!app-misc/foo",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0,
+		},
+		{
+			name: "Weak blocker in DEPEND AND RDEPEND",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"DEPEND":  "!app-misc/foo",
+								"RDEPEND": "!app-misc/foo",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 1, // Only DEPEND triggers warning
+		},
+		{
+			name: "Strong blocker in DEPEND",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"DEPEND": "!!app-misc/foo",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Adds a new linter rule to prevent common ebuild dependency pitfalls, as described in the gentoo devmanual. Tests are included.

---
*PR created automatically by Jules for task [17409489572957931008](https://jules.google.com/task/17409489572957931008) started by @arran4*