### PR TITLE
feat: Add USE-Controlled Optional RDEPEND lint rule

### DIFF
--- a/lints/ebuild/use_controlled_optional_rdepend.go
+++ b/lints/ebuild/use_controlled_optional_rdepend.go
@@ -59,9 +59,8 @@ func (r *UseControlledOptionalRdependRule) LintWithQA(repoDir string, pkg *g2.Pa
 				}
 			}
 
-            // Look in IUSE for flags - wait, actually we want to see if it's used in src_*
-            // Just scan the raw text for the flag.
-            rawText := string(ver.Ebuild.RawText)
+			// Just scan the raw text for the flag usage.
+			rawText := string(ver.Ebuild.RawText)
 
 			for flag := range rdependFlags {
 				// If used in another dependency var, it's likely valid
@@ -70,14 +69,7 @@ func (r *UseControlledOptionalRdependRule) LintWithQA(repoDir string, pkg *g2.Pa
 				}
 
 				// If the flag is used in the ebuild body (e.g., `use flag`, `usex flag`), it's valid
-                // We'll use a simple string containment check, but bounded to avoid false positives on substrings
-                // Usually it's `use foo`, `use_with foo`, etc. Or `if use foo; then`.
-                // Checking for " foo" or "foo " or "-foo" might be too broad.
-                // Let's check for specific patterns: `use flag`, `usex flag`, `use_with flag`, `use_enable flag`
-                // Actually, just checking if `flag` is in the raw text at all (outside of IUSE and RDEPEND) is a start.
-                // But wait, it will be in IUSE. We should check if it appears in `use flag` or similar.
-
-                isUsedInBody := false
+				isUsedInBody := false
 
                 // Common use functions
                 useFuncs := []string{"use", "usev", "usex", "use_with", "use_enable"}

--- a/lints/ebuild/use_controlled_optional_rdepend.go
+++ b/lints/ebuild/use_controlled_optional_rdepend.go
@@ -1,0 +1,117 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleUseControlledOptionalRdepend = lints.RuleMetadata{
+	ID:          "UseControlledOptionalRdepend",
+	Title:       "USE-Controlled Optional RDEPENDS",
+	Description: "USE-controlled optional RDEPs are generally not acceptable except under very specific circumstances. A USE flag used only to pull in a runtime dependency without affecting the build should be avoided.",
+	URL:         "https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Policies#USE-Controlled_Optional_RDEPENDS",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "rdepend", "use-flags"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleUseControlledOptionalRdepend)
+	lints.RegisterLintRule(&UseControlledOptionalRdependRule{})
+}
+
+type UseControlledOptionalRdependRule struct{}
+
+func (r *UseControlledOptionalRdependRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *UseControlledOptionalRdependRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := ruleUseControlledOptionalRdepend.Severity
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			rdependStr, ok := ver.Ebuild.Vars["RDEPEND"]
+			if !ok || rdependStr == "" {
+				continue
+			}
+
+			// Extract USE flags from RDEPEND
+			rdependFlags := r.extractUseFlags(rdependStr)
+			if len(rdependFlags) == 0 {
+				continue
+			}
+
+			// Check other DEPEND variables
+			otherDepFlags := make(map[string]bool)
+			for _, depVar := range []string{"DEPEND", "BDEPEND", "PDEPEND"} {
+				if depStr, ok := ver.Ebuild.Vars[depVar]; ok && depStr != "" {
+					flags := r.extractUseFlags(depStr)
+					for flag := range flags {
+						otherDepFlags[flag] = true
+					}
+				}
+			}
+
+            // Look in IUSE for flags - wait, actually we want to see if it's used in src_*
+            // Just scan the raw text for the flag.
+            rawText := string(ver.Ebuild.RawText)
+
+			for flag := range rdependFlags {
+				// If used in another dependency var, it's likely valid
+				if otherDepFlags[flag] {
+					continue
+				}
+
+				// If the flag is used in the ebuild body (e.g., `use flag`, `usex flag`), it's valid
+                // We'll use a simple string containment check, but bounded to avoid false positives on substrings
+                // Usually it's `use foo`, `use_with foo`, etc. Or `if use foo; then`.
+                // Checking for " foo" or "foo " or "-foo" might be too broad.
+                // Let's check for specific patterns: `use flag`, `usex flag`, `use_with flag`, `use_enable flag`
+                // Actually, just checking if `flag` is in the raw text at all (outside of IUSE and RDEPEND) is a start.
+                // But wait, it will be in IUSE. We should check if it appears in `use flag` or similar.
+
+                isUsedInBody := false
+
+                // Common use functions
+                useFuncs := []string{"use", "usev", "usex", "use_with", "use_enable"}
+                for _, f := range useFuncs {
+                    if strings.Contains(rawText, f+" "+flag) || strings.Contains(rawText, f+"\t"+flag) {
+                        isUsedInBody = true
+                        break
+                    }
+                }
+
+				if !isUsedInBody {
+					res := lints.LintResult{
+						RuleMetadata: ruleUseControlledOptionalRdepend,
+						Message:      fmt.Sprintf("[%s] Ebuild %s uses USE flag '%s' purely for an optional RDEPEND. USE-controlled optional RDEPs are not acceptable except under very specific circumstances.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, flag),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					results = append(results, res)
+				}
+			}
+		}
+	}
+	return results
+}
+
+func (r *UseControlledOptionalRdependRule) extractUseFlags(depStr string) map[string]bool {
+	flags := make(map[string]bool)
+	tokens := strings.Fields(depStr)
+	for _, token := range tokens {
+		if strings.HasSuffix(token, "?") {
+			flag := strings.TrimSuffix(token, "?")
+			// Remove any leading negation
+			flag = strings.TrimPrefix(flag, "!")
+			flags[flag] = true
+		}
+	}
+	return flags
+}

