### PR TITLE
feat: add directory and filename validation for Gentoo news linting

### DIFF
--- a/lints/news/news.go
+++ b/lints/news/news.go
@@ -5,12 +5,18 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints"
+)
+
+var (
+	newsDirNameRegex  = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})-([a-z0-9+_-]{1,20})$`)
+	newsFileNameRegex = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})-([a-z0-9+_-]{1,20})\.([a-zA-Z0-9-]+)\.txt$`)
 )
 
 var ruleNewsValidity = lints.RuleMetadata{
@@ -106,6 +112,18 @@ func (r *NewsValidityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, q
 		}
 		dirName := entry.Name()
 
+		dirMatch := newsDirNameRegex.FindStringSubmatch(dirName)
+		if dirMatch == nil {
+			res := lints.LintResult{
+				RuleMetadata: ruleNewsValidity,
+				Message:      fmt.Sprintf("[%s] Invalid news directory name format: '%s'", lints.SeverityError, dirName),
+				File:         filepath.Join("metadata", "news", dirName),
+				Package:      "metadata/news/" + dirName,
+			}
+			res.RuleMetadata.Severity = lints.SeverityError
+			results = append(results, res)
+		}
+
 		var txtFiles []string
 
 		if r.fs != nil {
@@ -147,6 +165,28 @@ func (r *NewsValidityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, q
 			if r.fs != nil {
 				// in test mode relPath is exactly the matched file path because repoDir is essentially root
 				relPath = txtFile
+			}
+
+			fileName := filepath.Base(txtFile)
+			fileMatch := newsFileNameRegex.FindStringSubmatch(fileName)
+			if fileMatch == nil {
+				res := lints.LintResult{
+					RuleMetadata: ruleNewsValidity,
+					Message:      fmt.Sprintf("[%s] Invalid news file name format: '%s'", lints.SeverityError, fileName),
+					File:         relPath,
+					Package:      "metadata/news/" + dirName,
+				}
+				res.RuleMetadata.Severity = lints.SeverityError
+				results = append(results, res)
+			} else if dirMatch != nil && (fileMatch[1] != dirMatch[1] || fileMatch[2] != dirMatch[2]) {
+				res := lints.LintResult{
+					RuleMetadata: ruleNewsValidity,
+					Message:      fmt.Sprintf("[%s] News file prefix '%s-%s' does not match directory name '%s'", lints.SeverityError, fileMatch[1], fileMatch[2], dirName),
+					File:         relPath,
+					Package:      "metadata/news/" + dirName,
+				}
+				res.RuleMetadata.Severity = lints.SeverityError
+				results = append(results, res)
 			}
 
 			res := r.lintNewsItem(string(content), relPath)

--- a/lints/news/news_test.go
+++ b/lints/news/news_test.go
@@ -29,6 +29,30 @@ Display-If-Installed: invalid_format
 
 Body
 `)},
+		"metadata/news/invalid_dir_name/2024-01-03-news.en.txt": &fstest.MapFile{Data: []byte(`Title: Invalid Dir
+Author: John Doe <john@example.com>
+Posted: 2024-01-03
+Revision: 1
+News-Item-Format: 2.0
+
+Body
+`)},
+		"metadata/news/2024-01-04-invalid-file/invalid_file_name.txt": &fstest.MapFile{Data: []byte(`Title: Invalid File
+Author: John Doe <john@example.com>
+Posted: 2024-01-04
+Revision: 1
+News-Item-Format: 2.0
+
+Body
+`)},
+		"metadata/news/2024-01-05-mismatch-prefix/2024-01-06-mismatch-prefix.en.txt": &fstest.MapFile{Data: []byte(`Title: Mismatched File
+Author: John Doe <john@example.com>
+Posted: 2024-01-05
+Revision: 1
+News-Item-Format: 2.0
+
+Body
+`)},
 	}
 
 	rule := NewNewsValidityLintRule(WithFS(fsys))
@@ -42,12 +66,22 @@ Body
 	}
 
 	var hasAuthorErr, hasDisplayErr bool
+	var hasInvalidDirErr, hasInvalidFileErr, hasMismatchErr bool
 	for _, res := range results {
 		if strings.Contains(res.Message, "Invalid Author format") {
 			hasAuthorErr = true
 		}
 		if strings.Contains(res.Message, "Invalid Display-If-Installed format") {
 			hasDisplayErr = true
+		}
+		if strings.Contains(res.Message, "Invalid news directory name format") {
+			hasInvalidDirErr = true
+		}
+		if strings.Contains(res.Message, "Invalid news file name format") {
+			hasInvalidFileErr = true
+		}
+		if strings.Contains(res.Message, "does not match directory name") {
+			hasMismatchErr = true
 		}
 	}
 
@@ -56,5 +90,14 @@ Body
 	}
 	if !hasDisplayErr {
 		t.Errorf("expected Invalid Display-If-Installed format error")
+	}
+	if !hasInvalidDirErr {
+		t.Errorf("expected Invalid news directory name format error")
+	}
+	if !hasInvalidFileErr {
+		t.Errorf("expected Invalid news file name format error")
+	}
+	if !hasMismatchErr {
+		t.Errorf("expected prefix mismatch error")
 	}
 }


### PR DESCRIPTION
Added regex-based validation for Gentoo news files and directories to ensure compliance with the Gentoo Developer Manual. Validates format and prefix parity. Includes updated tests.

---
*PR created automatically by Jules for task [9176828136306220545](https://jules.google.com/task/9176828136306220545) started by @arran4*