### PR TITLE
feat(lint): add dependency_no_revision rule (PG0002)

### DIFF
--- a/lints/ebuild/dependency_no_revision.go
+++ b/lints/ebuild/dependency_no_revision.go
@@ -1,0 +1,95 @@
+package ebuild
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+)
+
+var ruleDependencyNoRevision = lints.RuleMetadata{
+	ID:          "DependencyNoRevision",
+	Title:       "=-dependencies with no revision",
+	Description: "Whenever a non-wildcard = (equals) dependency is used on a package, the requested revision must be specified explicitly.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/dependencies.html#pg0002",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "dependencies", "pg0002"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleDependencyNoRevision)
+	lints.RegisterLintRule(&DependencyNoRevisionLintRule{})
+}
+
+type DependencyNoRevisionLintRule struct{}
+
+func (r *DependencyNoRevisionLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *DependencyNoRevisionLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := string(ruleDependencyNoRevision.Severity)
+	if len(severity) > 0 {
+		severity = strings.ToUpper(severity[:1]) + severity[1:]
+	}
+	revisionRe := regexp.MustCompile(`-r\d+$`)
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			for _, depVar := range []string{"DEPEND", "RDEPEND", "PDEPEND", "BDEPEND", "IDEPEND"} {
+				depStr, ok := ver.Ebuild.Vars[depVar]
+				if !ok || depStr == "" {
+					continue
+				}
+
+				walkDependencies(depStr, func(atomStr string) {
+					atom := g2.ParsePackageAtom(atomStr)
+
+					if atom.Operator == "=" && !strings.Contains(atomStr, "*") {
+						if !revisionRe.MatchString(atom.Version) {
+							res := lints.LintResult{
+								RuleMetadata: ruleDependencyNoRevision,
+								Message:      fmt.Sprintf("[%s] Ebuild %s uses a non-wildcard '=' dependency without an explicit revision in %s: %s", severity, ver.Version, depVar, atomStr),
+								Package:      pkg.Category + "/" + pkg.Name,
+							}
+							results = append(results, res)
+						}
+					}
+				})
+			}
+		}
+	}
+	return results
+}
+
+func walkDependencies(depStr string, cb func(atomStr string)) {
+	tokens := strings.Fields(depStr)
+	var stateStack []string
+	pendingAnyOf := false
+
+	for _, token := range tokens {
+		if token == "||" {
+			pendingAnyOf = true
+		} else if token == "(" {
+			if pendingAnyOf {
+				stateStack = append(stateStack, "||")
+				pendingAnyOf = false
+			} else {
+				stateStack = append(stateStack, "OTHER")
+			}
+		} else if token == ")" {
+			if len(stateStack) > 0 {
+				stateStack = stateStack[:len(stateStack)-1]
+			}
+		} else if strings.HasSuffix(token, "?") {
+			pendingAnyOf = false
+		} else {
+			cb(token)
+			pendingAnyOf = false
+		}
+	}
+}

--- a/lints/ebuild/dependency_no_revision_test.go
+++ b/lints/ebuild/dependency_no_revision_test.go
@@ -1,0 +1,153 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDependencyNoRevisionLintRule(t *testing.T) {
+	rule := &DependencyNoRevisionLintRule{}
+
+	tests := []struct {
+		name          string
+		ebuildVars    map[string]string
+		expectedCount int
+	}{
+		{
+			name: "No warning for explicit revision",
+			ebuildVars: map[string]string{
+				"DEPEND": "=dev-libs/libfrobnicate-1.2.3-r0",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "No warning for explicit revision >0",
+			ebuildVars: map[string]string{
+				"DEPEND": "=dev-libs/libfrobnicate-1.2.3-r3",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "No warning for tilde operator",
+			ebuildVars: map[string]string{
+				"DEPEND": "~dev-libs/libfrobnicate-1.2.3",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "No warning for wildcard",
+			ebuildVars: map[string]string{
+				"DEPEND": "=dev-libs/libfrobnicate-1.2*",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "Warning for non-wildcard equals dependency without revision",
+			ebuildVars: map[string]string{
+				"DEPEND": "=dev-libs/libfrobnicate-1.2.3",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Warning for multiple dependencies without revision",
+			ebuildVars: map[string]string{
+				"DEPEND": "=dev-libs/libfrobnicate-1.2.3\n	=dev-libs/another-1.0",
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "Warning inside block",
+			ebuildVars: map[string]string{
+				"DEPEND": "\n	|| (\n		=dev-libs/libfrobnicate-1.2.3\n		=dev-libs/another-1.0-r1\n	)\n",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "No warning for non-equals",
+			ebuildVars: map[string]string{
+				"DEPEND": ">=dev-libs/libfrobnicate-1.2.3",
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: "app-test",
+				Name:     "testpkg",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: tc.ebuildVars,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkg)
+			assert.Len(t, results, tc.expectedCount)
+			if tc.expectedCount > 0 {
+				assert.Contains(t, results[0].Message, "uses a non-wildcard '=' dependency without an explicit revision")
+			}
+		})
+	}
+}
+
+func TestDependencyNoRevisionLintRule_FalsePositives(t *testing.T) {
+	rule := &DependencyNoRevisionLintRule{}
+
+	tests := []struct {
+		name          string
+		ebuildVars    map[string]string
+		expectedCount int
+	}{
+		{
+			name: "Warning for package with -r in category name but no revision",
+			ebuildVars: map[string]string{
+				"DEPEND": "=app-runner/libfrobnicate-1.2.3",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Warning for package with -r in package name but no revision",
+			ebuildVars: map[string]string{
+				"DEPEND": "=dev-libs/runner-1.2.3",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Warning for package with -r in version suffix but no revision",
+			ebuildVars: map[string]string{
+				"DEPEND": "=dev-libs/libfrobnicate-1.2.3_rc1",
+			},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: "app-test",
+				Name:     "testpkg",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: tc.ebuildVars,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkg)
+			assert.Len(t, results, tc.expectedCount)
+			if tc.expectedCount > 0 {
+				assert.Contains(t, results[0].Message, "uses a non-wildcard '=' dependency without an explicit revision")
+			}
+		})
+	}
+}

--- a/lints/registry.go
+++ b/lints/registry.go
@@ -20,6 +20,7 @@ type Source string
 const (
 	SourceG2       Source = "g2"
 	SourcePkgcheck Source = "pkgcheck"
+	SourceQA       Source = "qa"
 )
 
 type RuleMetadata struct {


### PR DESCRIPTION
Adds a new lint rule based on the Gentoo QA policy PG0002. It checks DEPEND, RDEPEND, PDEPEND, BDEPEND, and IDEPEND to ensure `=-dependencies` have a specified revision, and warns otherwise.

---
*PR created automatically by Jules for task [2907622740630656604](https://jules.google.com/task/2907622740630656604) started by @arran4*