--- a/lints/ebuild/use_controlled_optional_rdepend_test.go
+++ b/lints/ebuild/use_controlled_optional_rdepend_test.go
@@ -1,0 +1,161 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestUseControlledOptionalRdependRule(t *testing.T) {
+	rule := &UseControlledOptionalRdependRule{}
+
+	tests := []struct {
+		name     string
+		pkg      *g2.PackageData
+		qaPolicy *g2.QAPolicy
+		expected int
+	}{
+		{
+			name: "No USE-controlled RDEPENDs",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RDEPEND": "dev-libs/A dev-libs/B",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0,
+		},
+		{
+			name: "USE-controlled RDEPEND (Pure)",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RDEPEND": "a? ( dev-libs/A ) dev-libs/B",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 1, // Flag 'a' is only in RDEPEND
+		},
+		{
+			name: "USE-controlled RDEPEND but used in DEPEND",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"DEPEND":  "a? ( dev-libs/A-headers )",
+								"RDEPEND": "a? ( dev-libs/A )",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0, // Flag 'a' is also in DEPEND, so it configures the build
+		},
+		{
+			name: "USE-controlled RDEPEND but used in BDEPEND",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"BDEPEND": "a? ( dev-util/A-tools )",
+								"RDEPEND": "a? ( dev-libs/A )",
+							},
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0, // Flag 'a' is also in BDEPEND
+		},
+		{
+			name: "USE-controlled RDEPEND but used in ebuild body",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"RDEPEND": "ssl? ( dev-libs/openssl )",
+							},
+                            RawText: `
+src_configure() {
+    econf $(use_with ssl)
+}
+`,
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 0, // Flag 'ssl' is used in src_configure
+		},
+		{
+			name: "Multiple USE-controlled RDEPENDs, mixed",
+			pkg: &g2.PackageData{
+				Category: "dev-libs",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+                                "DEPEND": "b? ( dev-libs/B )",
+								"RDEPEND": "a? ( dev-libs/A ) !b? ( dev-libs/B ) c? ( dev-libs/C )",
+							},
+                            RawText: `
+src_compile() {
+    if use c; then
+        emake with-c
+    fi
+}
+`,
+						},
+					},
+				},
+			},
+			qaPolicy: nil,
+			expected: 1, // 'a' is pure RDEPEND, 'b' is in DEPEND, 'c' is in body
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			results := rule.LintWithQA("", tc.pkg, tc.qaPolicy)
+
+			if len(results) != tc.expected {
+				t.Errorf("Expected %d results, got %d", tc.expected, len(results))
+				for _, res := range results {
+					t.Logf("Result: %s", res.Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a new lint rule, `UseControlledOptionalRdependRule`, to enforce the Gentoo QA policy regarding USE-controlled optional RDEPENDs. It detects USE flags that are exclusively used to conditionally pull in dependencies in `RDEPEND` without affecting the build process or being utilized in the ebuild script body.

The rule intelligently checks for the presence of the USE flag in `DEPEND`, `BDEPEND`, `PDEPEND`, and within the ebuild body (e.g., using `use`, `use_with`, `use_enable`) to minimize false positives, accurately distinguishing between valid conditional dependencies and purely optional runtime dependencies.

Unit tests are included to comprehensively validate the rule's logic against both passing and failing scenarios.

---
*PR created automatically by Jules for task [17210384583707663179](https://jules.google.com/task/17210384583707663179) started by @arran4*