### PR TITLE
feat(lints): Add ebuild formatting, whitespace, and charset rules

### DIFF
--- a/lints/ebuild/character_set.go
+++ b/lints/ebuild/character_set.go
@@ -1,0 +1,49 @@
+package ebuild
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var ruleCharacterSet = lints.RuleMetadata{
+	ID:          "CharacterSet",
+	Title:       "Character Set",
+	Description: "Checks if ebuild files use the UTF-8 character set.",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "encoding"},
+}
+
+// CharacterSetLintRule checks if ebuild files use the UTF-8 character set.
+type CharacterSetLintRule struct{}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleCharacterSet)
+	lints.RegisterLintRule(&CharacterSetLintRule{})
+}
+
+func (l *CharacterSetLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return l.LintWithQA(repoDir, pkg, nil)
+}
+
+func (l *CharacterSetLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			if !utf8.ValidString(ver.Ebuild.RawText) {
+				results = append(results, lints.LintResult{
+					RuleMetadata: ruleCharacterSet,
+					Message:      "Ebuild file contains non-UTF-8 characters.",
+					Package:      pkg.Category + "/" + pkg.Name,
+					File:         fmt.Sprintf("%s-%s.ebuild", pkg.Name, ver.Version),
+				})
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/character_set_test.go
+++ b/lints/ebuild/character_set_test.go
@@ -1,0 +1,42 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestCharacterSetLintRule(t *testing.T) {
+	rule := &CharacterSetLintRule{}
+
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "test",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "src_prepare() {\n\techo \"hello\"\n}\n",
+				},
+			},
+			{
+				Version: "2.0",
+				Ebuild: &g2.Ebuild{
+					RawText: string([]byte{0xff, 0xfe, 0xfd}), // Invalid UTF-8
+				},
+			},
+		},
+	}
+
+	results := rule.Lint("", pkg)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 results, got %d", len(results))
+	}
+
+	for _, result := range results {
+		if result.RuleMetadata.ID != "CharacterSet" {
+			t.Errorf("expected rule ID CharacterSet, got %s", result.RuleMetadata.ID)
+		}
+	}
+}

--- a/lints/ebuild/ebuild_header.go
+++ b/lints/ebuild/ebuild_header.go
@@ -1,0 +1,51 @@
+package ebuild
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var ruleEbuildHeader = lints.RuleMetadata{
+	ID:          "EbuildHeader",
+	Title:       "Ebuild Header Formatting",
+	Description: "Checks if ebuild files have the correct header formatting.",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy"},
+}
+
+// EbuildHeaderLintRule checks if ebuild header is correct.
+type EbuildHeaderLintRule struct{}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleEbuildHeader)
+	lints.RegisterLintRule(&EbuildHeaderLintRule{})
+}
+
+var correctHeaderRegex = regexp.MustCompile(`(?s)^# Copyright 1999-\d{4} Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2$`)
+
+func (l *EbuildHeaderLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return l.LintWithQA(repoDir, pkg, nil)
+}
+
+func (l *EbuildHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil {
+			if !correctHeaderRegex.MatchString(ver.Ebuild.EbuildHeader) {
+				results = append(results, lints.LintResult{
+					RuleMetadata: ruleEbuildHeader,
+					Message:      "Ebuild header is missing or incorrectly formatted.",
+					Package:      pkg.Category + "/" + pkg.Name,
+					File:         fmt.Sprintf("%s-%s.ebuild", pkg.Name, ver.Version),
+				})
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/ebuild_header_test.go
+++ b/lints/ebuild/ebuild_header_test.go
@@ -1,0 +1,48 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestEbuildHeaderLintRule(t *testing.T) {
+	rule := &EbuildHeaderLintRule{}
+
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "test",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					EbuildHeader: "# Copyright 1999-2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2",
+				},
+			},
+			{
+				Version: "2.0",
+				Ebuild: &g2.Ebuild{
+					EbuildHeader: "# Copyright 1999-2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n# $Id$",
+				},
+			},
+			{
+				Version: "3.0",
+				Ebuild: &g2.Ebuild{
+					EbuildHeader: "random string",
+				},
+			},
+		},
+	}
+
+	results := rule.Lint("", pkg)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	for _, result := range results {
+		if result.RuleMetadata.ID != "EbuildHeader" {
+			t.Errorf("expected rule ID EbuildHeader, got %s", result.RuleMetadata.ID)
+		}
+	}
+}

