### PR TITLE
Add InvalidVirtual lint rule to check virtual variables

### DIFF
--- a/lints/ebuild/invalid_virtual.go
+++ b/lints/ebuild/invalid_virtual.go
@@ -1,0 +1,80 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleInvalidVirtual = lints.RuleMetadata{
+	ID:          "InvalidVirtual",
+	Title:       "Invalid Virtual",
+	Description: "Checks if a virtual package defines HOMEPAGE or LICENSE variables, which it should not.",
+	URL:         "https://devmanual.gentoo.org/general-concepts/virtuals/index.html",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleInvalidVirtual)
+	lints.RegisterLintRule(&InvalidVirtualLintRule{})
+}
+
+type InvalidVirtualLintRule struct{}
+
+func (r *InvalidVirtualLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *InvalidVirtualLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if pkg.Category != "virtual" {
+		return nil
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			homepage := strings.TrimSpace(ver.Ebuild.Vars["HOMEPAGE"])
+			license := strings.TrimSpace(ver.Ebuild.Vars["LICENSE"])
+			srcUri := strings.TrimSpace(ver.Ebuild.Vars["SRC_URI"])
+
+			if homepage != "" {
+				res := lints.LintResult{
+					RuleMetadata: ruleInvalidVirtual,
+					Message:      fmt.Sprintf("[%s] Ebuild %s is a virtual but defines HOMEPAGE", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+
+			if license != "" {
+				res := lints.LintResult{
+					RuleMetadata: ruleInvalidVirtual,
+					Message:      fmt.Sprintf("[%s] Ebuild %s is a virtual but defines LICENSE", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+
+			if srcUri != "" {
+				res := lints.LintResult{
+					RuleMetadata: ruleInvalidVirtual,
+					Message:      fmt.Sprintf("[%s] Ebuild %s is a virtual but defines SRC_URI", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+	return results
+}

--- a/lints/ebuild/invalid_virtual_test.go
+++ b/lints/ebuild/invalid_virtual_test.go
@@ -1,0 +1,48 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestInvalidVirtual(t *testing.T) {
+	tests := []struct {
+		name     string
+		category string
+		version  string
+		vars     map[string]string
+		want     int
+	}{
+		{"Valid virtual", "virtual", "1.0", map[string]string{"EAPI": "8"}, 0},
+		{"Non-virtual with homepage", "app-misc", "1.0", map[string]string{"HOMEPAGE": "https://example.com"}, 0},
+		{"Virtual with homepage", "virtual", "1.0", map[string]string{"HOMEPAGE": "https://example.com"}, 1},
+		{"Virtual with license", "virtual", "1.0", map[string]string{"LICENSE": "GPL-2"}, 1},
+		{"Virtual with SRC_URI", "virtual", "1.0", map[string]string{"SRC_URI": "https://example.com/file.tar.gz"}, 1},
+		{"Virtual with multiple invalid", "virtual", "1.0", map[string]string{"HOMEPAGE": "https://example.com", "LICENSE": "GPL-2"}, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Name:     "testpkg",
+				Versions: []g2.VersionData{
+					{
+						Version: tt.version,
+						Ebuild: &g2.Ebuild{
+							Vars: tt.vars,
+						},
+					},
+				},
+			}
+
+			rule := &InvalidVirtualLintRule{}
+			results := rule.Lint("", pkg)
+
+			if len(results) != tt.want {
+				t.Errorf("Lint() returned %d results, want %d", len(results), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces the `InvalidVirtualLintRule` in `lints/ebuild/invalid_virtual.go`, enforcing rules outlined in the Gentoo Devmanual. Packages categorized as `virtual` should not define variables like `HOMEPAGE`, `LICENSE`, or `SRC_URI`, as virtuals do not install any files. A comprehensive test suite for this new behavior is provided in `lints/ebuild/invalid_virtual_test.go`.

---
*PR created automatically by Jules for task [8342606454748436501](https://jules.google.com/task/8342606454748436501) started by @arran4*