### PR TITLE
Add keyword linting rules

### DIFF
--- a/lints/ebuild/dropped_keywords.go
+++ b/lints/ebuild/dropped_keywords.go
@@ -1,0 +1,142 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+	"sort"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleDroppedKeywords = lints.RuleMetadata{
+	ID:          "DroppedKeywords",
+	Title:       "Dropped Keywords",
+	Description: "Checks if arch keywords were dropped during version bumping.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/keywords.html#pg0401",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "keywords"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleDroppedKeywords)
+	lints.RegisterLintRule(&DroppedKeywordsLintRule{})
+}
+
+type DroppedKeywordsLintRule struct{}
+
+func (r *DroppedKeywordsLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *DroppedKeywordsLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	// Filter and sort non-live ebuilds
+	var sortedVersions []g2.VersionData
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			if strings.HasSuffix(ver.Version, "9999") {
+				continue // Live ebuilds usually don't have keywords
+			}
+			sortedVersions = append(sortedVersions, ver)
+		}
+	}
+
+	if len(sortedVersions) <= 1 {
+		return nil
+	}
+
+	sort.Slice(sortedVersions, func(i, j int) bool {
+		return g2.CompareVersions(sortedVersions[i].Version, sortedVersions[j].Version) < 0
+	})
+
+	seenArches := make(map[string]bool)
+	previousArches := make(map[string]bool)
+
+	// Track dropped arches per version to detect regressions
+	changes := make(map[string][]string)
+
+	for _, ver := range sortedVersions {
+		keywordsStr := ver.Ebuild.Vars["KEYWORDS"]
+
+		pkgArches := make(map[string]bool)
+		disabledArches := make(map[string]bool)
+
+		hasStar := false
+		if strings.TrimSpace(keywordsStr) != "" {
+			for _, kw := range strings.Fields(keywordsStr) {
+				arch := strings.TrimLeft(kw, "~-")
+				if arch == "*" {
+					hasStar = true
+				}
+				pkgArches[arch] = true
+				if strings.HasPrefix(kw, "-") {
+					disabledArches[strings.TrimLeft(kw, "-")] = true
+				}
+			}
+		}
+
+		drops := make(map[string]bool)
+		if !hasStar {
+			for arch := range previousArches {
+				if !pkgArches[arch] {
+					drops[arch] = true
+				}
+			}
+			for arch := range seenArches {
+				if !pkgArches[arch] {
+					drops[arch] = true
+				}
+			}
+		}
+
+		for key := range drops {
+			changes[key] = append(changes[key], ver.Version)
+		}
+
+		if len(changes) > 0 {
+			adds := make(map[string]bool)
+			for arch := range pkgArches {
+				if !previousArches[arch] && !disabledArches[arch] {
+					adds[arch] = true
+				}
+			}
+
+			for key := range adds {
+				delete(changes, key)
+			}
+		}
+
+		for arch := range pkgArches {
+			seenArches[arch] = true
+		}
+
+		previousArches = pkgArches
+	}
+
+	dropped := make(map[string][]string)
+	for key, pkgs := range changes {
+		if len(pkgs) > 0 {
+			// only report the most recent pkg with dropped keywords (like pkgcheck does without verbose)
+			latestPkg := pkgs[len(pkgs)-1]
+			dropped[latestPkg] = append(dropped[latestPkg], key)
+		}
+	}
+
+	for pkgVer, keys := range dropped {
+		sort.Strings(keys)
+		if len(keys) > 0 {
+			results = append(results, lints.LintResult{
+				RuleMetadata: ruleDroppedKeywords,
+				Message:      fmt.Sprintf("[%s] Ebuild %s has dropped keywords: %s", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityWarning)), pkgVer, strings.Join(keys, ", ")),
+				Package:      pkg.Category + "/" + pkg.Name,
+			})
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/dropped_keywords_test.go
+++ b/lints/ebuild/dropped_keywords_test.go
@@ -1,0 +1,131 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestDroppedKeywordsLintRule(t *testing.T) {
+	rule := &DroppedKeywordsLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		pkgName  string
+		versions []struct {
+			version  string
+			keywords string
+		}
+		expected int
+	}{
+		{
+			name:     "No dropped keywords",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "~amd64 ~x86"},
+				{"1.1", "~amd64 ~x86"},
+				{"1.2", "amd64 ~x86"},
+			},
+			expected: 0,
+		},
+		{
+			name:     "Dropped keyword x86",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "~amd64 ~x86"},
+				{"1.1", "~amd64"},
+			},
+			expected: 1,
+		},
+		{
+			name:     "Dropped keyword restored",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "~amd64 ~x86"},
+				{"1.1", "~amd64"},
+				{"1.2", "~amd64 ~x86"},
+			},
+			expected: 0,
+		},
+		{
+			name:     "Disabled keyword does not drop",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "~amd64 ~x86"},
+				{"1.1", "~amd64 -x86"},
+			},
+			expected: 0,
+		},
+		{
+			name:     "Star keyword overrides",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "~amd64 ~x86"},
+				{"1.1", "-* amd64"},
+			},
+			expected: 0,
+		},
+		{
+			name:     "Only one version",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "~amd64 ~x86"},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Name:     tt.pkgName,
+				Versions: make([]g2.VersionData, 0, len(tt.versions)),
+			}
+
+			for _, v := range tt.versions {
+				pkg.Versions = append(pkg.Versions, g2.VersionData{
+					Version: v.version,
+					Ebuild: &g2.Ebuild{
+						Vars: map[string]string{
+							"KEYWORDS": v.keywords,
+						},
+					},
+				})
+			}
+
+			results := rule.Lint("", pkg)
+			if len(results) != tt.expected {
+				t.Errorf("expected %d results, got %d", tt.expected, len(results))
+				for _, r := range results {
+					t.Logf("Result: %s", r.Message)
+				}
+			}
+		})
+	}
+}