--- a/lints/ebuild/indenting_whitespace.go
+++ b/lints/ebuild/indenting_whitespace.go
@@ -1,0 +1,64 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var ruleIndentingWhitespace = lints.RuleMetadata{
+	ID:          "IndentingWhitespace",
+	Title:       "Indenting and Whitespace",
+	Description: "Checks if ebuild files use tabs for indentation and have no trailing whitespace.",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "whitespace"},
+}
+
+// IndentingWhitespaceLintRule checks if ebuild files use tabs for indentation and have no trailing whitespace.
+type IndentingWhitespaceLintRule struct{}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleIndentingWhitespace)
+	lints.RegisterLintRule(&IndentingWhitespaceLintRule{})
+}
+
+func (l *IndentingWhitespaceLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return l.LintWithQA(repoDir, pkg, nil)
+}
+
+func (l *IndentingWhitespaceLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			lines := strings.Split(ver.Ebuild.RawText, "\n")
+			for i, line := range lines {
+				if strings.HasSuffix(line, " ") || strings.HasSuffix(line, "\t") {
+					results = append(results, lints.LintResult{
+						RuleMetadata: ruleIndentingWhitespace,
+						Message:      fmt.Sprintf("Trailing whitespace found at line %d", i+1),
+						Package:      pkg.Category + "/" + pkg.Name,
+						File:         fmt.Sprintf("%s-%s.ebuild", pkg.Name, ver.Version),
+						Line:         i + 1,
+					})
+				}
+
+				trimmedLeftSpace := strings.TrimLeft(line, " \t")
+				if len(line) != len(trimmedLeftSpace) && line[0] == ' ' {
+					results = append(results, lints.LintResult{
+						RuleMetadata: ruleIndentingWhitespace,
+						Message:      fmt.Sprintf("Leading space instead of tab for indentation found at line %d", i+1),
+						Package:      pkg.Category + "/" + pkg.Name,
+						File:         fmt.Sprintf("%s-%s.ebuild", pkg.Name, ver.Version),
+						Line:         i + 1,
+					})
+				}
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/indenting_whitespace_test.go
+++ b/lints/ebuild/indenting_whitespace_test.go
@@ -1,0 +1,48 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestIndentingWhitespaceLintRule(t *testing.T) {
+	rule := &IndentingWhitespaceLintRule{}
+
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "test",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "src_prepare() {\n\techo \"hello\"\n}\n",
+				},
+			},
+			{
+				Version: "2.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "src_prepare() {\n  echo \"hello\"\n}\n", // leading space
+				},
+			},
+			{
+				Version: "3.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "src_prepare() { \n\techo \"hello\"\n}\n", // trailing space
+				},
+			},
+		},
+	}
+
+	results := rule.Lint("", pkg)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	for _, result := range results {
+		if result.RuleMetadata.ID != "IndentingWhitespace" {
+			t.Errorf("expected rule ID IndentingWhitespace, got %s", result.RuleMetadata.ID)
+		}
+	}
+}


### PR DESCRIPTION
Adds 3 new ebuild lint rules according to the Gentoo DevManual.

1.  **Ebuild Header (`EbuildHeaderLintRule`)**: Validates that ebuilds start with the standard `# Copyright 1999-[YEAR] Gentoo Authors` and `# Distributed under the terms of the GNU General Public License v2` lines.
2.  **Indenting and Whitespace (`IndentingWhitespaceLintRule`)**: Flags any trailing whitespace on lines, and flags leading space characters (tabs must be used for indentation).
3.  **Character Set (`CharacterSetLintRule`)**: Verifies that the ebuild content is valid UTF-8.

Includes tests and registers all rules.

---
*PR created automatically by Jules for task [16698028348388112522](https://jules.google.com/task/16698028348388112522) started by @arran4*