### PR TITLE
feat: Add DieSubshellLintRule to warn about `die` in subshells for EAPI < 7

### DIFF
--- a/lints/ebuild/die_subshell.go
+++ b/lints/ebuild/die_subshell.go
@@ -1,0 +1,112 @@
+package ebuild
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleDieSubshell = lints.RuleMetadata{
+	ID:          "DieSubshell",
+	Title:       "die in subshell",
+	Description: "die will not work in a subshell unless you are using EAPI=7 and onwards.",
+	URL:         "https://devmanual.gentoo.org/ebuild-writing/error-handling/index.html#die-and-subshells",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "die"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleDieSubshell)
+	lints.RegisterLintRule(&DieSubshellLintRule{})
+}
+
+type DieSubshellLintRule struct{}
+
+func (l *DieSubshellLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, version := range pkgData.Versions {
+		if version.Ebuild == nil {
+			continue
+		}
+
+		eapi := version.Ebuild.Vars["EAPI"]
+		if eapi == "" {
+			eapi = "0"
+		}
+
+		eapiNum, err := strconv.Atoi(eapi)
+		if err != nil {
+			// If EAPI is not a number, it's likely a non-standard or very new one,
+			// assume it's modern enough (or fallback to strict behavior)
+			// But for Gentoo, we only care if it's explicitly parsed as < 7.
+			// e.g. "4-slot-abi" -> we don't handle easily, but let's assume it's EAPI 4.
+			// Actually let's just do a simple prefix check for old EAPIs if it's not a pure number.
+			if strings.HasPrefix(eapi, "4-") {
+				eapiNum = 4
+			} else {
+				eapiNum = 8 // Default to safe if not purely numeric to avoid false positives
+			}
+		}
+
+		// "die will not work in a subshell unless you are using EAPI=7 and onwards."
+		if eapiNum >= 7 {
+			continue
+		}
+
+		// Parse the ebuild using sh syntax parser
+		parser := syntax.NewParser()
+		f, err := parser.Parse(strings.NewReader(version.Ebuild.RawText), "")
+		if err != nil {
+			continue
+		}
+
+		seen := make(map[*syntax.CallExpr]bool)
+
+		syntax.Walk(f, func(node syntax.Node) bool {
+			isSubshell := false
+			switch n := node.(type) {
+			case *syntax.Subshell, *syntax.CmdSubst, *syntax.ProcSubst, *syntax.CoprocClause:
+				isSubshell = true
+			case *syntax.BinaryCmd:
+				if n.Op == syntax.Pipe || n.Op == syntax.PipeAll {
+					isSubshell = true
+				}
+			case *syntax.Stmt:
+				if n.Background {
+					isSubshell = true
+				}
+			}
+
+			if isSubshell {
+				syntax.Walk(node, func(child syntax.Node) bool {
+					if call, ok := child.(*syntax.CallExpr); ok {
+						if len(call.Args) > 0 && len(call.Args[0].Parts) == 1 {
+							if lit, ok := call.Args[0].Parts[0].(*syntax.Lit); ok && lit.Value == "die" {
+								if !seen[call] {
+									res := lints.LintResult{
+										RuleMetadata: ruleDieSubshell,
+										Message:      fmt.Sprintf("[Warning] Ebuild %s uses 'die' in a subshell, but EAPI %s does not support this. The 'die' call will not abort the build as expected.", version.Ebuild.Path, eapi),
+										Package:      pkgData.Category + "/" + pkgData.Name,
+									}
+									results = append(results, res)
+									seen[call] = true
+								}
+							}
+						}
+					}
+					return true
+				})
+				return false // Do not process this subshell further from the outer loop
+			}
+			return true
+		})
+	}
+
+	return results
+}

--- a/lints/ebuild/die_subshell_test.go
+++ b/lints/ebuild/die_subshell_test.go
@@ -1,0 +1,132 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestDieSubshellLintRule(t *testing.T) {
+	rule := &DieSubshellLintRule{}
+
+	tests := []struct {
+		name        string
+		eapi        string
+		ebuildStr   string
+		expectError bool
+	}{
+		{
+			name: "EAPI 6 without die in subshell",
+			eapi: "6",
+			ebuildStr: `
+EAPI=6
+die "msg"
+`,
+			expectError: false,
+		},
+		{
+			name: "EAPI 6 with die in subshell",
+			eapi: "6",
+			ebuildStr: `
+EAPI=6
+( die "msg" )
+`,
+			expectError: true,
+		},
+		{
+			name: "EAPI 7 with die in subshell",
+			eapi: "7",
+			ebuildStr: `
+EAPI=7
+( die "msg" )
+`,
+			expectError: false,
+		},
+		{
+			name: "EAPI 6 with die in pipeline",
+			eapi: "6",
+			ebuildStr: `
+EAPI=6
+echo "test" | die "msg"
+`,
+			expectError: true,
+		},
+		{
+			name: "EAPI 7 with die in pipeline",
+			eapi: "7",
+			ebuildStr: `
+EAPI=7
+echo "test" | die "msg"
+`,
+			expectError: false,
+		},
+		{
+			name: "EAPI 6 with die in command substitution",
+			eapi: "6",
+			ebuildStr: `
+EAPI=6
+VAR=$(die "msg")
+`,
+			expectError: true,
+		},
+		{
+			name: "EAPI 6 with die in background",
+			eapi: "6",
+			ebuildStr: `
+EAPI=6
+die "msg" &
+`,
+			expectError: true,
+		},
+		{
+			name: "EAPI 6 with die in process substitution",
+			eapi: "6",
+			ebuildStr: `
+EAPI=6
+diff <(die "1") <(echo bar)
+`,
+			expectError: true,
+		},
+		{
+			name: "EAPI 6 with die in coproc",
+			eapi: "6",
+			ebuildStr: `
+EAPI=6
+coproc foo { die "7"; }
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := map[string]string{}
+			if tt.eapi != "" {
+				vars["EAPI"] = tt.eapi
+			}
+
+			pkg := &g2.PackageData{
+				Category: "app-test",
+				Name:     "test",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Path:    "/test.ebuild",
+							RawText: tt.ebuildStr,
+							Vars:    vars,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkg)
+
+			if tt.expectError && len(results) == 0 {
+				t.Errorf("expected warning, but got none")
+			} else if !tt.expectError && len(results) > 0 {
+				t.Errorf("expected no warning, but got one or more")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a linter rule to prevent the use of `die` within subshells for ebuilds with EAPI <= 6, as described in the Gentoo development manual. Includes accompanying unit tests and verifies compatibility across different EAPIs and subshell constructs.

---
*PR created automatically by Jules for task [8546078289574435610](https://jules.google.com/task/8546078289574435610) started by @arran4*