### PR TITLE
feat: add lint rule for ebuild header validation

### DIFF
--- a/lints/ebuild/ebuild_header.go
+++ b/lints/ebuild/ebuild_header.go
@@ -1,0 +1,53 @@
+package ebuild
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleEbuildHeader = lints.RuleMetadata{
+	ID:          "EbuildHeader",
+	Title:       "Invalid Ebuild Header",
+	Description: "Validates that the ebuild header matches the expected Gentoo copyright header.",
+	URL:         "https://devmanual.gentoo.org/ebuild-writing/file-format/index.html",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy"},
+}
+
+var validHeaderRegex = regexp.MustCompile(`^# Copyright 1999-\d{4} Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\n`)
+
+func init() {
+	lints.RegisterRuleMetadata(ruleEbuildHeader)
+	lints.RegisterLintRule(&EbuildHeaderLintRule{})
+}
+
+type EbuildHeaderLintRule struct{}
+
+func (r *EbuildHeaderLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *EbuildHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			if !validHeaderRegex.MatchString(ver.Ebuild.RawText) {
+				res := lints.LintResult{
+					RuleMetadata: ruleEbuildHeader,
+					Message:      fmt.Sprintf("[%s] Ebuild %s has an invalid header. It should exactly match the first two lines of header.txt followed by an empty line.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				results = append(results, res)
+			}
+		}
+	}
+	return results
+}

--- a/lints/ebuild/ebuild_header.go
+++ b/lints/ebuild/ebuild_header.go
@@ -15,7 +15,7 @@ var ruleEbuildHeader = lints.RuleMetadata{
 	Title:       "Invalid Ebuild Header",
 	Description: "Validates that the ebuild header matches the expected Gentoo copyright header.",
 	URL:         "https://devmanual.gentoo.org/ebuild-writing/file-format/index.html",
-	Severity:    lints.SeverityError,
+	Severity:    lints.SeverityNotice,
 	Source:      lints.SourceG2,
 	Tags:        []string{"ebuild", "gentoo-policy"},
 }
@@ -35,7 +35,23 @@ func (r *EbuildHeaderLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints
 
 func (r *EbuildHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
 	var results []lints.LintResult
-	severity := lints.SeverityError
+	severity := lints.SeverityNotice
+
+	if qa != nil {
+		if val, ok := qa.Policies[ruleEbuildHeader.ID]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
 
 	for _, ver := range pkg.Versions {
 		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
@@ -45,6 +61,7 @@ func (r *EbuildHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, q
 					Message:      fmt.Sprintf("[%s] Ebuild %s has an invalid header. It should exactly match the first two lines of header.txt followed by an empty line.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
+				res.RuleMetadata.Severity = severity
 				results = append(results, res)
 			}
 		}

--- a/lints/ebuild/ebuild_header_test.go
+++ b/lints/ebuild/ebuild_header_test.go
@@ -1,0 +1,94 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEbuildHeaderLintRule(t *testing.T) {
+	rule := &EbuildHeaderLintRule{}
+
+	tests := []struct {
+		name     string
+		pkg      *g2.PackageData
+		expected int // expected number of errors
+	}{
+		{
+			name: "Valid header",
+			pkg: &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: "# Copyright 1999-2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8",
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "Missing header",
+			pkg: &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: "EAPI=8",
+						},
+					},
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "Incorrect year start",
+			pkg: &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: "# Copyright 2000-2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8",
+						},
+					},
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "CVS header included",
+			pkg: &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: "# Copyright 1999-2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n# $Header$\n\nEAPI=8",
+						},
+					},
+				},
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := rule.Lint("", tt.pkg)
+			assert.Len(t, results, tt.expected)
+			if tt.expected > 0 {
+				assert.Equal(t, lints.SeverityError, results[0].RuleMetadata.Severity)
+			}
+		})
+	}
+}

--- a/lints/ebuild/ebuild_header_test.go
+++ b/lints/ebuild/ebuild_header_test.go
@@ -87,7 +87,7 @@ func TestEbuildHeaderLintRule(t *testing.T) {
 			results := rule.Lint("", tt.pkg)
 			assert.Len(t, results, tt.expected)
 			if tt.expected > 0 {
-				assert.Equal(t, lints.SeverityError, results[0].RuleMetadata.Severity)
+				assert.Equal(t, lints.SeverityNotice, results[0].RuleMetadata.Severity)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a new lint rule to enforce that all ebuilds in a repository start with the exact two-line Gentoo copyright header followed by an empty line.

**Details:**
- Adds `EbuildHeaderLintRule` (`lints/ebuild/ebuild_header.go`) to validate `RawText`.
- Uses regular expression (`^# Copyright 1999-\d{4} Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\n`) to verify.
- Also tests to make sure older, unsupported 3-line headers (containing CVS `$Header$`) are caught and flagged as errors.
- Adds comprehensive test coverage (`lints/ebuild/ebuild_header_test.go`).

---
*PR created automatically by Jules for task [10193301056438147861](https://jules.google.com/task/10193301056438147861) started by @arran4*