--- a/lints/ebuild/stabilize_new_versions.go
+++ b/lints/ebuild/stabilize_new_versions.go
@@ -1,0 +1,108 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+	"sort"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleStabilizeNewVersions = lints.RuleMetadata{
+	ID:          "StabilizeNewVersions",
+	Title:       "Stabilize New Versions",
+	Description: "Checks if a stabilized version missed some architectures that had stable versions.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/keywords.html#pg0402",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "keywords"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleStabilizeNewVersions)
+	lints.RegisterLintRule(&StabilizeNewVersionsLintRule{})
+}
+
+type StabilizeNewVersionsLintRule struct{}
+
+func (r *StabilizeNewVersionsLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *StabilizeNewVersionsLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	// Filter and sort non-live ebuilds
+	var sortedVersions []g2.VersionData
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			if strings.HasSuffix(ver.Version, "9999") {
+				continue // Live ebuilds usually don't have keywords
+			}
+			sortedVersions = append(sortedVersions, ver)
+		}
+	}
+
+	if len(sortedVersions) <= 1 {
+		return nil
+	}
+
+	sort.Slice(sortedVersions, func(i, j int) bool {
+		return g2.CompareVersions(sortedVersions[i].Version, sortedVersions[j].Version) < 0
+	})
+
+	previousStableArches := make(map[string]bool)
+
+	for _, ver := range sortedVersions {
+		keywordsStr := ver.Ebuild.Vars["KEYWORDS"]
+
+		pkgArches := make(map[string]bool)
+		stableArches := make(map[string]bool)
+
+		hasStar := false
+		if strings.TrimSpace(keywordsStr) != "" {
+			for _, kw := range strings.Fields(keywordsStr) {
+				arch := strings.TrimLeft(kw, "~-")
+				if arch == "*" {
+					hasStar = true
+				}
+				pkgArches[arch] = true
+				if !strings.HasPrefix(kw, "~") && !strings.HasPrefix(kw, "-") {
+					stableArches[arch] = true
+				}
+			}
+		}
+
+		if len(stableArches) > 0 && !hasStar {
+			// Found a stabilized version. Check if it missed any previous stable arches
+			var missedArches []string
+			for arch := range previousStableArches {
+				if pkgArches[arch] && !stableArches[arch] {
+					// This architecture was stable in previous versions,
+					// is present in this version (as unstable/testing ~arch),
+					// but wasn't stabilized along with the other architectures in this version.
+					missedArches = append(missedArches, arch)
+				}
+			}
+
+			if len(missedArches) > 0 {
+				sort.Strings(missedArches)
+				results = append(results, lints.LintResult{
+					RuleMetadata: ruleStabilizeNewVersions,
+					Message:      fmt.Sprintf("[%s] Ebuild %s is stabilized but misses arches: %s", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityWarning)), ver.Version, strings.Join(missedArches, ", ")),
+					Package:      pkg.Category + "/" + pkg.Name,
+				})
+			}
+		}
+
+		// Update stable arches for the next version
+		for arch := range stableArches {
+			previousStableArches[arch] = true
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/stabilize_new_versions_test.go
+++ b/lints/ebuild/stabilize_new_versions_test.go
@@ -1,0 +1,104 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestStabilizeNewVersionsLintRule(t *testing.T) {
+	rule := &StabilizeNewVersionsLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		pkgName  string
+		versions []struct {
+			version  string
+			keywords string
+		}
+		expected int
+	}{
+		{
+			name:     "All stabilized",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "amd64 x86"},
+				{"1.1", "amd64 x86"},
+			},
+			expected: 0,
+		},
+		{
+			name:     "Missed arch",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "amd64 x86"},
+				{"1.1", "amd64 ~x86"},
+			},
+			expected: 1,
+		},
+		{
+			name:     "Arch not present is not missed",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "amd64 x86"},
+				{"1.1", "amd64"},
+			},
+			expected: 0,
+		},
+		{
+			name:     "No stabilization",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "amd64 x86"},
+				{"1.1", "~amd64 ~x86"},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Name:     tt.pkgName,
+				Versions: make([]g2.VersionData, 0, len(tt.versions)),
+			}
+
+			for _, v := range tt.versions {
+				pkg.Versions = append(pkg.Versions, g2.VersionData{
+					Version: v.version,
+					Ebuild: &g2.Ebuild{
+						Vars: map[string]string{
+							"KEYWORDS": v.keywords,
+						},
+					},
+				})
+			}
+
+			results := rule.Lint("", pkg)
+			if len(results) != tt.expected {
+				t.Errorf("expected %d results, got %d", tt.expected, len(results))
+				for _, r := range results {
+					t.Logf("Result: %s", r.Message)
+				}
+			}
+		})
+	}
+}

