### PR TITLE
feat: add ebuild respect_variables lint rule

### DIFF
--- a/lints/ebuild/respect_variables.go
+++ b/lints/ebuild/respect_variables.go
@@ -1,0 +1,81 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleRespectVariables = lints.RuleMetadata{
+	ID:          "RespectVariables",
+	Title:       "Respect Variables",
+	Description: "Checks for assignments that overwrite CFLAGS, CXXFLAGS, or LDFLAGS without appending or referencing the original variable.",
+	URL:         "https://devmanual.gentoo.org/general-concepts/user-environment/index.html",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "qa"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleRespectVariables)
+	lints.RegisterLintRule(&RespectVariablesLintRule{})
+}
+
+type RespectVariablesLintRule struct{}
+
+func (l *RespectVariablesLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, version := range pkgData.Versions {
+		if version.Ebuild == nil {
+			continue
+		}
+
+		parser := syntax.NewParser()
+		f, err := parser.Parse(strings.NewReader(version.Ebuild.RawText), "")
+		if err != nil {
+			continue
+		}
+
+		syntax.Walk(f, func(node syntax.Node) bool {
+			if assign, ok := node.(*syntax.Assign); ok {
+				if assign.Name != nil && assign.Value != nil { // Ignore `export CFLAGS` where Value is nil
+					name := assign.Name.Value
+					if name == "CFLAGS" || name == "CXXFLAGS" || name == "LDFLAGS" {
+						if !assign.Append && !hasSelfReference(assign.Value, name) {
+							res := lints.LintResult{
+								RuleMetadata: ruleRespectVariables,
+								Message:      fmt.Sprintf("Ebuild %s overwrites %s unconditionally. You must respect the user's %s (e.g., use += or filter-flags instead).", version.Ebuild.Path, name, name),
+								Package:      pkgData.Category + "/" + pkgData.Name,
+							}
+							results = append(results, res)
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	return results
+}
+
+func hasSelfReference(word *syntax.Word, varName string) bool {
+	if word == nil {
+		return false
+	}
+	found := false
+	syntax.Walk(word, func(node syntax.Node) bool {
+		if param, ok := node.(*syntax.ParamExp); ok {
+			if param.Param != nil && param.Param.Value == varName {
+				found = true
+				return false // stop walking
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/lints/ebuild/respect_variables_test.go
+++ b/lints/ebuild/respect_variables_test.go
@@ -1,0 +1,138 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestRespectVariablesLintRule(t *testing.T) {
+	tests := []struct {
+		name          string
+		ebuildContent string
+		expectError   bool
+		variable      string
+	}{
+		{
+			name: "Overwrite CFLAGS unconditionally",
+			ebuildContent: `
+src_prepare() {
+	CFLAGS="-O2"
+}`,
+			expectError: true,
+			variable:    "CFLAGS",
+		},
+		{
+			name: "Overwrite CXXFLAGS unconditionally",
+			ebuildContent: `
+src_prepare() {
+	CXXFLAGS="-O3"
+}`,
+			expectError: true,
+			variable:    "CXXFLAGS",
+		},
+		{
+			name: "Overwrite LDFLAGS unconditionally",
+			ebuildContent: `
+src_prepare() {
+	LDFLAGS="-Wl,-O1"
+}`,
+			expectError: true,
+			variable:    "LDFLAGS",
+		},
+		{
+			name: "Append to CFLAGS",
+			ebuildContent: `
+src_prepare() {
+	CFLAGS+=" -O2"
+}`,
+			expectError: false,
+		},
+		{
+			name: "Self-reference CFLAGS",
+			ebuildContent: `
+src_prepare() {
+	CFLAGS="${CFLAGS} -O2"
+}`,
+			expectError: false,
+		},
+		{
+			name: "Self-reference CXXFLAGS",
+			ebuildContent: `
+src_prepare() {
+	CXXFLAGS="$(filter-flags "-O2" "${CXXFLAGS}")"
+}`,
+			expectError: false,
+		},
+		{
+			name: "Export CFLAGS without value",
+			ebuildContent: `
+src_prepare() {
+	export CFLAGS
+}`,
+			expectError: false,
+		},
+		{
+			name: "Local CFLAGS overwrite",
+			ebuildContent: `
+src_prepare() {
+	local CFLAGS="-O2"
+}`,
+			expectError: true,
+			variable:    "CFLAGS",
+		},
+		{
+			name: "Export CFLAGS overwrite",
+			ebuildContent: `
+src_prepare() {
+	export CFLAGS="-O2"
+}`,
+			expectError: true,
+			variable:    "CFLAGS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := &RespectVariablesLintRule{}
+			pkgData := &g2.PackageData{
+				Category: "app-misc",
+				Name:     "testpkg",
+				Versions: []g2.VersionData{
+					{
+						Ebuild: &g2.Ebuild{
+							Path:    "app-misc/testpkg/testpkg-1.0.ebuild",
+							RawText: tt.ebuildContent,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint(".", pkgData)
+
+			if tt.expectError {
+				if len(results) == 0 {
+					t.Fatalf("Expected error for overwriting %s, got none.", tt.variable)
+				}
+				found := false
+				for _, res := range results {
+					if res.RuleMetadata.ID == ruleRespectVariables.ID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("Expected RespectVariables lint error, got: %v", results)
+				}
+			} else {
+				if len(results) > 0 {
+					for _, res := range results {
+						if res.RuleMetadata.ID == ruleRespectVariables.ID {
+							t.Fatalf("Expected no errors, got: %v", res.Message)
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds an ebuild lint rule that prevents CFLAGS, CXXFLAGS, and LDFLAGS from being unconditionally overwritten.

---
*PR created automatically by Jules for task [5195590623800168380](https://jules.google.com/task/5195590623800168380) started by @arran4*