### PR TITLE
Fix g2 ebuild next-revision ignoring exact string literal matching on dirty inputs

### DIFF
--- a/cmd/g2/ebuild_next_revision.go
+++ b/cmd/g2/ebuild_next_revision.go
@@ -88,9 +88,7 @@ func sanitizeVersion(v string) string {
 	if atom.Version != "" {
 		v = atom.Version
 	}
-	if strings.HasPrefix(v, "v") {
-		v = strings.TrimPrefix(v, "v")
-	}
+	v = strings.TrimPrefix(v, "v")
 	return v
 }
 

--- a/cmd/g2/ebuild_next_revision.go
+++ b/cmd/g2/ebuild_next_revision.go
@@ -71,10 +71,45 @@ func compareEbuilds(file1, file2 string) (bool, error) {
 	return true, nil
 }
 
+func sanitizeVersion(v string) string {
+	for {
+		changed := false
+		for _, suffix := range []string{".ebuild", ".tmp", ".tbz2", ".tar.gz", ".tar.bz2", ".tar.xz", ".tar.zst"} {
+			if strings.HasSuffix(v, suffix) {
+				v = strings.TrimSuffix(v, suffix)
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	atom := g2.ParsePackageAtom("=" + v)
+	if atom.Version != "" {
+		v = atom.Version
+	}
+	if strings.HasPrefix(v, "v") {
+		v = strings.TrimPrefix(v, "v")
+	}
+	return v
+}
+
 func getNextRevision(dir, version string, inspectFile string) (string, int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return "", -1, fmt.Errorf("failed to read directory %s: %w", dir, err)
+	}
+
+	sanitized := sanitizeVersion(version)
+	targetGV := g2.ParseGentooVersion(sanitized)
+	var targetBase string
+	if targetGV.IsValid {
+		origRev := targetGV.Revision
+		targetGV.Revision = 0
+		targetBase = targetGV.String()
+		targetGV.Revision = origRev
+	} else {
+		targetBase = sanitized
 	}
 
 	var highestRevGV g2.GentooVersion
@@ -102,7 +137,7 @@ func getNextRevision(dir, version string, inspectFile string) (string, int, erro
 		base := gv.String()
 		gv.Revision = origRev
 
-		if base == version {
+		if base == targetBase {
 			if !found || gv.Revision > highestRevGV.Revision {
 				highestRevGV = gv
 				highestRevFile = filepath.Join(dir, name)
@@ -112,7 +147,7 @@ func getNextRevision(dir, version string, inspectFile string) (string, int, erro
 	}
 
 	if !found {
-		return version, 0, nil
+		return targetBase, 0, nil
 	}
 
 	if inspectFile != "" {

--- a/cmd/g2/ebuild_next_revision_test.go
+++ b/cmd/g2/ebuild_next_revision_test.go
@@ -48,6 +48,12 @@ func TestGetNextRevision(t *testing.T) {
 		{"Existing revision, no inspect", "1.0", "", "1.0-r2", 0},
 		{"Existing revision, inspect match", "1.0", inspectMatch, "1.0-r1", 1},
 		{"Existing revision, inspect differ", "1.0", inspectDiffer, "1.0-r2", 0},
+		{"Sanitized .ebuild suffix", "1.0.ebuild", "", "1.0-r2", 0},
+		{"Sanitized .tmp suffix", "1.0.tmp", "", "1.0-r2", 0},
+		{"Sanitized v prefix", "v1.0", "", "1.0-r2", 0},
+		{"Sanitized package name", "foo-1.0", "", "1.0-r2", 0},
+		{"Sanitized package name and suffix", "foo-1.0.ebuild", "", "1.0-r2", 0},
+		{"Sanitized package name with revision", "foo-1.0-r5", "", "1.0-r2", 0},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes an issue where `g2 ebuild next-revision` receives an unsterilized variable input like `v0.2.6.44` or `0.2.6.44.ebuild` and incorrectly outputs `v0.2.6.44` because it strictly evaluates `base == version`. Now, it actively strips common suffixes and prefixes and validates the version string thoroughly to ensure robust execution in external workflows.

---
*PR created automatically by Jules for task [17348408164490190487](https://jules.google.com/task/17348408164490190487) started by @arran4*