--- a/lints/ebuild/unstable_only.go
+++ b/lints/ebuild/unstable_only.go
@@ -1,0 +1,106 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+	"sort"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleUnstableOnly = lints.RuleMetadata{
+	ID:          "UnstableOnly",
+	Title:       "Unstable Only",
+	Description: "Checks if a package has only unstable keywords for an architecture.",
+	URL:         "",
+	Severity:    lints.SeverityNotice, // pkgcheck puts it as Info
+	Source:      lints.SourcePkgcheck,
+	Tags:        []string{"ebuild", "keywords"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleUnstableOnly)
+	lints.RegisterLintRule(&UnstableOnlyLintRule{})
+}
+
+type UnstableOnlyLintRule struct{}
+
+func (r *UnstableOnlyLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *UnstableOnlyLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+
+	// Filter and sort non-live ebuilds
+	var sortedVersions []g2.VersionData
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			if strings.HasSuffix(ver.Version, "9999") {
+				continue // Live ebuilds usually don't have keywords
+			}
+			sortedVersions = append(sortedVersions, ver)
+		}
+	}
+
+	if len(sortedVersions) == 0 {
+		return nil
+	}
+
+	sort.Slice(sortedVersions, func(i, j int) bool {
+		return g2.CompareVersions(sortedVersions[i].Version, sortedVersions[j].Version) < 0
+	})
+
+	// Collect all architectures mentioned in the package
+	allArches := make(map[string]bool)
+	archVersions := make(map[string][]string)
+	hasStable := make(map[string]bool)
+
+	for _, ver := range sortedVersions {
+		keywordsStr := ver.Ebuild.Vars["KEYWORDS"]
+
+		if strings.TrimSpace(keywordsStr) != "" {
+			for _, kw := range strings.Fields(keywordsStr) {
+				arch := strings.TrimLeft(kw, "~-")
+				if arch == "*" {
+					continue
+				}
+				allArches[arch] = true
+
+				if strings.HasPrefix(kw, "~") {
+					archVersions[arch] = append(archVersions[arch], ver.Version)
+				} else if !strings.HasPrefix(kw, "-") {
+					hasStable[arch] = true
+				}
+			}
+		}
+	}
+
+	// Group arches by the exact set of unstable versions
+	unstableGroups := make(map[string][]string)
+	for arch := range allArches {
+		if !hasStable[arch] && len(archVersions[arch]) > 0 {
+			versionsKey := strings.Join(archVersions[arch], ",")
+			unstableGroups[versionsKey] = append(unstableGroups[versionsKey], arch)
+		}
+	}
+
+	for versionsStr, arches := range unstableGroups {
+		sort.Strings(arches)
+		versions := strings.Split(versionsStr, ",")
+
+		results = append(results, lints.LintResult{
+			RuleMetadata: ruleUnstableOnly,
+			Message:      fmt.Sprintf("[%s] Package has only unstable keywords for arch(es): [ %s ], all versions are unstable: [ %s ]",
+				cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityNotice)),
+				strings.Join(arches, ", "),
+				strings.Join(versions, ", ")),
+			Package:      pkg.Category + "/" + pkg.Name,
+		})
+	}
+
+	return results
+}

