### PR TITLE
feat(lints): Add maintainer rules for metadata.xml

### DIFF
--- a/lints/metadata/maintainer_needed.go
+++ b/lints/metadata/maintainer_needed.go
@@ -1,0 +1,85 @@
+package metadata
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleMaintainerNeeded = lints.RuleMetadata{
+	ID:          "MaintainerNeeded",
+	Title:       "Maintainer Needed Comment Missing or Incorrect",
+	Description: "Ensures that a package with no maintainers has the <!-- maintainer-needed --> comment in its metadata.xml, and packages with maintainers do not have it.",
+	URL:         "https://devmanual.gentoo.org/general-concepts/package-maintainers/index.html#adding-and-removing-maintainers",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"metadata.xml", "site-quality", "PG0703"}, // Using a new tag, e.g., PG0703
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleMaintainerNeeded)
+	lints.RegisterLintRule(&MaintainerNeededLintRule{})
+}
+
+type MaintainerNeededLintRule struct{}
+
+func (r *MaintainerNeededLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *MaintainerNeededLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0703"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	if pkg.Metadata != nil {
+		hasMaintainers := len(pkg.Metadata.Maintainers) > 0
+		hasComment := false
+		for _, comment := range pkg.Metadata.Comments {
+			if strings.Contains(comment, "maintainer-needed") {
+				hasComment = true
+				break
+			}
+		}
+
+		if !hasMaintainers && !hasComment {
+			res := lints.LintResult{
+				RuleMetadata: ruleMaintainerNeeded,
+				Message:      fmt.Sprintf("[%s] Package has no maintainers but is missing the <!-- maintainer-needed --> comment in metadata.xml", cases.Title(language.Und, cases.NoLower).String(string(severity))),
+				Package:      pkg.Category + "/" + pkg.Name,
+			}
+			res.RuleMetadata.Severity = severity
+			results = append(results, res)
+		} else if hasMaintainers && hasComment {
+			res := lints.LintResult{
+				RuleMetadata: ruleMaintainerNeeded,
+				Message:      fmt.Sprintf("[%s] Package has maintainers but contains the <!-- maintainer-needed --> comment in metadata.xml", cases.Title(language.Und, cases.NoLower).String(string(severity))),
+				Package:      pkg.Category + "/" + pkg.Name,
+			}
+			res.RuleMetadata.Severity = severity
+			results = append(results, res)
+		}
+	}
+
+	return results
+}

