### PR TITLE
feat: add Md5CacheInvalid lint rule

### DIFF
--- a/lints/md5cache/md5cache_invalid.go
+++ b/lints/md5cache/md5cache_invalid.go
@@ -1,0 +1,193 @@
+package md5cache
+
+import (
+	"bufio"
+	"crypto/md5"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+/*
+Note: The format of the md5-cache file was verified using the egencache tool in a gentoo/stage3 Docker container:
+```bash
+docker run --rm gentoo/stage3:latest bash -c "
+  emerge --info
+  mkdir -p /var/db/repos/testrepo/profiles
+  mkdir -p /var/db/repos/testrepo/app-test/test
+  echo 'testrepo' > /var/db/repos/testrepo/profiles/repo_name
+  echo 'app-test' > /var/db/repos/testrepo/profiles/categories
+  echo 'EAPI=8' > /var/db/repos/testrepo/app-test/test/test-1.0.ebuild
+  echo 'DESCRIPTION=\"test\"' >> /var/db/repos/testrepo/app-test/test/test-1.0.ebuild
+  echo 'SLOT=\"0\"' >> /var/db/repos/testrepo/app-test/test/test-1.0.ebuild
+
+  mkdir -p /etc/portage/repos.conf
+  cat << INN > /etc/portage/repos.conf/testrepo.conf
+[testrepo]
+location = /var/db/repos/testrepo
+masters =
+auto-sync = no
+INN
+
+  egencache --repo testrepo --update
+
+  cat /var/db/repos/testrepo/metadata/md5-cache/app-test/test-1.0
+"
+```
+The output format consists of `KEY=VALUE` pairs separated by newlines.
+The `_md5_` key contains the md5sum of the ebuild.
+The `_eclasses_` key contains pairs of `eclass_name eclass_md5` separated by whitespace (tab).
+*/
+
+var ruleMD5CacheInvalid = lints.RuleMetadata{
+	ID:          "Md5CacheInvalid",
+	Title:       "Invalid MD5 Cache",
+	Description: "Verifies that md5-cache entries are correctly formatted, contain correct ebuild md5sums, and valid eclass md5sums.",
+	URL:         "https://devmanual.gentoo.org/general-concepts/portage-cache/index.html",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceG2,
+	Tags:        []string{"md5-cache", "site-quality", "PG0803"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleMD5CacheInvalid)
+	lints.RegisterLintRule(&MD5CacheInvalidLintRule{})
+}
+
+type MD5CacheInvalidLintRule struct {
+}
+
+func (r *MD5CacheInvalidLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *MD5CacheInvalidLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityWarning
+
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0803"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil {
+			cachePath := filepath.Join(repoDir, "metadata", "md5-cache", pkg.Category, pkg.Name+"-"+ver.Version)
+
+			f, err := os.Open(cachePath)
+			if err != nil {
+				// Handled by missing md5-cache rule
+				continue
+			}
+
+			scanner := bufio.NewScanner(f)
+			hasEbuildMd5 := false
+			var ebuildMd5 string
+			var eclassesLine string
+			for scanner.Scan() {
+				line := scanner.Text()
+				parts := strings.SplitN(line, "=", 2)
+				if len(parts) != 2 {
+					sevStr := string(severity)
+					sevTitle := strings.ToUpper(sevStr[:1]) + sevStr[1:]
+					res := lints.LintResult{
+						RuleMetadata: ruleMD5CacheInvalid,
+						Message:      fmt.Sprintf("[%s] Invalid format in md5-cache for %s-%s: %s", sevTitle, pkg.Name, ver.Version, line),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+					continue
+				}
+
+				if parts[0] == "_md5_" {
+					hasEbuildMd5 = true
+					ebuildMd5 = parts[1]
+				} else if parts[0] == "_eclasses_" {
+					eclassesLine = parts[1]
+				}
+			}
+			f.Close()
+
+			sevStr := string(severity)
+			sevTitle := strings.ToUpper(sevStr[:1]) + sevStr[1:]
+
+			if !hasEbuildMd5 {
+				res := lints.LintResult{
+					RuleMetadata: ruleMD5CacheInvalid,
+					Message:      fmt.Sprintf("[%s] Missing _md5_ in md5-cache for %s-%s", sevTitle, pkg.Name, ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			} else {
+				ebuildPath := filepath.Join(repoDir, pkg.Category, pkg.Name, pkg.Name+"-"+ver.Version+".ebuild")
+				ebuildData, err := os.ReadFile(ebuildPath)
+				if err == nil {
+					actualMd5 := fmt.Sprintf("%x", md5.Sum(ebuildData))
+					if actualMd5 != ebuildMd5 {
+						res := lints.LintResult{
+							RuleMetadata: ruleMD5CacheInvalid,
+							Message:      fmt.Sprintf("[%s] Incorrect _md5_ in md5-cache for %s-%s. Expected %s, got %s", sevTitle, pkg.Name, ver.Version, actualMd5, ebuildMd5),
+							Package:      pkg.Category + "/" + pkg.Name,
+						}
+						res.RuleMetadata.Severity = severity
+						results = append(results, res)
+					}
+				}
+			}
+
+			if eclassesLine != "" {
+				eclassParts := strings.Fields(eclassesLine)
+				if len(eclassParts)%2 != 0 {
+					res := lints.LintResult{
+						RuleMetadata: ruleMD5CacheInvalid,
+						Message:      fmt.Sprintf("[%s] Invalid _eclasses_ format in md5-cache for %s-%s", sevTitle, pkg.Name, ver.Version),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+				} else {
+					for i := 0; i < len(eclassParts); i += 2 {
+						eclassName := eclassParts[i]
+						eclassMd5 := eclassParts[i+1]
+
+						eclassPath := filepath.Join(repoDir, "eclass", eclassName+".eclass")
+						eclassData, err := os.ReadFile(eclassPath)
+						if err == nil {
+							actualEclassMd5 := fmt.Sprintf("%x", md5.Sum(eclassData))
+							if actualEclassMd5 != eclassMd5 {
+								res := lints.LintResult{
+									RuleMetadata: ruleMD5CacheInvalid,
+									Message:      fmt.Sprintf("[%s] Incorrect eclass md5 for %s in md5-cache of %s-%s. Expected %s, got %s", sevTitle, eclassName, pkg.Name, ver.Version, actualEclassMd5, eclassMd5),
+									Package:      pkg.Category + "/" + pkg.Name,
+								}
+								res.RuleMetadata.Severity = severity
+								results = append(results, res)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/md5cache/md5cache_invalid.go
+++ b/lints/md5cache/md5cache_invalid.go
@@ -117,14 +117,15 @@ func (r *MD5CacheInvalidLintRule) LintWithQA(repoDir string, pkg *g2.PackageData
 					continue
 				}
 
-				if parts[0] == "_md5_" {
+				switch parts[0] {
+				case "_md5_":
 					hasEbuildMd5 = true
 					ebuildMd5 = parts[1]
-				} else if parts[0] == "_eclasses_" {
+				case "_eclasses_":
 					eclassesLine = parts[1]
 				}
 			}
-			f.Close()
+			_ = f.Close()
 
 			sevStr := string(severity)
 			sevTitle := strings.ToUpper(sevStr[:1]) + sevStr[1:]

--- a/lints/md5cache/md5cache_invalid_test.go
+++ b/lints/md5cache/md5cache_invalid_test.go
@@ -28,22 +28,22 @@ func TestMD5CacheInvalidLintRule(t *testing.T) {
 
 	// 1. Valid cache
 	cacheDir := filepath.Join(tempDir, "metadata", "md5-cache", "app-misc")
-	os.MkdirAll(cacheDir, 0755)
+	_ = os.MkdirAll(cacheDir, 0755)
 	cacheFile := filepath.Join(cacheDir, "foo-1.0")
 
 	ebuildDir := filepath.Join(tempDir, "app-misc", "foo")
-	os.MkdirAll(ebuildDir, 0755)
+	_ = os.MkdirAll(ebuildDir, 0755)
 	ebuildFile := filepath.Join(ebuildDir, "foo-1.0.ebuild")
-	os.WriteFile(ebuildFile, []byte("EAPI=8\n"), 0644)
+	_ = os.WriteFile(ebuildFile, []byte("EAPI=8\n"), 0644)
 	md5sum := fmt.Sprintf("%x", md5.Sum([]byte("EAPI=8\n")))
 
 	eclassDir := filepath.Join(tempDir, "eclass")
-	os.MkdirAll(eclassDir, 0755)
+	_ = os.MkdirAll(eclassDir, 0755)
 	eclassFile := filepath.Join(eclassDir, "test.eclass")
-	os.WriteFile(eclassFile, []byte("# test\n"), 0644)
+	_ = os.WriteFile(eclassFile, []byte("# test\n"), 0644)
 	eclassMd5 := fmt.Sprintf("%x", md5.Sum([]byte("# test\n")))
 
-	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", md5sum, eclassMd5)), 0644)
+	_ = os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", md5sum, eclassMd5)), 0644)
 
 	results := rule.Lint(tempDir, pkg)
 	if len(results) != 0 {
@@ -51,7 +51,7 @@ func TestMD5CacheInvalidLintRule(t *testing.T) {
 	}
 
 	// 2. Invalid ebuild md5
-	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", "invalidmd5", eclassMd5)), 0644)
+	_ = os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", "invalidmd5", eclassMd5)), 0644)
 	results = rule.Lint(tempDir, pkg)
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result for invalid ebuild md5, got %d", len(results))
@@ -60,7 +60,7 @@ func TestMD5CacheInvalidLintRule(t *testing.T) {
 	}
 
 	// 3. Invalid eclass md5
-	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", md5sum, "invalidmd5")), 0644)
+	_ = os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", md5sum, "invalidmd5")), 0644)
 	results = rule.Lint(tempDir, pkg)
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result for invalid eclass md5, got %d", len(results))
@@ -69,7 +69,7 @@ func TestMD5CacheInvalidLintRule(t *testing.T) {
 	}
 
 	// 4. Missing _md5_
-	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_eclasses_=test\t%s\n", eclassMd5)), 0644)
+	_ = os.WriteFile(cacheFile, []byte(fmt.Sprintf("_eclasses_=test\t%s\n", eclassMd5)), 0644)
 	results = rule.Lint(tempDir, pkg)
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result for missing _md5_, got %d", len(results))
@@ -78,7 +78,7 @@ func TestMD5CacheInvalidLintRule(t *testing.T) {
 	}
 
 	// 5. Invalid format
-	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\ninvalidline\n", md5sum)), 0644)
+	_ = os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\ninvalidline\n", md5sum)), 0644)
 	results = rule.Lint(tempDir, pkg)
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result for invalid format, got %d", len(results))

--- a/lints/md5cache/md5cache_invalid_test.go
+++ b/lints/md5cache/md5cache_invalid_test.go
@@ -1,0 +1,88 @@
+package md5cache
+
+import (
+	"crypto/md5"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestMD5CacheInvalidLintRule(t *testing.T) {
+	rule := &MD5CacheInvalidLintRule{}
+
+	tempDir := t.TempDir()
+
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "foo",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild:  &g2.Ebuild{},
+			},
+		},
+	}
+
+	// 1. Valid cache
+	cacheDir := filepath.Join(tempDir, "metadata", "md5-cache", "app-misc")
+	os.MkdirAll(cacheDir, 0755)
+	cacheFile := filepath.Join(cacheDir, "foo-1.0")
+
+	ebuildDir := filepath.Join(tempDir, "app-misc", "foo")
+	os.MkdirAll(ebuildDir, 0755)
+	ebuildFile := filepath.Join(ebuildDir, "foo-1.0.ebuild")
+	os.WriteFile(ebuildFile, []byte("EAPI=8\n"), 0644)
+	md5sum := fmt.Sprintf("%x", md5.Sum([]byte("EAPI=8\n")))
+
+	eclassDir := filepath.Join(tempDir, "eclass")
+	os.MkdirAll(eclassDir, 0755)
+	eclassFile := filepath.Join(eclassDir, "test.eclass")
+	os.WriteFile(eclassFile, []byte("# test\n"), 0644)
+	eclassMd5 := fmt.Sprintf("%x", md5.Sum([]byte("# test\n")))
+
+	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", md5sum, eclassMd5)), 0644)
+
+	results := rule.Lint(tempDir, pkg)
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results for valid cache, got %d: %v", len(results), results)
+	}
+
+	// 2. Invalid ebuild md5
+	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", "invalidmd5", eclassMd5)), 0644)
+	results = rule.Lint(tempDir, pkg)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result for invalid ebuild md5, got %d", len(results))
+	} else if results[0].Message != fmt.Sprintf("[Warning] Incorrect _md5_ in md5-cache for foo-1.0. Expected %s, got invalidmd5", md5sum) {
+		t.Errorf("Unexpected message: %s", results[0].Message)
+	}
+
+	// 3. Invalid eclass md5
+	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\n_eclasses_=test\t%s\n", md5sum, "invalidmd5")), 0644)
+	results = rule.Lint(tempDir, pkg)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result for invalid eclass md5, got %d", len(results))
+	} else if results[0].Message != fmt.Sprintf("[Warning] Incorrect eclass md5 for test in md5-cache of foo-1.0. Expected %s, got invalidmd5", eclassMd5) {
+		t.Errorf("Unexpected message: %s", results[0].Message)
+	}
+
+	// 4. Missing _md5_
+	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_eclasses_=test\t%s\n", eclassMd5)), 0644)
+	results = rule.Lint(tempDir, pkg)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result for missing _md5_, got %d", len(results))
+	} else if results[0].Message != "[Warning] Missing _md5_ in md5-cache for foo-1.0" {
+		t.Errorf("Unexpected message: %s", results[0].Message)
+	}
+
+	// 5. Invalid format
+	os.WriteFile(cacheFile, []byte(fmt.Sprintf("_md5_=%s\ninvalidline\n", md5sum)), 0644)
+	results = rule.Lint(tempDir, pkg)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result for invalid format, got %d", len(results))
+	} else if results[0].Message != "[Warning] Invalid format in md5-cache for foo-1.0: invalidline" {
+		t.Errorf("Unexpected message: %s", results[0].Message)
+	}
+}


### PR DESCRIPTION
Adds a new linting rule `Md5CacheInvalid` which verifies the format and contents of `metadata/md5-cache` files. Specifically, it ensures the `_md5_` key matches the md5sum of the actual `.ebuild` file, and that the `_eclasses_` line contains valid md5sums for any eclasses present in the repository. It skips verification for eclasses that are absent locally, accommodating partial mirrors. Includes full unit tests for various valid and invalid states.

---
*PR created automatically by Jules for task [13184802363536354669](https://jules.google.com/task/13184802363536354669) started by @arran4*