### PR TITLE
feat: Add IndentingWhitespace and CharacterSet ebuild lints

### DIFF
--- a/lints/ebuild/character_set.go
+++ b/lints/ebuild/character_set.go
@@ -1,0 +1,68 @@
+package ebuild
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleCharacterSet = lints.RuleMetadata{
+	ID:          "CharacterSet",
+	Title:       "Character Set",
+	Description: "Validates that ebuild files use the UTF-8 character set.",
+	URL:         "https://devmanual.gentoo.org/ebuild-writing/file-format/index.html#character-set",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "encoding"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleCharacterSet)
+	lints.RegisterLintRule(&CharacterSetLintRule{})
+}
+
+type CharacterSetLintRule struct{}
+
+func (r *CharacterSetLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *CharacterSetLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if qa != nil {
+		if val, ok := qa.Policies[ruleCharacterSet.ID]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			if !utf8.ValidString(ver.Ebuild.RawText) {
+				res := lints.LintResult{
+					RuleMetadata: ruleCharacterSet,
+					Message:      fmt.Sprintf("[%s] Ebuild %s is not valid UTF-8.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+	return results
+}

--- a/lints/ebuild/character_set_test.go
+++ b/lints/ebuild/character_set_test.go
@@ -1,0 +1,58 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCharacterSetLintRule(t *testing.T) {
+	rule := &CharacterSetLintRule{}
+
+	t.Run("Valid UTF-8", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "good-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						RawText: "# Copyright 1999-2024 Gentoo Authors\n" +
+							"# Distributed under the terms of the GNU General Public License v2\n\n" +
+							"EAPI=8\n\n" +
+							"DESCRIPTION=\"A valid package\"\n" +
+							"HOMEPAGE=\"https://example.com\"\n" +
+							"SRC_URI=\"\"\n\n" +
+							"LICENSE=\"GPL-2\"\n" +
+							"SLOT=\"0\"\n" +
+							"KEYWORDS=\"~amd64\"\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Empty(t, results)
+	})
+
+	t.Run("Invalid UTF-8", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "invalid-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						// Contains invalid UTF-8 sequence \xff\xfe
+						RawText: "DESCRIPTION=\"Invalid char \xff\xfe\"\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "is not valid UTF-8")
+	})
+}

--- a/lints/ebuild/indenting_whitespace.go
+++ b/lints/ebuild/indenting_whitespace.go
@@ -1,0 +1,136 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleIndentingWhitespace = lints.RuleMetadata{
+	ID:          "IndentingWhitespace",
+	Title:       "Indenting and Whitespace",
+	Description: "Validates that ebuilds use tabs for indentation and contain no trailing whitespace.",
+	URL:         "https://devmanual.gentoo.org/ebuild-writing/file-format/index.html#indenting-and-whitespace",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "whitespace"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleIndentingWhitespace)
+	lints.RegisterLintRule(&IndentingWhitespaceLintRule{})
+}
+
+type IndentingWhitespaceLintRule struct{}
+
+func (r *IndentingWhitespaceLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *IndentingWhitespaceLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityWarning
+
+	if qa != nil {
+		if val, ok := qa.Policies[ruleIndentingWhitespace.ID]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			lines := strings.Split(ver.Ebuild.RawText, "\n")
+			for i, line := range lines {
+				line = strings.TrimSuffix(line, "\r")
+				if len(line) == 0 {
+					continue
+				}
+
+				// Check trailing whitespace
+				if line[len(line)-1] == ' ' || line[len(line)-1] == '\t' {
+					res := lints.LintResult{
+						RuleMetadata: ruleIndentingWhitespace,
+						Message:      fmt.Sprintf("[%s] Ebuild %s has trailing whitespace on line %d.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, i+1),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+				}
+
+				// Check leading space for indentation and tabs after indentation
+				indenting := true
+				positions := 0
+				hasTabAfterIndent := false
+				hasSpaceIndent := false
+
+				for _, ch := range line {
+					if indenting {
+						if ch == '\t' {
+							positions += 4
+							continue
+						} else if ch == ' ' {
+							hasSpaceIndent = true
+							indenting = false
+							positions += 1
+						} else {
+							indenting = false
+							positions += 1
+						}
+					} else {
+						if ch == '\t' {
+							hasTabAfterIndent = true
+							positions += 4
+						} else {
+							positions += 1
+						}
+					}
+				}
+
+				if hasSpaceIndent {
+					res := lints.LintResult{
+						RuleMetadata: ruleIndentingWhitespace,
+						Message:      fmt.Sprintf("[%s] Ebuild %s uses spaces for indentation on line %d.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, i+1),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+				}
+
+				if hasTabAfterIndent {
+					res := lints.LintResult{
+						RuleMetadata: ruleIndentingWhitespace,
+						Message:      fmt.Sprintf("[%s] Ebuild %s has a tab character outside of indentation on line %d.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, i+1),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+				}
+
+				if positions > 80 {
+					res := lints.LintResult{
+						RuleMetadata: ruleIndentingWhitespace,
+						Message:      fmt.Sprintf("[%s] Ebuild %s has a line exceeding 80 positions on line %d.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, i+1),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+				}
+			}
+		}
+	}
+	return results
+}

--- a/lints/ebuild/indenting_whitespace_test.go
+++ b/lints/ebuild/indenting_whitespace_test.go
@@ -1,0 +1,184 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndentingWhitespaceLintRule(t *testing.T) {
+	rule := &IndentingWhitespaceLintRule{}
+
+	t.Run("Valid ebuild", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "good-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						RawText: "# Copyright 1999-2024 Gentoo Authors\n" +
+							"# Distributed under the terms of the GNU General Public License v2\n\n" +
+							"EAPI=8\n\n" +
+							"DESCRIPTION=\"A valid package\"\n" +
+							"HOMEPAGE=\"https://example.com\"\n" +
+							"SRC_URI=\"\"\n\n" +
+							"LICENSE=\"GPL-2\"\n" +
+							"SLOT=\"0\"\n" +
+							"KEYWORDS=\"~amd64\"\n\n" +
+							"src_prepare() {\n" +
+							"\tdefault\n" +
+							"}\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Empty(t, results)
+	})
+
+	t.Run("Trailing whitespace", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "trailing-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						RawText: "EAPI=8 \n" +
+							"DESCRIPTION=\"A valid package\"\t\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Len(t, results, 3)
+		assert.Contains(t, results[0].Message, "trailing whitespace on line 1")
+		assert.Contains(t, results[1].Message, "trailing whitespace on line 2")
+		assert.Contains(t, results[2].Message, "tab character outside of indentation on line 2")
+	})
+
+	t.Run("Leading spaces for indentation", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "spaces-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						RawText: "src_prepare() {\n" +
+							"  default\n" +
+							"}\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "uses spaces for indentation on line 2")
+	})
+
+	t.Run("Mixed spaces and tabs for indentation", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "mixed-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						RawText: "src_prepare() {\n" +
+							"\t  default\n" +
+							"}\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "uses spaces for indentation on line 2")
+	})
+
+	t.Run("Ignores spaces after other text", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "spaces-after-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						RawText: "src_prepare() {\n" +
+							"\tdefault # comments can have spaces\n" +
+							"}\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Empty(t, results)
+	})
+
+	t.Run("Tab after indent", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "tab-after-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						RawText: "DESCRIPTION=\"A\tpackage\"\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "has a tab character outside of indentation on line 1")
+	})
+
+	t.Run("Line length > 80 positions", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "long-line-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						// 81 'a's
+						RawText: "DESCRIPTION=\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "has a line exceeding 80 positions on line 1")
+	})
+
+	t.Run("Line length with tabs", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Category: "app-test",
+			Name:     "long-line-tabs-pkg",
+			Versions: []g2.VersionData{
+				{
+					Version: "1.0",
+					Ebuild: &g2.Ebuild{
+						// 20 tabs (80 positions) + 1 char = 81 positions
+						RawText: "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ta\n",
+					},
+				},
+			},
+		}
+
+		results := rule.Lint("/tmp/dummyrepo", pkg)
+		assert.Len(t, results, 1)
+		assert.Contains(t, results[0].Message, "has a line exceeding 80 positions on line 1")
+	})
+}


### PR DESCRIPTION
Adds the CharacterSet and IndentingWhitespace lint rules according to the gentoo devmanual specifications.

---
*PR created automatically by Jules for task [12628581702442483275](https://jules.google.com/task/12628581702442483275) started by @arran4*