### PR TITLE
feat: separate eclass lint rules and implement starter documentation checks

### DIFF
--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arran4/g2/lints"
 
 	_ "github.com/arran4/g2/lints/ebuild"
+	_ "github.com/arran4/g2/lints/eclass"
 	_ "github.com/arran4/g2/lints/md5cache"
 	_ "github.com/arran4/g2/lints/metadata"
 	_ "github.com/arran4/g2/lints/news"
@@ -325,6 +326,100 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 
 	hasErrors := false
 	var allResults []lints.LintResult
+
+	for _, eclass := range siteData.Eclasses {
+		if len(targetMap) > 0 {
+			eclassName := filepath.Base(eclass.Path)
+			if !targetMap[eclassName] && !targetMap[eclass.Path] && !targetMap["eclass"] {
+				continue
+			}
+		}
+
+		eclassWarnings := lints.PerformEclassLintingResults(location, eclass)
+
+		var filteredEclassWarnings []lints.LintResult
+		for _, w := range eclassWarnings {
+			if severityFilter != "" && !strings.EqualFold(string(w.RuleMetadata.Severity), severityFilter) {
+				continue
+			}
+			if sourceFilter != "" && string(w.RuleMetadata.Source) != sourceFilter {
+				continue
+			}
+			if tagFilter != "" {
+				hasTag := false
+				for _, t := range w.RuleMetadata.Tags {
+					if t == tagFilter {
+						hasTag = true
+						break
+					}
+				}
+				if !hasTag {
+					continue
+				}
+			}
+			isIgnored := false
+			if disableRule != "" {
+				disabled := strings.Split(disableRule, ",")
+				for _, dr := range disabled {
+					if strings.EqualFold(string(w.RuleMetadata.ID), strings.TrimSpace(dr)) {
+						isIgnored = true
+						break
+					}
+				}
+			}
+			if !isIgnored && ignoreTag != "" {
+				ignoredTags := strings.Split(ignoreTag, ",")
+				for _, it := range ignoredTags {
+					it = strings.TrimSpace(it)
+					for _, t := range w.RuleMetadata.Tags {
+						if strings.EqualFold(t, it) {
+							isIgnored = true
+							break
+						}
+					}
+					if isIgnored {
+						break
+					}
+				}
+			}
+			if isIgnored {
+				continue
+			}
+
+			filteredEclassWarnings = append(filteredEclassWarnings, w)
+		}
+
+		for i := range filteredEclassWarnings {
+			if filteredEclassWarnings[i].Package == "" {
+				filteredEclassWarnings[i].Package = filepath.Base(eclass.Path)
+			}
+		}
+
+		if len(filteredEclassWarnings) > 0 {
+			hasErrors = true
+			if format == "text" {
+				packageGroups := make(map[string][]lints.LintResult)
+				for _, w := range filteredEclassWarnings {
+					packageGroups[w.Package] = append(packageGroups[w.Package], w)
+				}
+
+				var pkgNames []string
+				for k := range packageGroups {
+					pkgNames = append(pkgNames, k)
+				}
+				sort.Strings(pkgNames)
+
+				for _, pkgName := range pkgNames {
+					warnings := packageGroups[pkgName]
+					fmt.Printf("[%s]\n", pkgName)
+					for _, w := range warnings {
+						fmt.Printf("  - %s\n", w.Message)
+					}
+				}
+			}
+			allResults = append(allResults, filteredEclassWarnings...)
+		}
+	}
 
 	for _, cat := range siteData.Categories {
 		if query != nil && query.Category != "" && query.Category != cat.Name {

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -328,6 +328,9 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 	var allResults []lints.LintResult
 
 	for _, eclass := range siteData.Eclasses {
+		if query != nil {
+			continue // Skip eclasses for package query
+		}
 		if len(targetMap) > 0 {
 			eclassName := filepath.Base(eclass.Path)
 			if !targetMap[eclassName] && !targetMap[eclass.Path] && !targetMap["eclass"] {

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -50,6 +50,14 @@ func TestParseLintQuery(t *testing.T) {
 				Package:  "foo",
 			},
 		},
+		{
+			name:  "eclass query fallback",
+			query: "foo.eclass",
+			expectedQuery: LintQuery{
+				RepoPath: ".",
+				Package:  "foo.eclass",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lints/eclass/eclass_header.go
+++ b/lints/eclass/eclass_header.go
@@ -1,0 +1,111 @@
+package eclass
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var ruleEclassHeader = lints.RuleMetadata{
+	ID:          "EclassHeader",
+	Title:       "Eclass Header Documentation",
+	Description: "Validates the presence of required documentation tags in eclasses.",
+	URL:         "https://devmanual.gentoo.org/eclass-writing/index.html",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceG2,
+	Tags:        []string{"eclass", "gentoo-policy", "PG0804"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleEclassHeader)
+	lints.RegisterEclassLintRule(&EclassHeaderLintRule{})
+}
+
+type EclassHeaderLintRule struct{}
+
+func (r *EclassHeaderLintRule) Lint(repoDir string, eclass *g2.Ebuild) []lints.LintResult {
+	return r.LintWithQA(repoDir, eclass, nil)
+}
+
+func (r *EclassHeaderLintRule) LintWithQA(repoDir string, eclass *g2.Ebuild, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityWarning
+
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0804"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	if eclass == nil {
+		return results
+	}
+
+	hasEclassTag := false
+	hasMaintainerTag := false
+	hasBlurbTag := false
+
+	lines := strings.Split(eclass.RawText, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# @ECLASS:") {
+			hasEclassTag = true
+		} else if strings.HasPrefix(trimmed, "# @MAINTAINER:") {
+			hasMaintainerTag = true
+		} else if strings.HasPrefix(trimmed, "# @BLURB:") {
+			hasBlurbTag = true
+		}
+	}
+
+	eclassName := filepath.Base(eclass.Path)
+
+	if !hasEclassTag {
+		res := lints.LintResult{
+			RuleMetadata: ruleEclassHeader,
+			Message:      fmt.Sprintf("[%s] Eclass %s is missing the required @ECLASS: documentation tag.", severity, eclassName),
+			Package:      eclassName,
+			File:         eclass.Path,
+		}
+		res.RuleMetadata.Severity = severity
+		results = append(results, res)
+	}
+
+	if !hasMaintainerTag {
+		res := lints.LintResult{
+			RuleMetadata: ruleEclassHeader,
+			Message:      fmt.Sprintf("[%s] Eclass %s is missing the required @MAINTAINER: documentation tag.", severity, eclassName),
+			Package:      eclassName,
+			File:         eclass.Path,
+		}
+		res.RuleMetadata.Severity = severity
+		results = append(results, res)
+	}
+
+	if !hasBlurbTag {
+		res := lints.LintResult{
+			RuleMetadata: ruleEclassHeader,
+			Message:      fmt.Sprintf("[%s] Eclass %s is missing the required @BLURB: documentation tag.", severity, eclassName),
+			Package:      eclassName,
+			File:         eclass.Path,
+		}
+		res.RuleMetadata.Severity = severity
+		results = append(results, res)
+	}
+
+	return results
+}

--- a/lints/eclass/eclass_header_test.go
+++ b/lints/eclass/eclass_header_test.go
@@ -1,0 +1,149 @@
+package eclass
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestEclassHeaderLintRule(t *testing.T) {
+	tests := []struct {
+		name       string
+		eclass     *g2.Ebuild
+		qa         *g2.QAPolicy
+		wantCount  int
+		wantErrors []string
+	}{
+		{
+			name: "All tags present",
+			eclass: &g2.Ebuild{
+				Path: "eclass/test.eclass",
+				RawText: `# @ECLASS: test.eclass
+# @MAINTAINER: test@example.com
+# @BLURB: test blurb
+`,
+			},
+			wantCount: 0,
+		},
+		{
+			name: "Missing BLURB tag",
+			eclass: &g2.Ebuild{
+				Path: "eclass/test.eclass",
+				RawText: `# @ECLASS: test.eclass
+# @MAINTAINER: test@example.com
+`,
+			},
+			wantCount: 1,
+			wantErrors: []string{
+				"[Warning] Eclass test.eclass is missing the required @BLURB: documentation tag.",
+			},
+		},
+		{
+			name: "Missing MAINTAINER tag",
+			eclass: &g2.Ebuild{
+				Path: "eclass/test.eclass",
+				RawText: `# @ECLASS: test.eclass
+# @BLURB: test blurb
+`,
+			},
+			wantCount: 1,
+			wantErrors: []string{
+				"[Warning] Eclass test.eclass is missing the required @MAINTAINER: documentation tag.",
+			},
+		},
+		{
+			name: "Missing ECLASS tag",
+			eclass: &g2.Ebuild{
+				Path: "eclass/test.eclass",
+				RawText: `# @MAINTAINER: test@example.com
+# @BLURB: test blurb
+`,
+			},
+			wantCount: 1,
+			wantErrors: []string{
+				"[Warning] Eclass test.eclass is missing the required @ECLASS: documentation tag.",
+			},
+		},
+		{
+			name: "Missing all tags",
+			eclass: &g2.Ebuild{
+				Path:    "eclass/test.eclass",
+				RawText: ``,
+			},
+			wantCount: 3,
+			wantErrors: []string{
+				"[Warning] Eclass test.eclass is missing the required @ECLASS: documentation tag.",
+				"[Warning] Eclass test.eclass is missing the required @MAINTAINER: documentation tag.",
+				"[Warning] Eclass test.eclass is missing the required @BLURB: documentation tag.",
+			},
+		},
+		{
+			name:   "Nil eclass",
+			eclass: nil,
+			wantCount: 0,
+		},
+		{
+			name: "QA Policy Ignore",
+			eclass: &g2.Ebuild{
+				Path: "eclass/test.eclass",
+				RawText: `# @ECLASS: test.eclass
+# @MAINTAINER: test@example.com
+`,
+			},
+			qa: &g2.QAPolicy{
+				Policies: map[string]string{"PG0804": "ignore"},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "QA Policy Error",
+			eclass: &g2.Ebuild{
+				Path: "eclass/test.eclass",
+				RawText: `# @ECLASS: test.eclass
+# @MAINTAINER: test@example.com
+`,
+			},
+			qa: &g2.QAPolicy{
+				Policies: map[string]string{"PG0804": "error"},
+			},
+			wantCount: 1,
+			wantErrors: []string{
+				"[Error] Eclass test.eclass is missing the required @BLURB: documentation tag.",
+			},
+		},
+		{
+			name: "QA Policy Notice",
+			eclass: &g2.Ebuild{
+				Path: "eclass/test.eclass",
+				RawText: `# @ECLASS: test.eclass
+# @MAINTAINER: test@example.com
+`,
+			},
+			qa: &g2.QAPolicy{
+				Policies: map[string]string{"PG0804": "notice"},
+			},
+			wantCount: 1,
+			wantErrors: []string{
+				"[Notice] Eclass test.eclass is missing the required @BLURB: documentation tag.",
+			},
+		},
+	}
+
+	rule := &EclassHeaderLintRule{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := rule.LintWithQA(".", tt.eclass, tt.qa)
+			if len(results) != tt.wantCount {
+				t.Errorf("expected %d results, got %d", tt.wantCount, len(results))
+			}
+			if tt.wantCount > 0 && len(results) == tt.wantCount {
+				for i, want := range tt.wantErrors {
+					if results[i].Message != want {
+						t.Errorf("expected result message %q, got %q", want, results[i].Message)
+					}
+				}
+			}
+		})
+	}
+}

--- a/lints/registry.go
+++ b/lints/registry.go
@@ -52,10 +52,23 @@ type QAAwareLintRule interface {
 	LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []LintResult
 }
 
+type EclassLintRule interface {
+	Lint(repoDir string, eclass *g2.Ebuild) []LintResult
+}
+
+type QAAwareEclassLintRule interface {
+	LintWithQA(repoDir string, eclass *g2.Ebuild, qa *g2.QAPolicy) []LintResult
+}
+
 var lintRules []LintRule
+var eclassLintRules []EclassLintRule
 
 func RegisterLintRule(rule LintRule) {
 	lintRules = append(lintRules, rule)
+}
+
+func RegisterEclassLintRule(rule EclassLintRule) {
+	eclassLintRules = append(eclassLintRules, rule)
 }
 
 func PerformLintingResults(repoDir string, pkg *g2.PackageData) []LintResult {
@@ -81,6 +94,23 @@ func PerformLinting(repoDir string, pkg *g2.PackageData) []string {
 		warnings = append(warnings, res.Message)
 	}
 	return warnings
+}
+
+func PerformEclassLintingResults(repoDir string, eclass *g2.Ebuild) []LintResult {
+	var results []LintResult
+
+	// Try to load QA Policy
+	qaPolicyPath := filepath.Join(repoDir, "metadata", "qa-policy.conf")
+	qa, _ := g2.ParseQAPolicy(qaPolicyPath)
+
+	for _, rule := range eclassLintRules {
+		if qaRule, ok := rule.(QAAwareEclassLintRule); ok {
+			results = append(results, qaRule.LintWithQA(repoDir, eclass, qa)...)
+		} else {
+			results = append(results, rule.Lint(repoDir, eclass)...)
+		}
+	}
+	return results
 }
 
 type MetadataAwareLintRule interface {


### PR DESCRIPTION
Introduces separate interfaces and logic for linting Gentoo eclasses, complete with starter rules to validate header documentation according to the Gentoo Devmanual.

---
*PR created automatically by Jules for task [1155237646832366230](https://jules.google.com/task/1155237646832366230) started by @arran4*