### PR TITLE
feat(lint): add package collision lint rule

### DIFF
--- a/cmd/g2/ebuild.go
+++ b/cmd/g2/ebuild.go
@@ -724,7 +724,7 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildCheck(args []string) error {
 
 		pkgData.Versions = append(pkgData.Versions, vData)
 
-		lintWarnings := lints.PerformLintingResults(dir, &pkgData)
+		lintWarnings := lints.PerformLintingResults(dir, &pkgData, nil)
 
 		for _, w := range lintWarnings {
 			w.File = filename

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -39,6 +39,35 @@ func (cfg *MainArgConfig) cmdLint(args []string) error {
 	return cfg.runOldLint(args)
 }
 
+
+func buildLintContext(reposXML, reposDir string) *lints.LintContext {
+	lintCtx := &lints.LintContext{}
+	if reposXML != "" {
+		fileRepos, err := g2.ParseRepositories(reposXML)
+		if err == nil {
+			for _, r := range fileRepos.Repositories {
+				repoPath := filepath.Join(reposDir, r.Name)
+				if stat, err := os.Stat(repoPath); err == nil && stat.IsDir() {
+					lintCtx.OtherRepos = append(lintCtx.OtherRepos, repoPath)
+				}
+			}
+		}
+	} else {
+		if entries, err := os.ReadDir(reposDir); err == nil {
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				repoPath := filepath.Join(reposDir, entry.Name())
+				if _, err := os.Stat(filepath.Join(repoPath, "profiles", "repo_name")); err == nil {
+					lintCtx.OtherRepos = append(lintCtx.OtherRepos, repoPath)
+				}
+			}
+		}
+	}
+	return lintCtx
+}
+
 func (cfg *MainArgConfig) cmdLintList(args []string) error {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 	format := fs.String("format", "text", "Output format: text, json")
@@ -146,7 +175,7 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 				})
 			}
 
-			lintWarnings := lints.PerformLintingResults(location, &pkgCopy)
+			lintWarnings := lints.PerformLintingResults(location, &pkgCopy, nil)
 
 			// Filter warnings
 			var filteredWarnings []lints.LintResult
@@ -317,7 +346,7 @@ type LintQuery struct {
 	VWildcard string // e.g. "3." for "v3"
 }
 
