### PR TITLE
Add common problems lints for ebuilds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/go-cmp v0.7.0
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.54.0
 	golang.org/x/text v0.40.0
 	golang.org/x/tools v0.48.0
@@ -12,8 +13,11 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/onsi/gomega v1.36.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/lints/ebuild/eclass_inherit.go
+++ b/lints/ebuild/eclass_inherit.go
@@ -159,6 +159,6 @@ func (l *ConditionalInheritLintRule) Lint(repoDir string, pkgData *g2.PackageDat
 func formatNode(node syntax.Node) string {
 	printer := syntax.NewPrinter()
 	var buf strings.Builder
-	printer.Print(&buf, node)
+	_ = printer.Print(&buf, node)
 	return buf.String()
 }

--- a/lints/ebuild/eclass_inherit.go
+++ b/lints/ebuild/eclass_inherit.go
@@ -1,0 +1,164 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleConditionalInherit = lints.RuleMetadata{
+	ID:          "ConditionalInherit",
+	Title:       "Conditional Eclass Inheritance",
+	Description: "Warns about conditional inheritance of eclasses, which is illegal unless based strictly on PN or PV.",
+	URL:         "https://devmanual.gentoo.org/appendices/common-problems/index.html#qa-notice-eclass-foo-inherited-illegally",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "qa"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleConditionalInherit)
+	lints.RegisterLintRule(&ConditionalInheritLintRule{})
+}
+
+type ConditionalInheritLintRule struct{}
+
+func (l *ConditionalInheritLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, version := range pkgData.Versions {
+		if version.Ebuild == nil {
+			continue
+		}
+
+		parser := syntax.NewParser()
+		f, err := parser.Parse(strings.NewReader(version.Ebuild.RawText), "")
+		if err != nil {
+			continue
+		}
+
+		var walk func(node syntax.Node, inConditional bool)
+		walk = func(node syntax.Node, inConditional bool) {
+			if node == nil {
+				return
+			}
+
+			switch n := node.(type) {
+			case *syntax.CallExpr:
+				if len(n.Args) > 0 {
+					var cmdName string
+					if len(n.Args[0].Parts) == 1 {
+						if lit, ok := n.Args[0].Parts[0].(*syntax.Lit); ok {
+							cmdName = lit.Value
+						}
+					}
+					if cmdName == "inherit" && inConditional {
+						res := lints.LintResult{
+							RuleMetadata: ruleConditionalInherit,
+							Message:      fmt.Sprintf("[Error] Ebuild %s inherits eclasses conditionally, which is not permitted. All eclass inherits must be unconditional.", version.Ebuild.Path),
+							Package:      pkgData.Category + "/" + pkgData.Name,
+						}
+						results = append(results, res)
+					}
+				}
+			}
+
+			// Traverse deeper
+			switch n := node.(type) {
+			case *syntax.File:
+				for _, stmt := range n.Stmts {
+					walk(stmt, inConditional)
+				}
+			case *syntax.Stmt:
+				walk(n.Cmd, inConditional)
+				for _, redir := range n.Redirs {
+					walk(redir, inConditional)
+				}
+			case *syntax.CallExpr:
+				for _, arg := range n.Args {
+					walk(arg, inConditional)
+				}
+				for _, assign := range n.Assigns {
+					walk(assign, inConditional)
+				}
+			case *syntax.Word:
+				for _, part := range n.Parts {
+					walk(part, inConditional)
+				}
+			case *syntax.CmdSubst:
+				for _, stmt := range n.Stmts {
+					walk(stmt, true) // Inside $(), considered conditional/dynamic
+				}
+			case *syntax.IfClause:
+				for _, stmt := range n.Cond {
+					walk(stmt, inConditional)
+				}
+				for _, stmt := range n.Then {
+					// We could analyze if condition is strictly based on PN or PV,
+					// but Devmanual says: "All eclass inherits must be unconditional, or based purely upon static machine-independent criteria (PN and PV are most common here)."
+					// A simple rule might just warn on ANY conditional inherit, or we can check the Cond for PN/PV usage.
+					// To be safe, we mark it conditional and let developer review it. Or we check if condition ONLY uses PV/PN.
+					isStatic := false
+					if len(n.Cond) == 1 {
+						// a simple check, if condition contains PV or PN
+						condStr := formatNode(n.Cond[0])
+						if strings.Contains(condStr, "${PV}") || strings.Contains(condStr, "${PN}") {
+							isStatic = true
+						}
+					}
+					walk(stmt, inConditional || !isStatic)
+				}
+				if n.Else != nil {
+					walk(n.Else, true)
+				}
+			case *syntax.Block:
+				for _, stmt := range n.Stmts {
+					walk(stmt, inConditional)
+				}
+			case *syntax.CaseClause:
+				walk(n.Word, inConditional)
+				isStatic := false
+				wordStr := formatNode(n.Word)
+				if strings.Contains(wordStr, "${PV}") || strings.Contains(wordStr, "${PN}") {
+					isStatic = true
+				}
+				for _, item := range n.Items {
+					for _, word := range item.Patterns {
+						walk(word, inConditional)
+					}
+					for _, stmt := range item.Stmts {
+						walk(stmt, inConditional || !isStatic)
+					}
+				}
+			case *syntax.WhileClause:
+				for _, stmt := range n.Cond {
+					walk(stmt, inConditional)
+				}
+				for _, stmt := range n.Do {
+					walk(stmt, true) // Loops are inherently conditional/dynamic
+				}
+			case *syntax.ForClause:
+				walk(n.Loop, inConditional)
+				for _, stmt := range n.Do {
+					walk(stmt, true)
+				}
+			case *syntax.FuncDecl:
+				walk(n.Body, true) // Inside function is dynamic/conditional
+			}
+		}
+
+		walk(f, false)
+	}
+
+	return results
+}
+
+func formatNode(node syntax.Node) string {
+	printer := syntax.NewPrinter()
+	var buf strings.Builder
+	printer.Print(&buf, node)
+	return buf.String()
+}