--- a/lints/ebuild/unstable_only_test.go
+++ b/lints/ebuild/unstable_only_test.go
@@ -1,0 +1,89 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestUnstableOnlyLintRule(t *testing.T) {
+	rule := &UnstableOnlyLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		pkgName  string
+		versions []struct {
+			version  string
+			keywords string
+		}
+		expected int
+	}{
+		{
+			name:     "Has stable",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "amd64 ~x86"},
+				{"1.1", "~amd64 ~x86"},
+			},
+			expected: 1, // x86 is unstable only
+		},
+		{
+			name:     "All stable",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "amd64 x86"},
+			},
+			expected: 0,
+		},
+		{
+			name:     "Unstable only",
+			category: "app-misc",
+			pkgName:  "testpkg",
+			versions: []struct {
+				version  string
+				keywords string
+			}{
+				{"1.0", "~amd64 ~x86"},
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Name:     tt.pkgName,
+				Versions: make([]g2.VersionData, 0, len(tt.versions)),
+			}
+
+			for _, v := range tt.versions {
+				pkg.Versions = append(pkg.Versions, g2.VersionData{
+					Version: v.version,
+					Ebuild: &g2.Ebuild{
+						Vars: map[string]string{
+							"KEYWORDS": v.keywords,
+						},
+					},
+				})
+			}
+
+			results := rule.Lint("", pkg)
+			if len(results) != tt.expected {
+				t.Errorf("expected %d results, got %d", tt.expected, len(results))
+				for _, r := range results {
+					t.Logf("Result: %s", r.Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented missing lint rules from the Gentoo QA Policy Guide regarding keywords. This includes checks for dropped keywords, stabilization misses on version bumps, and unstable-only architectures. Tests have been added and verify proper functionality.

---
*PR created automatically by Jules for task [10298455260609617046](https://jules.google.com/task/10298455260609617046) started by @arran4*