-func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool, query *LintQuery, format, severityFilter, sourceFilter, tagFilter, disableRule, ignoreTag string) error {
+func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool, query *LintQuery, format, severityFilter, sourceFilter, tagFilter, disableRule, ignoreTag string, lintCtx *lints.LintContext) error {
 	siteData, err := parseRepo(os.DirFS(location), ".", "Linting", true, nil)
 	if err != nil {
 		return fmt.Errorf("parsing repo: %w", err)
@@ -400,7 +429,7 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 				continue
 			}
 
-			lintWarnings := lints.PerformLintingResults(location, &pkgCopy)
+			lintWarnings := lints.PerformLintingResults(location, &pkgCopy, lintCtx)
 
 			var filteredWarnings []lints.LintResult
 			for _, w := range lintWarnings {
@@ -515,6 +544,9 @@ func (cfg *MainArgConfig) cmdLintRepo(args []string) error {
 	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
 	ignoreTag := fs.String("ignore-tag", "", "Comma-separated list of tags to ignore")
 
+	reposXML := fs.String("repos-xml", "", "Path to repositories.xml to load other repositories for cross-repo lint checks")
+	reposDir := fs.String("repos-dir", "/var/db/repos", "Default directory to look for repositories if repos-xml is not provided")
+
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -524,7 +556,10 @@ func (cfg *MainArgConfig) cmdLintRepo(args []string) error {
 		location = fs.Arg(0)
 	}
 
-	return cfg.runLintCore(location, nil, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
+
+lintCtx := buildLintContext(*reposXML, *reposDir)
+
+	return cfg.runLintCore(location, nil, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag, lintCtx)
 }
 
 func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
@@ -542,6 +577,9 @@ func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
 	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
 	ignoreTag := fs.String("ignore-tag", "", "Comma-separated list of tags to ignore")
+
+	reposXML := fs.String("repos-xml", "", "Path to repositories.xml to load other repositories for cross-repo lint checks")
+	reposDir := fs.String("repos-dir", "/var/db/repos", "Default directory to look for repositories if repos-xml is not provided")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -579,7 +617,10 @@ func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
 		targetMap[cleanP] = true
 	}
 
-	return cfg.runLintCore(location, targetMap, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
+
+lintCtx := buildLintContext(*reposXML, *reposDir)
+
+	return cfg.runLintCore(location, targetMap, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag, lintCtx)
 }
 
 func parseLintQuery(queryStr string, defaultLocation string) (*LintQuery, error) {
@@ -700,6 +741,9 @@ func (cfg *MainArgConfig) cmdLintQuery(args []string) error {
 	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
 	ignoreTag := fs.String("ignore-tag", "", "Comma-separated list of tags to ignore")
 
+	reposXML := fs.String("repos-xml", "", "Path to repositories.xml to load other repositories for cross-repo lint checks")
+	reposDir := fs.String("repos-dir", "/var/db/repos", "Default directory to look for repositories if repos-xml is not provided")
+
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -721,5 +765,8 @@ func (cfg *MainArgConfig) cmdLintQuery(args []string) error {
 		return fmt.Errorf("parsing query: %w", err)
 	}
 
-	return cfg.runLintCore(query.RepoPath, nil, query, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
+
+lintCtx := buildLintContext(*reposXML, *reposDir)
+
+	return cfg.runLintCore(query.RepoPath, nil, query, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag, lintCtx)
 }

--- a/cmd/g2/parse_repo.go
+++ b/cmd/g2/parse_repo.go
@@ -535,7 +535,7 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 				pkgData.IsInfoPkg = true
 			}
 
-			pkgData.LintWarnings = lints.PerformLinting(repoDir, &g2PkgData)
+			pkgData.LintWarnings = lints.PerformLinting(repoDir, &g2PkgData, nil)
 
 			if len(supportedCategories) > 0 && !inRepo {
 				if inMain {

--- a/lints/ebuild/category_sanity.go
+++ b/lints/ebuild/category_sanity.go
@@ -34,7 +34,7 @@ func init() {
 	lints.RegisterLintRule(&CategorySanityLintRule{})
 }
 
-func (l *CategorySanityLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+func (l *CategorySanityLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
 	if SkipForSiteGen {
 		return nil
 	}

--- a/lints/ebuild/dependency_pitfalls.go
+++ b/lints/ebuild/dependency_pitfalls.go
@@ -27,11 +27,11 @@ func init() {
 
 type DependencyPitfallsLintRule struct{}
 
-func (r *DependencyPitfallsLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *DependencyPitfallsLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *DependencyPitfallsLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *DependencyPitfallsLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := ruleDependencyPitfalls.Severity
 

--- a/lints/ebuild/dependency_pitfalls_test.go
+++ b/lints/ebuild/dependency_pitfalls_test.go
@@ -250,7 +250,7 @@ func TestDependencyPitfallsLintRule(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			results := rule.LintWithQA("", tc.pkg, tc.qaPolicy)
+			results := rule.LintWithQA("", tc.pkg, tc.qaPolicy, nil)
 
 			if len(results) != tc.expected {
 				t.Errorf("Expected %d results, got %d", tc.expected, len(results))

--- a/lints/ebuild/eapi_deprecated.go
+++ b/lints/ebuild/eapi_deprecated.go
@@ -24,11 +24,11 @@ func init() {
 
 type EAPIDeprecatedLintRule struct{}
 
-func (r *EAPIDeprecatedLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *EAPIDeprecatedLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *EAPIDeprecatedLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *EAPIDeprecatedLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityWarning
 	if qa != nil && qa.Policies != nil {

--- a/lints/ebuild/eapi_deprecated_test.go
+++ b/lints/ebuild/eapi_deprecated_test.go
@@ -38,7 +38,7 @@ func TestEAPIDeprecatedLintRule(t *testing.T) {
 					},
 				},
 			}
-			warnings := rule.Lint(".", pkg)
+			warnings := rule.Lint(".", pkg, nil)
 			if tt.hasWarn && len(warnings) == 0 {
 				t.Errorf("expected warning for EAPI %s, got none", tt.eapi)
 			}

--- a/lints/ebuild/eclass_inherit.go
+++ b/lints/ebuild/eclass_inherit.go
@@ -26,7 +26,7 @@ func init() {
 
 type ConditionalInheritLintRule struct{}
 
-func (l *ConditionalInheritLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+func (l *ConditionalInheritLintRule) Lint(repoDir string, pkgData *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 
 	for _, version := range pkgData.Versions {

--- a/lints/ebuild/eclass_inherit_test.go
+++ b/lints/ebuild/eclass_inherit_test.go
@@ -99,7 +99,7 @@ esac
 				},
 			}
 
-			results := rule.Lint("", pkgData)
+			results := rule.Lint("", pkgData, nil)
 			assert.Len(t, results, tt.expected)
 		})
 	}

--- a/lints/ebuild/global_scope.go
+++ b/lints/ebuild/global_scope.go
@@ -26,7 +26,7 @@ func init() {
 
 type GlobalScopeLintRule struct{}
 
-func (l *GlobalScopeLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+func (l *GlobalScopeLintRule) Lint(repoDir string, pkgData *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 
 	disallowedCommands := map[string]bool{

--- a/lints/ebuild/global_scope_test.go
+++ b/lints/ebuild/global_scope_test.go
@@ -79,7 +79,7 @@ grep "foo" file
 				},
 			}
 
-			results := rule.Lint("", pkgData)
+			results := rule.Lint("", pkgData, nil)
 			assert.Len(t, results, tt.expected)
 		})
 	}

--- a/lints/ebuild/invalid_slot.go
+++ b/lints/ebuild/invalid_slot.go
@@ -31,11 +31,11 @@ func init() {
 
 type InvalidSlotLintRule struct{}
 
-func (r *InvalidSlotLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *InvalidSlotLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *InvalidSlotLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *InvalidSlotLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityError
 

--- a/lints/ebuild/invalid_slot_test.go
+++ b/lints/ebuild/invalid_slot_test.go
@@ -38,7 +38,7 @@ func TestInvalidSlotLintRule(t *testing.T) {
 					},
 				},
 			}
-			warnings := rule.Lint(".", pkg)
+			warnings := rule.Lint(".", pkg, nil)
 			if len(warnings) != tt.want {
 				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
 			}

--- a/lints/ebuild/iuse_documented.go
+++ b/lints/ebuild/iuse_documented.go
@@ -27,11 +27,11 @@ func init() {
 
 type IUSELintRule struct{}
 
-func (r *IUSELintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *IUSELintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *IUSELintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *IUSELintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityWarning
 

--- a/lints/ebuild/layout_conf_rules.go
+++ b/lints/ebuild/layout_conf_rules.go
@@ -28,11 +28,11 @@ func init() {
 
 type LayoutConfLintRule struct{}
 
-func (r *LayoutConfLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *LayoutConfLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *LayoutConfLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *LayoutConfLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityWarning
 

--- a/lints/ebuild/license_sanity.go
+++ b/lints/ebuild/license_sanity.go
@@ -27,11 +27,11 @@ func init() {
 
 type LicenseSanityLintRule struct{}
 
-func (r *LicenseSanityLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *LicenseSanityLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *LicenseSanityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *LicenseSanityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityError
 	if qa != nil && qa.Policies != nil {

--- a/lints/ebuild/license_sanity_test.go
+++ b/lints/ebuild/license_sanity_test.go
@@ -37,7 +37,7 @@ func TestLicenseSanityLintRule(t *testing.T) {
 					},
 				},
 			}
-			warnings := rule.Lint(".", pkg)
+			warnings := rule.Lint(".", pkg, nil)
 			if len(warnings) != tt.want {
 				t.Errorf("got %d warnings, want %d: %v", len(warnings), tt.want, warnings)
 			}

--- a/lints/ebuild/missing_description.go
+++ b/lints/ebuild/missing_description.go
@@ -27,11 +27,11 @@ func init() {
 
 type MissingDescriptionLintRule struct{}
 
-func (r *MissingDescriptionLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *MissingDescriptionLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *MissingDescriptionLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *MissingDescriptionLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityWarning
 

--- a/lints/ebuild/missing_description_test.go
+++ b/lints/ebuild/missing_description_test.go
@@ -34,7 +34,7 @@ func TestMissingDescriptionLintRule(t *testing.T) {
 					},
 				},
 			}
-			warnings := rule.Lint(".", pkg)
+			warnings := rule.Lint(".", pkg, nil)
 			if len(warnings) != tt.want {
 				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
 			}

--- a/lints/ebuild/missing_homepage.go
+++ b/lints/ebuild/missing_homepage.go
@@ -27,11 +27,11 @@ func init() {
 
 type MissingHomepageLintRule struct{}
 
-func (r *MissingHomepageLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *MissingHomepageLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *MissingHomepageLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *MissingHomepageLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityWarning
 

--- a/lints/ebuild/missing_homepage_test.go
+++ b/lints/ebuild/missing_homepage_test.go
@@ -37,7 +37,7 @@ func TestMissingHomepageLintRule(t *testing.T) {
 					},
 				},
 			}
-			warnings := rule.Lint(".", pkg)
+			warnings := rule.Lint(".", pkg, nil)
 			if len(warnings) != tt.want {
 				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
 			}

--- a/lints/ebuild/missing_keyword.go
+++ b/lints/ebuild/missing_keyword.go
@@ -27,11 +27,11 @@ func init() {
 
 type MissingKeywordLintRule struct{}
 
-func (r *MissingKeywordLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *MissingKeywordLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *MissingKeywordLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *MissingKeywordLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityWarning
 

--- a/lints/ebuild/missing_keyword_test.go
+++ b/lints/ebuild/missing_keyword_test.go
@@ -38,7 +38,7 @@ func TestMissingKeywordLintRule(t *testing.T) {
 					},
 				},
 			}
-			warnings := rule.Lint(".", pkg)
+			warnings := rule.Lint(".", pkg, nil)
 			if len(warnings) != tt.want {
 				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
 			}

--- a/lints/ebuild/missing_manifest.go
+++ b/lints/ebuild/missing_manifest.go
@@ -27,11 +27,11 @@ func init() {
 
 type MissingManifestLintRule struct{}
 
-func (r *MissingManifestLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *MissingManifestLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *MissingManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *MissingManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	return r.lintWithFS(os.DirFS(repoDir), filepath.Join(pkg.Category, pkg.Name), pkg, qa)
 }
 

--- a/lints/ebuild/missing_slot.go
+++ b/lints/ebuild/missing_slot.go
@@ -27,11 +27,11 @@ func init() {
 
 type MissingSlotLintRule struct{}
 
-func (r *MissingSlotLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *MissingSlotLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *MissingSlotLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *MissingSlotLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := ruleMissingSlot.Severity
 	if qa != nil && qa.Policies != nil {

--- a/lints/ebuild/network_sandbox.go
+++ b/lints/ebuild/network_sandbox.go
@@ -23,11 +23,11 @@ func init() {
 
 type NetworkSandboxLintRule struct{}
 
-func (r *NetworkSandboxLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *NetworkSandboxLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *NetworkSandboxLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *NetworkSandboxLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	if pkg == nil {
 		return nil
 	}

--- a/lints/ebuild/network_sandbox_test.go
+++ b/lints/ebuild/network_sandbox_test.go
@@ -51,7 +51,7 @@ func TestNetworkSandboxLintRule(t *testing.T) {
 					},
 				},
 			}
-			warnings := rule.Lint(".", pkg)
+			warnings := rule.Lint(".", pkg, nil)
 			if len(warnings) != tt.want {
 				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
 			}

--- a/lints/ebuild/orphaned_manifest.go
+++ b/lints/ebuild/orphaned_manifest.go
@@ -26,11 +26,11 @@ func init() {
 
 type OrphanedManifestLintRule struct{}
 
-func (r *OrphanedManifestLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *OrphanedManifestLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *OrphanedManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *OrphanedManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 
 	if pkg.Manifest == nil || len(pkg.Manifest.Entries) == 0 {

--- a/lints/ebuild/orphaned_manifest_test.go
+++ b/lints/ebuild/orphaned_manifest_test.go
@@ -59,7 +59,7 @@ func TestOrphanedManifestLintRule(t *testing.T) {
 		},
 	}
 
-	warnings := rule.Lint(repoDir, pkg)
+	warnings := rule.Lint(repoDir, pkg, nil)
 
 	expectedWarnings := []string{
 		"Manifest entry for unused DIST file 'file2.tar.gz'",

--- a/lints/ebuild/pkg_collisions.go
+++ b/lints/ebuild/pkg_collisions.go
@@ -1,0 +1,93 @@
+package ebuild
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+func init() {
+	rule := &PackageCollisionLintRule{}
+	lints.RegisterRuleMetadata(rule.Metadata())
+	lints.RegisterLintRule(rule)
+}
+
+type PackageCollisionLintRule struct{}
+
+func (r *PackageCollisionLintRule) Metadata() lints.RuleMetadata {
+	return lints.RuleMetadata{
+		ID:          "PG1000",
+		Title:       "Package Name Collision",
+		Description: "Warns if a package shares the exact same name with a package in another category.",
+		Severity:    lints.SeverityWarning,
+		Source:      lints.SourceG2,
+		Tags:        []string{"pkg_collisions"},
+	}
+}
+
+func (r *PackageCollisionLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
+}
+
+func (r *PackageCollisionLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
+	if qa != nil {
+		policy := qa.Policies[string(r.Metadata().ID)]
+		if policy == "ignore" {
+			return nil
+		}
+	}
+
+		var results []lints.LintResult
+	dirsToCheck := []string{repoDir}
+	seenDirs := map[string]bool{repoDir: true}
+
+	if ctx != nil {
+		for _, r := range ctx.OtherRepos {
+			if !seenDirs[r] {
+				dirsToCheck = append(dirsToCheck, r)
+				seenDirs[r] = true
+			}
+		}
+	}
+
+	for _, dir := range dirsToCheck {
+		categories, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+
+		for _, cat := range categories {
+			if !cat.IsDir() || strings.HasPrefix(cat.Name(), ".") || cat.Name() == "metadata" || cat.Name() == "profiles" || cat.Name() == "eclass" {
+				continue
+			}
+
+			// If it's the exact same category and name, it's just an overlay overriding it, not a collision.
+			if cat.Name() == pkg.Category {
+				continue
+			}
+
+			// Check if package name exists in this category
+			pkgPath := filepath.Join(dir, cat.Name(), pkg.Name)
+			if stat, err := os.Stat(pkgPath); err == nil && stat.IsDir() {
+				// Potential collision
+				var repoName string
+				if repoInfo, err := os.ReadFile(filepath.Join(dir, "profiles", "repo_name")); err == nil {
+					repoName = strings.TrimSpace(string(repoInfo))
+				} else {
+					repoName = filepath.Base(dir)
+				}
+
+				results = append(results, lints.LintResult{
+					RuleMetadata: r.Metadata(),
+					Message:      fmt.Sprintf("Package name collision: '%s' is also defined in category '%s' in repository '%s'.", pkg.Name, cat.Name(), repoName),
+				})
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/python_single_r1_usedep.go
+++ b/lints/ebuild/python_single_r1_usedep.go
@@ -31,11 +31,11 @@ func init() {
 
 type PythonSingleR1UseDepLintRule struct{}
 
-func (r *PythonSingleR1UseDepLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *PythonSingleR1UseDepLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *PythonSingleR1UseDepLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *PythonSingleR1UseDepLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityError
 	if qa != nil && qa.Policies != nil {

--- a/lints/ebuild/python_single_r1_usedep_test.go
+++ b/lints/ebuild/python_single_r1_usedep_test.go
@@ -94,7 +94,7 @@ RDEPEND="dev-python/bar[${PYTHON_USEDEP}]"
 			}
 
 			rule := &PythonSingleR1UseDepLintRule{}
-			results := rule.Lint(".", pkg)
+			results := rule.Lint(".", pkg, nil)
 
 			if diff := cmp.Diff(tt.expected, results, cmpopts.IgnoreFields(lints.RuleMetadata{}, "Tags")); diff != "" {
 				t.Errorf("Lint results mismatch (-want +got):\n%s", diff)

--- a/lints/ebuild/repo_name_missing.go
+++ b/lints/ebuild/repo_name_missing.go
@@ -34,11 +34,11 @@ type RepoNameMissingLintRule struct {
 	repoCache map[string]bool // map[repoDir]hasRepoName
 }
 
-func (r *RepoNameMissingLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *RepoNameMissingLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *RepoNameMissingLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *RepoNameMissingLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityError
 

--- a/lints/ebuild/repo_name_missing_test.go
+++ b/lints/ebuild/repo_name_missing_test.go
@@ -75,7 +75,7 @@ func TestRepoNameMissingLintRule(t *testing.T) {
 			tt.setupRepo(tempDir)
 
 			rule := &RepoNameMissingLintRule{}
-			results := rule.Lint(tempDir, pkgData)
+			results := rule.Lint(tempDir, pkgData, nil)
 
 			if len(results) != tt.expectErrors {
 				t.Errorf("expected %d errors, got %d", tt.expectErrors, len(results))

--- a/lints/ebuild/sandbox_functions.go
+++ b/lints/ebuild/sandbox_functions.go
@@ -26,7 +26,7 @@ func init() {
 
 type SandboxFunctionsLintRule struct{}
 
-func (l *SandboxFunctionsLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+func (l *SandboxFunctionsLintRule) Lint(repoDir string, pkgData *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 
 	for _, version := range pkgData.Versions {

--- a/lints/ebuild/sandbox_functions_test.go
+++ b/lints/ebuild/sandbox_functions_test.go
@@ -84,7 +84,7 @@ src_compile() {
 				},
 			}
 
-			results := rule.Lint("", pkgData)
+			results := rule.Lint("", pkgData, nil)
 
 			if len(results) != len(tt.expected) {
 				t.Fatalf("expected %d results, got %d", len(tt.expected), len(results))

--- a/lints/ebuild/subshell_function.go
+++ b/lints/ebuild/subshell_function.go
@@ -25,7 +25,7 @@ func init() {
 
 type SubshellFunctionLintRule struct{}
 
-func (l *SubshellFunctionLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+func (l *SubshellFunctionLintRule) Lint(repoDir string, pkgData *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 
 	for _, version := range pkgData.Versions {

--- a/lints/ebuild/use_expand.go
+++ b/lints/ebuild/use_expand.go
@@ -28,7 +28,7 @@ func (r *UseExpandRule) Metadata() lints.RuleMetadata {
 	}
 }
 
-func (r *UseExpandRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+func (r *UseExpandRule) Lint(repoDir string, pkgData *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 
 	// Load USE_EXPAND descriptions

--- a/lints/ebuild/usr_local.go
+++ b/lints/ebuild/usr_local.go
@@ -54,7 +54,7 @@ func isUsrLocalPath(word *syntax.Word) (bool, string) {
 	return false, ""
 }
 
-func (l *UsrLocalLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+func (l *UsrLocalLintRule) Lint(repoDir string, pkgData *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 
 	for _, version := range pkgData.Versions {

--- a/lints/ebuild/usr_local_test.go
+++ b/lints/ebuild/usr_local_test.go
@@ -78,7 +78,7 @@ src_install() {
 				},
 			}
 
-			results := rule.Lint(".", pkg)
+			results := rule.Lint(".", pkg, nil)
 
 			if len(results) != tc.expected {
 				t.Fatalf("expected %d issues, got %d. Results: %v", tc.expected, len(results), results)

--- a/lints/md5cache/md5cache_missing.go
+++ b/lints/md5cache/md5cache_missing.go
@@ -38,11 +38,11 @@ type MD5CacheLintRule struct {
 	fs FileStat
 }
 
-func (r *MD5CacheLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *MD5CacheLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *MD5CacheLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityWarning
 

--- a/lints/md5cache/md5cache_missing_test.go
+++ b/lints/md5cache/md5cache_missing_test.go
@@ -36,7 +36,7 @@ func TestMD5CacheMissing(t *testing.T) {
 
 	// Test case 1: md5-cache directory does not exist, default QA policy
 	rule := &MD5CacheLintRule{fs: mockFileStat{paths: map[string]bool{}}}
-	results := rule.LintWithQA(repoDir, pkg, nil)
+	results := rule.LintWithQA(repoDir, pkg, nil, nil)
 	if len(results) != 0 {
 		t.Errorf("Expected 0 results when md5-cache dir is missing, got %d", len(results))
 	}
@@ -47,7 +47,7 @@ func TestMD5CacheMissing(t *testing.T) {
 			"PG0802": "error",
 		},
 	}
-	results = rule.LintWithQA(repoDir, pkg, qaPolicy)
+	results = rule.LintWithQA(repoDir, pkg, qaPolicy, nil)
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result when explicitly enforced, got %d", len(results))
 	} else if results[0].RuleMetadata.Severity != lints.SeverityError {
@@ -58,7 +58,7 @@ func TestMD5CacheMissing(t *testing.T) {
 	rule = &MD5CacheLintRule{fs: mockFileStat{paths: map[string]bool{
 		filepath.Join(repoDir, "metadata", "md5-cache"): true,
 	}}}
-	results = rule.LintWithQA(repoDir, pkg, nil)
+	results = rule.LintWithQA(repoDir, pkg, nil, nil)
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result when md5-cache dir exists but file is missing, got %d", len(results))
 	} else if results[0].RuleMetadata.Severity != lints.SeverityWarning {
@@ -70,7 +70,7 @@ func TestMD5CacheMissing(t *testing.T) {
 		filepath.Join(repoDir, "metadata", "md5-cache"):                        true,
 		filepath.Join(repoDir, "metadata", "md5-cache", "app-misc", "foo-1.0"): true,
 	}}}
-	results = rule.LintWithQA(repoDir, pkg, nil)
+	results = rule.LintWithQA(repoDir, pkg, nil, nil)
 	if len(results) != 0 {
 		t.Errorf("Expected 0 results when cache file exists, got %d", len(results))
 	}

--- a/lints/metadata/maintainer_missing.go
+++ b/lints/metadata/maintainer_missing.go
@@ -26,11 +26,11 @@ func init() {
 
 type MaintainerLintRule struct{}
 
-func (r *MaintainerLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *MaintainerLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *MaintainerLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *MaintainerLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityError
 	if qa != nil && qa.Policies != nil {

--- a/lints/metadata/maintainer_missing_test.go
+++ b/lints/metadata/maintainer_missing_test.go
@@ -16,7 +16,7 @@ func TestMaintainerMissingLintRule(t *testing.T) {
 				Maintainers: []g2.Maintainer{},
 			},
 		}
-		warnings := rule.Lint(".", pkg)
+		warnings := rule.Lint(".", pkg, nil)
 		if len(warnings) == 0 {
 			t.Error("expected warning for missing maintainer, got none")
 		}
@@ -30,7 +30,7 @@ func TestMaintainerMissingLintRule(t *testing.T) {
 				},
 			},
 		}
-		warnings := rule.Lint(".", pkg)
+		warnings := rule.Lint(".", pkg, nil)
 		if len(warnings) > 0 {
 			t.Errorf("expected no warnings, got %v", warnings)
 		}

--- a/lints/metadata/manifest.go
+++ b/lints/metadata/manifest.go
@@ -28,11 +28,11 @@ func init() {
 
 type ManifestLintRule struct{}
 
-func (r *ManifestLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *ManifestLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *ManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 
 	// Check if missing entirely

--- a/lints/metadata/manifest_test.go
+++ b/lints/metadata/manifest_test.go
@@ -72,7 +72,7 @@ func TestManifestLintRule_MissingFiles(t *testing.T) {
 	}
 
 	rule := &ManifestLintRule{}
-	results := rule.Lint(tempDir, pkgData)
+	results := rule.Lint(tempDir, pkgData, nil)
 
 	if len(results) != 3 {
 		t.Fatalf("expected 3 results, got %d", len(results))
@@ -101,7 +101,7 @@ func TestManifestLintRule_MissingFiles(t *testing.T) {
 		t.Fatalf("failed to write patch: %v", err)
 	}
 
-	results = rule.Lint(tempDir, pkgData)
+	results = rule.Lint(tempDir, pkgData, nil)
 	if len(results) != 0 {
 		t.Fatalf("expected 0 results, got %d: %v", len(results), results)
 	}

--- a/lints/metadata/metadata_missing_invalid.go
+++ b/lints/metadata/metadata_missing_invalid.go
@@ -26,11 +26,11 @@ func init() {
 
 type MetadataLintRule struct{}
 
-func (r *MetadataLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *MetadataLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *MetadataLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *MetadataLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	var results []lints.LintResult
 	severity := lints.SeverityError
 	if qa != nil && qa.Policies != nil {

--- a/lints/news/news.go
+++ b/lints/news/news.go
@@ -58,11 +58,11 @@ func NewNewsValidityLintRule(opts ...func(*NewsValidityLintRule)) *NewsValidityL
 // SkipForSiteGen disables this rule when it is already pre-calculated manually by site.go.
 var SkipForSiteGen bool
 
-func (r *NewsValidityLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
+func (r *NewsValidityLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *lints.LintContext) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil, ctx)
 }
 
-func (r *NewsValidityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+func (r *NewsValidityLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *lints.LintContext) []lints.LintResult {
 	if SkipForSiteGen {
 		return nil
 	}

--- a/lints/news/news_test.go
+++ b/lints/news/news_test.go
@@ -35,7 +35,7 @@ Body
 
 	pkg := &g2.PackageData{Category: "app-misc", Name: "foo"}
 
-	results := rule.Lint(".", pkg)
+	results := rule.Lint(".", pkg, nil)
 
 	if len(results) == 0 {
 		t.Fatalf("expected lint results, got none")

--- a/lints/registry.go
+++ b/lints/registry.go
@@ -44,12 +44,16 @@ func (lr LintResult) String() string {
 	return lr.Message
 }
 
+type LintContext struct {
+	OtherRepos []string
+}
+
 type LintRule interface {
-	Lint(repoDir string, pkg *g2.PackageData) []LintResult
+	Lint(repoDir string, pkg *g2.PackageData, ctx *LintContext) []LintResult
 }
 
 type QAAwareLintRule interface {
-	LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []LintResult
+	LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *LintContext) []LintResult
 }
 
 var lintRules []LintRule
@@ -58,7 +62,7 @@ func RegisterLintRule(rule LintRule) {
 	lintRules = append(lintRules, rule)
 }
 
-func PerformLintingResults(repoDir string, pkg *g2.PackageData) []LintResult {
+func PerformLintingResults(repoDir string, pkg *g2.PackageData, ctx *LintContext) []LintResult {
 	var results []LintResult
 
 	// Try to load QA Policy
@@ -67,17 +71,17 @@ func PerformLintingResults(repoDir string, pkg *g2.PackageData) []LintResult {
 
 	for _, rule := range lintRules {
 		if qaRule, ok := rule.(QAAwareLintRule); ok {
-			results = append(results, qaRule.LintWithQA(repoDir, pkg, qa)...)
+			results = append(results, qaRule.LintWithQA(repoDir, pkg, qa, ctx)...)
 		} else {
-			results = append(results, rule.Lint(repoDir, pkg)...)
+			results = append(results, rule.Lint(repoDir, pkg, ctx)...)
 		}
 	}
 	return results
 }
 
-func PerformLinting(repoDir string, pkg *g2.PackageData) []string {
+func PerformLinting(repoDir string, pkg *g2.PackageData, ctx *LintContext) []string {
 	var warnings []string
-	for _, res := range PerformLintingResults(repoDir, pkg) {
+	for _, res := range PerformLintingResults(repoDir, pkg, ctx) {
 		warnings = append(warnings, res.Message)
 	}
 	return warnings

--- a/lints/registry_test.go
+++ b/lints/registry_test.go
@@ -10,11 +10,11 @@ import (
 
 type MockLintRule struct{}
 
-func (m *MockLintRule) Lint(repoDir string, pkg *g2.PackageData) []LintResult {
+func (m *MockLintRule) Lint(repoDir string, pkg *g2.PackageData, ctx *LintContext) []LintResult {
 	return []LintResult{{Message: "basic rule"}}
 }
 
-func (m *MockLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []LintResult {
+func (m *MockLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy, ctx *LintContext) []LintResult {
 	if qa != nil {
 		if val, ok := qa.Policies["PG123"]; ok {
 			return []LintResult{{Message: "qa rule " + val}}
@@ -43,7 +43,7 @@ func TestPerformLintingWithQA(t *testing.T) {
 
 	lintRules = []LintRule{&MockLintRule{}}
 
-	warnings := PerformLinting(tmpDir, &g2.PackageData{})
+	warnings := PerformLinting(tmpDir, &g2.PackageData{}, nil)
 	if len(warnings) != 1 || warnings[0] != "qa rule yes" {
 		t.Errorf("Expected 'qa rule yes', got %v", warnings)
 	}

--- a/lints/repositories/init.go
+++ b/lints/repositories/init.go
@@ -1,0 +1,5 @@
+package repositories
+
+// Initialize lint rules for repositories
+func init() {
+}


### PR DESCRIPTION
Added a new lint rule to detect Gentoo package name collisions and added cross-repository support via the `LintContext`.

---
*PR created automatically by Jules for task [4281625367804342699](https://jules.google.com/task/4281625367804342699) started by @arran4*