### PR TITLE
fix(lint): update invalid slot regex for correct portage specifications

### DIFF
--- a/lints/ebuild/invalid_slot.go
+++ b/lints/ebuild/invalid_slot.go
@@ -22,7 +22,7 @@ var ruleInvalidSlot = lints.RuleMetadata{
 
 // PMS 3.1.3: Alphanumeric, plus _, ., -
 // Can optionally have a subslot, separated by /
-var validSlotRegex = regexp.MustCompile(`^[A-Za-z0-9_.-]+(/[A-Za-z0-9_.-]+)?$`)
+var validSlotRegex = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.\-+]*(/[A-Za-z0-9_][A-Za-z0-9_.\-+]*)?$`)
 
 func init() {
 	lints.RegisterRuleMetadata(ruleInvalidSlot)

--- a/lints/ebuild/invalid_slot_test.go
+++ b/lints/ebuild/invalid_slot_test.go
@@ -19,9 +19,14 @@ func TestInvalidSlotLintRule(t *testing.T) {
 		{"Valid slot", "1", 0},
 		{"Valid subslot", "0/1", 0},
 		{"Valid complex", "1.2_alpha-r1", 0},
+		{"Valid with plus", "kde-frameworks+qt5", 0},
+		{"Valid subslot with plus", "good/sub-slot+1", 0},
 		{"Invalid character", "1:2", 1},
 		{"Invalid character space", "1 2", 1},
 		{"Invalid multiple slashes", "1/2/3", 1},
+		{"Invalid start plus", "+bad", 1},
+		{"Invalid start minus", "-bad", 1},
+		{"Invalid start dot", ".bad", 1},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Updates the slot name validation in the InvalidSlot lint rule to match current Portage specifications. Slots and sub-slots can now validly start with an alphanumeric or `_` and can contain `+` alongside the previously allowed characters. Included new test cases to ensure correct behavior.

---
*PR created automatically by Jules for task [11195020684870718767](https://jules.google.com/task/11195020684870718767) started by @arran4*