--- a/lints/ebuild/eclass_inherit_test.go
+++ b/lints/ebuild/eclass_inherit_test.go
@@ -1,0 +1,106 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConditionalInheritLintRule(t *testing.T) {
+	rule := &ConditionalInheritLintRule{}
+
+	tests := []struct {
+		name          string
+		ebuildContent string
+		expected      int
+	}{
+		{
+			name: "Unconditional inherit",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+inherit foo
+`,
+			expected: 0,
+		},
+		{
+			name: "Conditional inherit on PV",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+fi
+`,
+			expected: 0,
+		},
+		{
+			name: "Conditional inherit on other var",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+
+if [[ ${USE_GIT} == "yes" ]]; then
+	inherit git-r3
+fi
+`,
+			expected: 1,
+		},
+		{
+			name: "Inherit in function",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+
+src_prepare() {
+	inherit foo
+}
+`,
+			expected: 1,
+		},
+		{
+			name: "Inherit in case clause on PV",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+
+case ${PV} in
+	9999)
+		inherit git-r3
+		;;
+esac
+`,
+			expected: 0,
+		},
+		{
+			name: "Inherit in case clause on other var",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+
+case ${MY_VAR} in
+	yes)
+		inherit git-r3
+		;;
+esac
+`,
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkgData := &g2.PackageData{
+				Category: "app-test",
+				Name:     "testpkg",
+				Versions: []g2.VersionData{
+					{
+						Ebuild: &g2.Ebuild{
+							Path:    "testpkg-1.0.ebuild",
+							RawText: tt.ebuildContent,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkgData)
+			assert.Len(t, results, tt.expected)
+		})
+	}
+}

--- a/lints/ebuild/global_scope.go
+++ b/lints/ebuild/global_scope.go
@@ -1,0 +1,198 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleGlobalScope = lints.RuleMetadata{
+	ID:          "GlobalScope",
+	Title:       "Invalid commands in global scope",
+	Description: "Warns about using external commands like sed, awk, grep, has_version, etc. in global scope.",
+	URL:         "https://devmanual.gentoo.org/appendices/common-problems/index.html#qa-notice-foo-in-global-scope",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "qa"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleGlobalScope)
+	lints.RegisterLintRule(&GlobalScopeLintRule{})
+}
+
+type GlobalScopeLintRule struct{}
+
+func (l *GlobalScopeLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	disallowedCommands := map[string]bool{
+		"sed":          true,
+		"awk":          true,
+		"grep":         true,
+		"egrep":        true,
+		"cut":          true,
+		"has_version":  true,
+		"best_version": true,
+		"python":       true,
+		"perl":         true,
+	}
+
+	for _, version := range pkgData.Versions {
+		if version.Ebuild == nil {
+			continue
+		}
+
+		parser := syntax.NewParser()
+		f, err := parser.Parse(strings.NewReader(version.Ebuild.RawText), "")
+		if err != nil {
+			continue
+		}
+
+		var walkGlobal func(node syntax.Node)
+		walkGlobal = func(node syntax.Node) {
+			if node == nil {
+				return
+			}
+
+			switch n := node.(type) {
+			case *syntax.FuncDecl:
+				// Do not walk inside function body
+				return
+			case *syntax.CallExpr:
+				if len(n.Args) > 0 {
+					var cmdName string
+					if len(n.Args[0].Parts) == 1 {
+						if lit, ok := n.Args[0].Parts[0].(*syntax.Lit); ok {
+							cmdName = lit.Value
+						}
+					}
+					if cmdName != "" && disallowedCommands[cmdName] {
+						res := lints.LintResult{
+							RuleMetadata: ruleGlobalScope,
+							Message:      fmt.Sprintf("[Error] Ebuild %s calls %s in global scope. This is not allowed.", version.Ebuild.Path, cmdName),
+							Package:      pkgData.Category + "/" + pkgData.Name,
+						}
+						results = append(results, res)
+					}
+				}
+			}
+
+			// Continue walking down
+			switch n := node.(type) {
+			case *syntax.File:
+				for _, stmt := range n.Stmts {
+					walkGlobal(stmt)
+				}
+			case *syntax.Stmt:
+				walkGlobal(n.Cmd)
+				for _, redir := range n.Redirs {
+					walkGlobal(redir)
+				}
+			case *syntax.CallExpr:
+				for _, arg := range n.Args {
+					walkGlobal(arg)
+				}
+				for _, assign := range n.Assigns {
+					walkGlobal(assign)
+				}
+			case *syntax.Word:
+				for _, part := range n.Parts {
+					walkGlobal(part)
+				}
+			case *syntax.CmdSubst:
+				for _, stmt := range n.Stmts {
+					walkGlobal(stmt)
+				}
+			case *syntax.IfClause:
+				for _, stmt := range n.Cond {
+					walkGlobal(stmt)
+				}
+				for _, stmt := range n.Then {
+					walkGlobal(stmt)
+				}
+				if n.Else != nil {
+					walkGlobal(n.Else)
+				}
+			case *syntax.Block:
+				for _, stmt := range n.Stmts {
+					walkGlobal(stmt)
+				}
+			case *syntax.Assign:
+				if n.Value != nil {
+					walkGlobal(n.Value)
+				}
+				if n.Array != nil {
+					walkGlobal(n.Array)
+				}
+			case *syntax.ArrayExpr:
+				for _, elem := range n.Elems {
+					walkGlobal(elem)
+				}
+			case *syntax.ArrayElem:
+				walkGlobal(n.Value)
+			case *syntax.DeclClause:
+				for _, assign := range n.Args {
+					walkGlobal(assign)
+				}
+			case *syntax.CaseClause:
+				walkGlobal(n.Word)
+				for _, item := range n.Items {
+					for _, word := range item.Patterns {
+						walkGlobal(word)
+					}
+					for _, stmt := range item.Stmts {
+						walkGlobal(stmt)
+					}
+				}
+			case *syntax.WhileClause:
+				for _, stmt := range n.Cond {
+					walkGlobal(stmt)
+				}
+				for _, stmt := range n.Do {
+					walkGlobal(stmt)
+				}
+			case *syntax.ForClause:
+				walkGlobal(n.Loop)
+				for _, stmt := range n.Do {
+					walkGlobal(stmt)
+				}
+			case *syntax.WordIter:
+				for _, word := range n.Items {
+					walkGlobal(word)
+				}
+			case *syntax.Subshell:
+				for _, stmt := range n.Stmts {
+					walkGlobal(stmt)
+				}
+			case *syntax.BinaryCmd:
+				walkGlobal(n.X)
+				walkGlobal(n.Y)
+			case *syntax.CoprocClause:
+				walkGlobal(n.Stmt)
+			case *syntax.TimeClause:
+				walkGlobal(n.Stmt)
+			case *syntax.LetClause:
+				for _, expr := range n.Exprs {
+					walkGlobal(expr)
+				}
+			case *syntax.TestClause:
+				walkGlobal(n.X)
+			case *syntax.BinaryTest:
+				walkGlobal(n.X)
+				walkGlobal(n.Y)
+			case *syntax.UnaryTest:
+				walkGlobal(n.X)
+			case *syntax.ParenTest:
+				walkGlobal(n.X)
+			}
+		}
+
+		walkGlobal(f)
+	}
+
+	return results
+}

