### PR TITLE
fix: Correctly split revision values in ParseEbuildVariables and fix OrphanedManifest lint

### DIFF
--- a/cmd/g2/ebuild_next_revision.go
+++ b/cmd/g2/ebuild_next_revision.go
@@ -129,7 +129,7 @@ func getNextRevision(dir, version string, inspectFile string) (string, int, erro
 			continue
 		}
 
-		gv := g2.ParseGentooVersion(vars["PV"])
+		gv := g2.ParseGentooVersion(vars["PVR"])
 		origRev := gv.Revision
 		gv.Revision = 0
 		base := gv.String()

--- a/cmd/g2/ebuild_tag.go
+++ b/cmd/g2/ebuild_tag.go
@@ -48,7 +48,7 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string, opts ...any) error {
 		}
 
 		vars := g2.ParseEbuildVariables(entry.Name())
-		if vars == nil || vars["PV"] == "" {
+		if vars == nil || vars["PVR"] == "" {
 			continue
 		}
 
@@ -58,7 +58,7 @@ func (cfg *CmdEbuildArgConfig) cmdEbuildTag(args []string, opts ...any) error {
 			log.Printf("Warning: mixed package names found in directory: %s and %s", pn, vars["PN"])
 		}
 
-		versions = append(versions, vars["PV"])
+		versions = append(versions, vars["PVR"])
 	}
 
 	if len(versions) == 0 {

--- a/ebuild.go
+++ b/ebuild.go
@@ -488,10 +488,19 @@ func ParseEbuildVariables(filename string) map[string]string {
 		gv := ParseGentooVersion(pvCandidate)
 		if gv.IsValid {
 			pn := strings.Join(parts[:i], "-")
+
+			origRev := gv.Revision
+			gv.Revision = 0
+			pvBase := gv.String()
+			gv.Revision = origRev
+
 			return map[string]string{
-				"P":  pn + "-" + pvCandidate,
 				"PN": pn,
-				"PV": pvCandidate,
+				"PV": pvBase,
+				"P":  pn + "-" + pvBase,
+				"PR": fmt.Sprintf("r%d", origRev),
+				"PVR": pvCandidate,
+				"PF": pn + "-" + pvCandidate,
 			}
 		}
 	}
@@ -1123,7 +1132,7 @@ func GetLatestMatchingPackageRevision(overlayFS fs.FS, category, pkgName, versio
 			continue
 		}
 
-		gv := ParseGentooVersion(vars["PV"])
+		gv := ParseGentooVersion(vars["PVR"])
 		origRev := gv.Revision
 		gv.Revision = 0
 		base := gv.String()

--- a/ebuild_test.go
+++ b/ebuild_test.go
@@ -18,25 +18,67 @@ func TestParseEbuildVariables(t *testing.T) {
 		{
 			filename: "ollama-bin-0.10.1.ebuild",
 			want: map[string]string{
-				"P":  "ollama-bin-0.10.1",
 				"PN": "ollama-bin",
 				"PV": "0.10.1",
+				"P":  "ollama-bin-0.10.1",
+				"PR": "r0",
+				"PVR": "0.10.1",
+				"PF": "ollama-bin-0.10.1",
 			},
 		},
 		{
 			filename: "g2-bin-0.0.2.ebuild",
 			want: map[string]string{
-				"P":  "g2-bin-0.0.2",
 				"PN": "g2-bin",
 				"PV": "0.0.2",
+				"P":  "g2-bin-0.0.2",
+				"PR": "r0",
+				"PVR": "0.0.2",
+				"PF": "g2-bin-0.0.2",
 			},
 		},
 		{
 			filename: "app-1.2.3_rc4-r1.ebuild",
 			want: map[string]string{
-				"P":  "app-1.2.3_rc4-r1",
 				"PN": "app",
-				"PV": "1.2.3_rc4-r1",
+				"PV": "1.2.3_rc4",
+				"P":  "app-1.2.3_rc4",
+				"PR": "r1",
+				"PVR": "1.2.3_rc4-r1",
+				"PF": "app-1.2.3_rc4-r1",
+			},
+		},
+		{
+			filename: "foo-1.2.3.ebuild",
+			want: map[string]string{
+				"PN": "foo",
+				"PV": "1.2.3",
+				"P":  "foo-1.2.3",
+				"PR": "r0",
+				"PVR": "1.2.3",
+				"PF": "foo-1.2.3",
+			},
+		},
+		{
+			filename: "foo-1.2.3-r1.ebuild",
+			want: map[string]string{
+				"PN": "foo",
+				"PV": "1.2.3",
+				"P":  "foo-1.2.3",
+				"PR": "r1",
+				"PVR": "1.2.3-r1",
+				"PF": "foo-1.2.3-r1",
+			},
+		},
+		{
+			filename: "foo-bar-1.2.3-r12.ebuild",
+			want: map[string]string{
+				"PN": "foo-bar",
+				"PV": "1.2.3",
+				"P":  "foo-bar-1.2.3",
+				"PR": "r12",
+				"PVR": "1.2.3-r12",
+				"PF": "foo-bar-1.2.3-r12",
 			},
 		},
 		{

--- a/lints/ebuild/orphaned_manifest.go
+++ b/lints/ebuild/orphaned_manifest.go
@@ -46,13 +46,8 @@ func (r *OrphanedManifestLintRule) LintWithQA(repoDir string, pkg *g2.PackageDat
 			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".ebuild") {
 				parsedEbuild, err := g2.ParseEbuild(os.DirFS(pkgDir), entry.Name(), g2.ParseFull)
 				if err == nil {
-					srcUriVar := parsedEbuild.Vars["SRC_URI"]
-					dummyContent := fmt.Sprintf(`SRC_URI="%s"`, srcUriVar)
-					uris, err := g2.ExtractURIs(dummyContent, parsedEbuild.Vars)
-					if err == nil {
-						for _, uri := range uris {
-							usedFiles[uri.Filename] = true
-						}
+					for _, uri := range parsedEbuild.SrcUri {
+						usedFiles[uri.Filename] = true
 					}
 				} else {
 					parseFailed = true

--- a/lints/ebuild/orphaned_manifest_test.go
+++ b/lints/ebuild/orphaned_manifest_test.go
@@ -20,9 +20,9 @@ func TestOrphanedManifestLintRule(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create an ebuild that uses a DIST file
-	ebuildPath := filepath.Join(pkgDir, "testpkg-1.0.ebuild")
-	ebuildContent := `SRC_URI="https://example.com/file1.tar.gz"`
+	// Create an ebuild that uses a DIST file with PV variable
+	ebuildPath := filepath.Join(pkgDir, "testpkg-1.0-r1.ebuild")
+	ebuildContent := `SRC_URI="https://example.com/file1-v${PV}.tar.gz"`
 	if err := os.WriteFile(ebuildPath, []byte(ebuildContent), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -38,10 +38,13 @@ func TestOrphanedManifestLintRule(t *testing.T) {
 		Name:     "testpkg",
 		Versions: []g2.VersionData{
 			{
-				Version: "1.0",
+				Version: "1.0-r1",
 				Ebuild: &g2.Ebuild{
 					Vars: map[string]string{
-						"SRC_URI": "https://example.com/file1.tar.gz",
+						"SRC_URI": "https://example.com/file1-v${PV}.tar.gz",
+					},
+					SrcUri: []g2.URIEntry{
+						{Filename: "file1-v1.0.tar.gz"},
 					},
 				},
 			},
@@ -49,7 +52,7 @@ func TestOrphanedManifestLintRule(t *testing.T) {
 		Manifest: &g2.Manifest{
 			Entries: []*g2.ManifestEntry{
 				// Used DIST file (should not error)
-				{Type: "DIST", Filename: "file1.tar.gz"},
+				{Type: "DIST", Filename: "file1-v1.0.tar.gz"},
 				// Unused DIST file (should error)
 				{Type: "DIST", Filename: "file2.tar.gz"},
 				// Used AUX file (should not error)

--- a/testdata/ebuilds.txtar
+++ b/testdata/ebuilds.txtar
@@ -953,6 +953,9 @@ src_install() {
 	systemd_dounit "${FILESDIR}/whoogle.service"
 }
 INHERITED="distutils-r1 systemd"
+PF="whoogle-search-0.9.3"
+PR="r0"
+PVR="0.9.3"
 SRC_URI="
 	https://github.com/benbusby/whoogle-search/archive/refs/tags/v0.9.3.tar.gz -> whoogle-search-0.9.3.gh.tar.gz
 "


### PR DESCRIPTION
This patch updates `ParseEbuildVariables` to properly strip the revision suffix (`-rN`) from `PV` and `P` in accordance with Gentoo semantics. It also exposes the full set of expected variables: `PR`, `PVR`, and `PF`.

Additionally, the `OrphanedManifestLintRule` is simplified to use the pre-resolved `parsedEbuild.SrcUri` array rather than redundantly parsing `SRC_URI`, eliminating false-positive "unused DIST file" reports when the variable contains substitutions.

Relevant downstream users of `ParseEbuildVariables` across the CLI were migrated to utilize `PVR` where appropriate to ensure they correctly track full versioning including revisions. Test cases were enhanced to verify all parsed variables.

---
*PR created automatically by Jules for task [3154315499528666885](https://jules.google.com/task/3154315499528666885) started by @arran4*