### PR TITLE
feat: add KeywordIUSE lint rule

### DIFF
--- a/lints/ebuild/keyword_iuse.go
+++ b/lints/ebuild/keyword_iuse.go
@@ -1,0 +1,94 @@
+package ebuild
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleKeywordIUSE = lints.RuleMetadata{
+	ID:          "KeywordIUSE",
+	Title:       "Keyword in IUSE",
+	Description: "Checks if a keyword is used in IUSE or `use <keyword>` checks.",
+	Severity:    lints.SeverityWarning,
+	Source:      "g2",
+	Tags:        []string{"ebuild", "use", "keywords"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleKeywordIUSE)
+	lints.RegisterLintRule(&KeywordIUSELintRule{})
+}
+
+type KeywordIUSELintRule struct{}
+
+func (r *KeywordIUSELintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *KeywordIUSELintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	// Get arches list to know the keywords
+	archesFile := filepath.Join(repoDir, "profiles", "arch.list")
+	arches, err := g2.ParseArchListFile(archesFile)
+	if err != nil {
+		return results
+	}
+
+	knownArches := make(map[string]bool)
+	for _, arch := range arches.Arches {
+		knownArches[arch] = true
+		knownArches["~"+arch] = true
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild == nil || ver.Ebuild.Vars == nil {
+			continue
+		}
+
+		iuse := ver.Ebuild.Vars["IUSE"]
+		if iuse != "" {
+			parsedFlags := g2.ParseIUSE(iuse)
+			for _, flag := range parsedFlags {
+				if knownArches[flag] {
+					results = append(results, lints.LintResult{
+						RuleMetadata: ruleKeywordIUSE,
+						Message:      fmt.Sprintf("Version %s: Architecture keyword '%s' found in IUSE", ver.Version, flag),
+						File:         fmt.Sprintf("%s-%s.ebuild", pkg.Name, ver.Version),
+					})
+				}
+			}
+		}
+
+		// Also check for `use <keyword>` and `usex <keyword>` etc.
+		if ver.Ebuild.RawText != "" {
+			f, err := syntax.NewParser().Parse(strings.NewReader(ver.Ebuild.RawText), "")
+			if err == nil {
+				syntax.Walk(f, func(node syntax.Node) bool {
+					call, ok := node.(*syntax.CallExpr)
+					if ok && len(call.Args) > 1 {
+						cmd := call.Args[0].Lit()
+						if cmd == "use" || cmd == "usex" || cmd == "use_with" || cmd == "use_enable" || cmd == "useq" || cmd == "usev" {
+							arg := call.Args[1].Lit()
+							if knownArches[arg] {
+								results = append(results, lints.LintResult{
+									RuleMetadata: ruleKeywordIUSE,
+									Message:      fmt.Sprintf("Version %s: Architecture keyword '%s' used in `%s %s`", ver.Version, arg, cmd, arg),
+									File:         fmt.Sprintf("%s-%s.ebuild", pkg.Name, ver.Version),
+								})
+							}
+						}
+					}
+					return true
+				})
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/keyword_iuse_test.go
+++ b/lints/ebuild/keyword_iuse_test.go
@@ -1,0 +1,80 @@
+package ebuild_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeywordIUSELintRule(t *testing.T) {
+	rule := &ebuild.KeywordIUSELintRule{}
+	repoDir := filepath.Join("testdata", "repo")
+
+	tests := []struct {
+		name          string
+		version       string
+		vars          map[string]string
+		rawText       string
+		expectedCount int
+	}{
+		{
+			name:          "No issues",
+			version:       "1.0",
+			vars:          map[string]string{"IUSE": "debug test"},
+			rawText:       `use debug && echo "debug"`,
+			expectedCount: 0,
+		},
+		{
+			name:          "Keyword in IUSE",
+			version:       "1.1",
+			vars:          map[string]string{"IUSE": "debug x86 test"},
+			rawText:       ``,
+			expectedCount: 1,
+		},
+		{
+			name:          "Keyword in use check",
+			version:       "1.2",
+			vars:          map[string]string{"IUSE": "debug test"},
+			rawText:       `if use x86; then echo "x86"; fi`,
+			expectedCount: 1,
+		},
+		{
+			name:          "Tilde keyword in use check",
+			version:       "1.3",
+			vars:          map[string]string{"IUSE": "debug test"},
+			rawText:       `if use ~x86; then echo "x86"; fi`,
+			expectedCount: 1,
+		},
+		{
+			name:          "Keyword in usex check",
+			version:       "1.4",
+			vars:          map[string]string{"IUSE": "debug test"},
+			rawText:       `usex x86`,
+			expectedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkgData := &g2.PackageData{
+				Name:     "app-test/testpkg",
+				Category: "app-test",
+				Versions: []g2.VersionData{
+					{
+						Version: tt.version,
+						Ebuild: &g2.Ebuild{
+							Vars:    tt.vars,
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint(repoDir, pkgData)
+			assert.Len(t, results, tt.expectedCount)
+		})
+	}
+}

--- a/lints/ebuild/testdata/repo/profiles/arch.list
+++ b/lints/ebuild/testdata/repo/profiles/arch.list
@@ -1,0 +1,3 @@
+amd64
+x86
+sparc


### PR DESCRIPTION
This PR implements the `KeywordIUSE` lint rule, mitigating common developer misconceptions where architecture variables are assumed to act like `USE` flags in ebuilds.

- Uses `profiles/arch.list` dynamically via `g2.ParseArchListFile`.
- Expands the set to track unstable variations (e.g. `~arch`).
- Verifies both `IUSE` values and shell conditionals via `mvdan.cc/sh/v3/syntax`.
- Adds tests with both positive and negative cases.

---
*PR created automatically by Jules for task [11144581915513780145](https://jules.google.com/task/11144581915513780145) started by @arran4*