### PR TITLE
feat(lint): add TreeLayoutFiles rule for valid file names

### DIFF
--- a/lints/ebuild/tree_layout_files.go
+++ b/lints/ebuild/tree_layout_files.go
@@ -1,0 +1,55 @@
+package ebuild
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var ruleTreeLayoutFiles = lints.RuleMetadata{
+	ID:          "TreeLayoutFiles",
+	Title:       "Tree Layout Files Naming",
+	Description: "Checks if files in the package directory follow naming rules: no characters outside [A-Za-z0-9._+-] and not starting with a dot, a hyphen, or a plus sign.",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"repo-layout"},
+}
+
+// TreeLayoutFilesLintRule checks if file names adhere to Gentoo tree rules.
+type TreeLayoutFilesLintRule struct{}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleTreeLayoutFiles)
+	lints.RegisterLintRule(&TreeLayoutFilesLintRule{})
+}
+
+var invalidCharsRegex = regexp.MustCompile(`[^A-Za-z0-9._+-]`)
+var invalidStartRegex = regexp.MustCompile(`^[.+-]`)
+
+func (l *TreeLayoutFilesLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, file := range pkg.Files {
+		name := file.Name
+
+		if invalidStartRegex.MatchString(name) {
+			results = append(results, lints.LintResult{
+				RuleMetadata: ruleTreeLayoutFiles,
+				Message:      fmt.Sprintf("file '%s' starts with a dot, hyphen, or plus sign", name),
+				Package:      pkg.Category + "/" + pkg.Name,
+				File:         file.Path,
+			})
+		} else if invalidCharsRegex.MatchString(name) {
+			results = append(results, lints.LintResult{
+				RuleMetadata: ruleTreeLayoutFiles,
+				Message:      fmt.Sprintf("file '%s' contains characters outside [A-Za-z0-9._+-]", name),
+				Package:      pkg.Category + "/" + pkg.Name,
+				File:         file.Path,
+			})
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/tree_layout_files_test.go
+++ b/lints/ebuild/tree_layout_files_test.go
@@ -1,0 +1,43 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestTreeLayoutFilesLintRule(t *testing.T) {
+	rule := &TreeLayoutFilesLintRule{}
+
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "foo",
+		Files: []g2.FileData{
+			{Name: "valid-name.patch", Path: "app-misc/foo/files/valid-name.patch"},
+			{Name: ".hidden", Path: "app-misc/foo/files/.hidden"},
+			{Name: "-test", Path: "app-misc/foo/files/-test"},
+			{Name: "+test", Path: "app-misc/foo/files/+test"},
+			{Name: "te!st", Path: "app-misc/foo/files/te!st"},
+			{Name: "a", Path: "app-misc/foo/files/a"},
+		},
+	}
+
+	results := rule.Lint("", pkg)
+
+	expectedMessages := []string{
+		"file '.hidden' starts with a dot, hyphen, or plus sign",
+		"file '-test' starts with a dot, hyphen, or plus sign",
+		"file '+test' starts with a dot, hyphen, or plus sign",
+		"file 'te!st' contains characters outside [A-Za-z0-9._+-]",
+	}
+
+	if len(results) != len(expectedMessages) {
+		t.Fatalf("expected %d results, got %d", len(expectedMessages), len(results))
+	}
+
+	for i, expected := range expectedMessages {
+		if results[i].Message != expected {
+			t.Errorf("expected message %q, got %q", expected, results[i].Message)
+		}
+	}
+}


### PR DESCRIPTION
Add `TreeLayoutFilesLintRule` to enforce Gentoo's repository layout file naming constraints within package directories, ensuring they do not contain invalid characters or start with `.`, `-`, or `+`.

---
*PR created automatically by Jules for task [1542603435370383806](https://jules.google.com/task/1542603435370383806) started by @arran4*