--- a/lints/metadata/maintainer_needed_test.go
+++ b/lints/metadata/maintainer_needed_test.go
@@ -1,0 +1,72 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/metadata"
+)
+
+func TestMaintainerNeededLintRule(t *testing.T) {
+	rule := &metadata.MaintainerNeededLintRule{}
+
+	t.Run("Missing maintainer and missing comment", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{},
+				Comments:    []string{},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for missing maintainer-needed comment, got none")
+		} else if warnings[0].RuleMetadata.ID != "MaintainerNeeded" {
+			t.Errorf("expected MaintainerNeeded rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+
+	t.Run("Missing maintainer and has comment", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{},
+				Comments:    []string{" maintainer-needed "},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Has maintainer and has comment", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "dev@example.com"},
+				},
+				Comments: []string{" maintainer-needed "},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for unneeded maintainer-needed comment, got none")
+		} else if warnings[0].RuleMetadata.ID != "MaintainerNeeded" {
+			t.Errorf("expected MaintainerNeeded rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+
+	t.Run("Has maintainer and no comment", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "dev@example.com"},
+				},
+				Comments: []string{},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+}

--- a/lints/metadata/proxied_maintainer.go
+++ b/lints/metadata/proxied_maintainer.go
@@ -1,0 +1,89 @@
+package metadata
+
+import (
+	"fmt"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleProxiedMaintainer = lints.RuleMetadata{
+	ID:          "ProxiedMaintainer",
+	Title:       "Proxied Maintainer Rules",
+	Description: "Ensures that packages maintained by proxied maintainers explicitly list their proxy developer or project.",
+	URL:         "https://devmanual.gentoo.org/general-concepts/package-maintainers/index.html#adding-and-removing-maintainers",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"metadata.xml", "site-quality", "PG0704"}, // Using a new tag, e.g., PG0704
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleProxiedMaintainer)
+	lints.RegisterLintRule(&ProxiedMaintainerLintRule{})
+}
+
+type ProxiedMaintainerLintRule struct{}
+
+func (r *ProxiedMaintainerLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *ProxiedMaintainerLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0704"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	if pkg.Metadata != nil {
+		hasProxied := false
+		hasProxy := false
+
+		for _, m := range pkg.Metadata.Maintainers {
+			if m.Proxied == "yes" {
+				hasProxied = true
+			}
+			if m.Proxied == "proxy" {
+				hasProxy = true
+			}
+		}
+
+		if hasProxied && !hasProxy {
+			res := lints.LintResult{
+				RuleMetadata: ruleProxiedMaintainer,
+				Message:      fmt.Sprintf("[%s] Package has a proxied maintainer but no proxy developer/project is listed", cases.Title(language.Und, cases.NoLower).String(string(severity))),
+				Package:      pkg.Category + "/" + pkg.Name,
+			}
+			res.RuleMetadata.Severity = severity
+			results = append(results, res)
+		}
+
+		if hasProxy && !hasProxied {
+		    res := lints.LintResult{
+				RuleMetadata: ruleProxiedMaintainer,
+				Message:      fmt.Sprintf("[%s] Package has a proxy developer/project but no proxied maintainer is listed", cases.Title(language.Und, cases.NoLower).String(string(severity))),
+				Package:      pkg.Category + "/" + pkg.Name,
+			}
+			res.RuleMetadata.Severity = severity
+			results = append(results, res)
+		}
+	}
+
+	return results
+}

--- a/lints/metadata/proxied_maintainer_test.go
+++ b/lints/metadata/proxied_maintainer_test.go
@@ -1,0 +1,73 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/metadata"
+)
+
+func TestProxiedMaintainerLintRule(t *testing.T) {
+	rule := &metadata.ProxiedMaintainerLintRule{}
+
+	t.Run("Has proxied but no proxy", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "proxied@example.com", Proxied: "yes"},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for missing proxy, got none")
+		} else if warnings[0].RuleMetadata.ID != "ProxiedMaintainer" {
+			t.Errorf("expected ProxiedMaintainer rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+
+	t.Run("Has proxy but no proxied", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "proxy@example.com", Proxied: "proxy"},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for missing proxied, got none")
+		} else if warnings[0].RuleMetadata.ID != "ProxiedMaintainer" {
+			t.Errorf("expected ProxiedMaintainer rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+
+	t.Run("Has both", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "proxied@example.com", Proxied: "yes"},
+					{Email: "proxy@example.com", Proxied: "proxy"},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Has neither", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "maintainer@example.com", Proxied: "no"},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+}


### PR DESCRIPTION
This PR introduces two new lint rules for `metadata.xml` as per Gentoo developer manual specifications:

1. **MaintainerNeededLintRule (PG0703)**:
    - Triggers an error if a package has no maintainers but is missing the `<!-- maintainer-needed -->` comment.
    - Triggers an error if a package *has* maintainers but inappropriately includes the `<!-- maintainer-needed -->` comment.

2. **ProxiedMaintainerLintRule (PG0704)**:
    - Triggers an error if a package specifies a proxied maintainer (`proxied="yes"`) but fails to list a proxy developer or project (`proxied="proxy"`).
    - Triggers an error if a proxy developer is listed but no proxied maintainer is defined.

Both rules include comprehensive unit tests covering relevant edge cases. This enhances the overall QA for metadata within repositories.

---
*PR created automatically by Jules for task [8381356278099362691](https://jules.google.com/task/8381356278099362691) started by @arran4*