--- a/lints/ebuild/global_scope_test.go
+++ b/lints/ebuild/global_scope_test.go
@@ -1,0 +1,86 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobalScopeLintRule(t *testing.T) {
+	rule := &GlobalScopeLintRule{}
+
+	tests := []struct {
+		name          string
+		ebuildContent string
+		expected      int
+	}{
+		{
+			name: "Clean ebuild",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+HOMEPAGE="https://example.com"
+LICENSE="GPL-2"
+SLOT="0"
+
+src_prepare() {
+	sed -i 's/a/b/' file
+	has_version a/b
+}
+`,
+			expected: 0,
+		},
+		{
+			name: "sed in global scope",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+
+sed -i 's/a/b/' file
+
+src_prepare() {
+	true
+}
+`,
+			expected: 1,
+		},
+		{
+			name: "has_version in subshell in global scope",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+
+FOO=$(has_version a/b)
+`,
+			expected: 1,
+		},
+		{
+			name: "multiple bad commands",
+			ebuildContent: `
+DESCRIPTION="A test ebuild"
+
+awk '{print $1}' file
+grep "foo" file
+`,
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkgData := &g2.PackageData{
+				Category: "app-test",
+				Name:     "testpkg",
+				Versions: []g2.VersionData{
+					{
+						Ebuild: &g2.Ebuild{
+							Path:    "testpkg-1.0.ebuild",
+							RawText: tt.ebuildContent,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkgData)
+			assert.Len(t, results, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
Adds two new lint rules for ebuilds, targeting common issues like invalid global scope usage and conditional eclass inheritance.

---
*PR created automatically by Jules for task [4534195914701943915](https://jules.google.com/task/4534195914701943915) started by @arran4*