### PR TITLE
feat(lints): implement Gentoo QA policies PG0101-PG0107

### DIFF
--- a/lints/ebuild/coding_style.go
+++ b/lints/ebuild/coding_style.go
@@ -1,0 +1,101 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleCodingStyle = lints.RuleMetadata{
+	ID:          "CodingStyle",
+	Title:       "Coding Style",
+	Description: "Validates ebuild coding style: no POSIX test ([ ... ] or test), use bracketed variables (${foo}).",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/ebuild-format.html#pg0101",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0101"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleCodingStyle)
+	lints.RegisterLintRule(&CodingStyleLintRule{})
+}
+
+type CodingStyleLintRule struct{}
+
+func (r *CodingStyleLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *CodingStyleLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityWarning
+
+	if qa != nil {
+		if val, ok := qa.Policies["PG0101"]; ok { // Coding style
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			parser := syntax.NewParser(syntax.KeepComments(true))
+			f, err := parser.Parse(strings.NewReader(ver.Ebuild.RawText), "")
+			if err != nil {
+				continue // handled by syntax error lint
+			}
+
+			syntax.Walk(f, func(node syntax.Node) bool {
+				switch n := node.(type) {
+				case *syntax.ParamExp:
+					if n.Short {
+						// Exclude special bash variables
+						if len(n.Param.Value) == 1 && strings.ContainsAny(n.Param.Value, "0123456789@*?$-#!") {
+							// skip
+						} else {
+							res := lints.LintResult{
+								RuleMetadata: ruleCodingStyle,
+								Message:      fmt.Sprintf("[%s] Ebuild %s uses unbracketed variable '$%s'. Use '${%s}' instead.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, n.Param.Value, n.Param.Value),
+								Package:      pkg.Category + "/" + pkg.Name,
+							}
+							res.RuleMetadata.Severity = severity
+							results = append(results, res)
+						}
+					}
+				case *syntax.CallExpr:
+					if len(n.Args) > 0 && len(n.Args[0].Parts) > 0 {
+						if lit, ok := n.Args[0].Parts[0].(*syntax.Lit); ok {
+							cmd := lit.Value
+							if cmd == "[" || cmd == "test" {
+								res := lints.LintResult{
+									RuleMetadata: ruleCodingStyle,
+									Message:      fmt.Sprintf("[%s] Ebuild %s uses POSIX test '%s'. Use bash conditions '[[ ... ]]' instead.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, cmd),
+									Package:      pkg.Category + "/" + pkg.Name,
+								}
+								res.RuleMetadata.Severity = severity
+								results = append(results, res)
+							}
+						}
+					}
+				}
+				return true
+			})
+		}
+	}
+	return results
+}

--- a/lints/ebuild/coding_style_test.go
+++ b/lints/ebuild/coding_style_test.go
@@ -1,0 +1,45 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestCodingStyleLintRule(t *testing.T) {
+	rule := &ebuild.CodingStyleLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		rawText  string
+		want     int
+	}{
+		{"Valid ebuild", "app-misc", "pkg_setup() {\n[[ -n \"${foo}\" ]] || die\n}", 0},
+		{"POSIX condition [", "app-misc", "pkg_setup() {\n[ -n \"${foo}\" ] || die\n}", 1},
+		{"POSIX condition test", "app-misc", "pkg_setup() {\ntest -n \"${foo}\" || die\n}", 1},
+		{"Unbracketed variable", "app-misc", "pkg_setup() {\necho $foo\n}", 1},
+		{"Special unbracketed variable", "app-misc", "pkg_setup() {\necho $1 $@ $* $? $$ $! $- $#\n}", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			warnings := rule.Lint(".", pkg)
+			if len(warnings) != tt.want {
+				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
+			}
+		})
+	}
+}

--- a/lints/ebuild/d_variables.go
+++ b/lints/ebuild/d_variables.go
@@ -1,0 +1,101 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleDVariables = lints.RuleMetadata{
+	ID:          "DVariables",
+	Title:       "D used outside src_install and pkg_preinst",
+	Description: "The D and ED variables must be used only in the src_install and pkg_preinst phase functions.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/ebuild-format.html#pg0107",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0107"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleDVariables)
+	lints.RegisterLintRule(&DVariablesLintRule{})
+}
+
+type DVariablesLintRule struct{}
+
+func (r *DVariablesLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *DVariablesLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if qa != nil {
+		if val, ok := qa.Policies["PG0107"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			parser := syntax.NewParser(syntax.KeepComments(true))
+			f, err := parser.Parse(strings.NewReader(ver.Ebuild.RawText), "")
+			if err != nil {
+				continue
+			}
+
+			syntax.Walk(f, func(node syntax.Node) bool {
+				switch n := node.(type) {
+				case *syntax.FuncDecl:
+					funcName := n.Name.Value
+					if funcName != "src_install" && funcName != "pkg_preinst" {
+						syntax.Walk(n, func(inner syntax.Node) bool {
+							switch nx := inner.(type) {
+							case *syntax.ParamExp:
+								if nx.Param.Value == "D" || nx.Param.Value == "ED" {
+									res := lints.LintResult{
+										RuleMetadata: ruleDVariables,
+										Message:      fmt.Sprintf("[%s] Ebuild %s uses '${%s}' in '%s'. It must be used only in src_install and pkg_preinst.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, nx.Param.Value, funcName),
+										Package:      pkg.Category + "/" + pkg.Name,
+									}
+									res.RuleMetadata.Severity = severity
+									results = append(results, res)
+								}
+							}
+							return true
+						})
+					}
+					return false // do not walk inside the function again from global walk
+				case *syntax.ParamExp: // Global scope check
+					if n.Param.Value == "D" || n.Param.Value == "ED" {
+						res := lints.LintResult{
+							RuleMetadata: ruleDVariables,
+							Message:      fmt.Sprintf("[%s] Ebuild %s uses '${%s}' in global scope. It must be used only in src_install and pkg_preinst.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, n.Param.Value),
+							Package:      pkg.Category + "/" + pkg.Name,
+						}
+						res.RuleMetadata.Severity = severity
+						results = append(results, res)
+					}
+				}
+				return true
+			})
+		}
+	}
+	return results
+}

--- a/lints/ebuild/d_variables_test.go
+++ b/lints/ebuild/d_variables_test.go
@@ -1,0 +1,46 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestDVariablesLintRule(t *testing.T) {
+	rule := &ebuild.DVariablesLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		rawText  string
+		want     int
+	}{
+		{"Valid usage in src_install", "app-misc", "src_install() {\necho ${D}\n}", 0},
+		{"Valid usage in pkg_preinst", "app-misc", "pkg_preinst() {\necho ${ED}\n}", 0},
+		{"Invalid usage in src_configure", "app-misc", "src_configure() {\necho ${D}\n}", 1},
+		{"Invalid usage in global scope", "app-misc", "MY_VAR=\"${D}/foo\"", 1},
+		{"Valid short var usage", "app-misc", "src_install() {\necho $D\n}", 0},
+		{"Invalid short var usage in global scope", "app-misc", "MY_VAR=\"$D/foo\"", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			warnings := rule.Lint(".", pkg)
+			if len(warnings) != tt.want {
+				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
+			}
+		})
+	}
+}

--- a/lints/ebuild/external_code.go
+++ b/lints/ebuild/external_code.go
@@ -1,0 +1,90 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleExternalCode = lints.RuleMetadata{
+	ID:          "ExternalCode",
+	Title:       "Code must be contained within ebuild and eclasses",
+	Description: "It is forbidden to load additional ebuild code from other files via source, eval or any other possible method.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/ebuild-format.html#pg0102",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0102"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleExternalCode)
+	lints.RegisterLintRule(&ExternalCodeLintRule{})
+}
+
+type ExternalCodeLintRule struct{}
+
+func (r *ExternalCodeLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *ExternalCodeLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if qa != nil {
+		if val, ok := qa.Policies["PG0102"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			parser := syntax.NewParser(syntax.KeepComments(true))
+			f, err := parser.Parse(strings.NewReader(ver.Ebuild.RawText), "")
+			if err != nil {
+				continue
+			}
+
+			syntax.Walk(f, func(node syntax.Node) bool {
+				switch n := node.(type) {
+				case *syntax.CallExpr:
+					if len(n.Args) > 0 && len(n.Args[0].Parts) > 0 {
+						if lit, ok := n.Args[0].Parts[0].(*syntax.Lit); ok {
+							cmd := lit.Value
+							if cmd == "source" || cmd == "." || cmd == "eval" {
+								// We should probably check if it's sourcing something other than eclasses if possible?
+								// PG0102 just says "It is forbidden to load additional ebuild code from other files via source, eval or any other possible method."
+								// eclasses are usually inherited, not sourced manually in ebuilds (except inside inherit itself which isn't an ebuild).
+								// Let's just flag source/. and eval
+								res := lints.LintResult{
+									RuleMetadata: ruleExternalCode,
+									Message:      fmt.Sprintf("[%s] Ebuild %s sources external code using '%s'. Code must be contained within ebuild and eclasses.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, cmd),
+									Package:      pkg.Category + "/" + pkg.Name,
+								}
+								res.RuleMetadata.Severity = severity
+								results = append(results, res)
+							}
+						}
+					}
+				}
+				return true
+			})
+		}
+	}
+	return results
+}

--- a/lints/ebuild/external_code_test.go
+++ b/lints/ebuild/external_code_test.go
@@ -1,0 +1,44 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestExternalCodeLintRule(t *testing.T) {
+	rule := &ebuild.ExternalCodeLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		rawText  string
+		want     int
+	}{
+		{"Valid ebuild", "app-misc", "pkg_setup() {\necho \"test\"\n}", 0},
+		{"Source external file", "app-misc", "pkg_setup() {\nsource ./foo\n}", 1},
+		{"Dot source external file", "app-misc", "pkg_setup() {\n. ./foo\n}", 1},
+		{"Eval usage", "app-misc", "pkg_setup() {\neval \"echo test\"\n}", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			warnings := rule.Lint(".", pkg)
+			if len(warnings) != tt.want {
+				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
+			}
+		})
+	}
+}

--- a/lints/ebuild/homepage_variables.go
+++ b/lints/ebuild/homepage_variables.go
@@ -1,0 +1,86 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleHomepageVariables = lints.RuleMetadata{
+	ID:          "HomepageVariables",
+	Title:       "HOMEPAGE contains variables",
+	Description: "HOMEPAGE must specify all URIs verbatim, without referring to variables.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/ebuild-format.html#pg0103",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0103"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleHomepageVariables)
+	lints.RegisterLintRule(&HomepageVariablesLintRule{})
+}
+
+type HomepageVariablesLintRule struct{}
+
+func (r *HomepageVariablesLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *HomepageVariablesLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if qa != nil {
+		if val, ok := qa.Policies["PG0103"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			parser := syntax.NewParser(syntax.KeepComments(true))
+			f, err := parser.Parse(strings.NewReader(ver.Ebuild.RawText), "")
+			if err != nil {
+				continue
+			}
+
+			syntax.Walk(f, func(node syntax.Node) bool {
+				if assign, ok := node.(*syntax.Assign); ok {
+					if assign.Name != nil && assign.Name.Value == "HOMEPAGE" {
+						syntax.Walk(assign.Value, func(inner syntax.Node) bool {
+							switch nx := inner.(type) {
+							case *syntax.ParamExp:
+								res := lints.LintResult{
+									RuleMetadata: ruleHomepageVariables,
+									Message:      fmt.Sprintf("[%s] Ebuild %s HOMEPAGE must not contain variables (found '%s')", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, nx.Param.Value),
+									Package:      pkg.Category + "/" + pkg.Name,
+								}
+								res.RuleMetadata.Severity = severity
+								results = append(results, res)
+							}
+							return true
+						})
+					}
+				}
+				return true
+			})
+		}
+	}
+	return results
+}

--- a/lints/ebuild/homepage_variables_test.go
+++ b/lints/ebuild/homepage_variables_test.go
@@ -1,0 +1,44 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestHomepageVariablesLintRule(t *testing.T) {
+	rule := &ebuild.HomepageVariablesLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		rawText  string
+		want     int
+	}{
+		{"Valid HOMEPAGE", "app-misc", "HOMEPAGE=\"https://example.com/\"", 0},
+		{"Variable in HOMEPAGE", "app-misc", "HOMEPAGE=\"https://example.com/${PN}\"", 1},
+		{"Multiple variables in HOMEPAGE", "app-misc", "HOMEPAGE=\"https://example.com/${PN}/${PV}\"", 2},
+		{"Short variable in HOMEPAGE", "app-misc", "HOMEPAGE=\"https://example.com/$PN\"", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			warnings := rule.Lint(".", pkg)
+			if len(warnings) != tt.want {
+				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
+			}
+		})
+	}
+}

--- a/lints/ebuild/keywords_single_line.go
+++ b/lints/ebuild/keywords_single_line.go
@@ -1,0 +1,131 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleKeywordsSingleLine = lints.RuleMetadata{
+	ID:          "KeywordsSingleLine",
+	Title:       "KEYWORDS defined on a single line",
+	Description: "KEYWORDS must be defined at most once in an ebuild, on a single line, with literal content.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/ebuild-format.html#pg0105",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0105"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleKeywordsSingleLine)
+	lints.RegisterLintRule(&KeywordsSingleLineLintRule{})
+}
+
+type KeywordsSingleLineLintRule struct{}
+
+func (r *KeywordsSingleLineLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *KeywordsSingleLineLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if qa != nil {
+		if val, ok := qa.Policies["PG0105"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			parser := syntax.NewParser(syntax.KeepComments(true))
+			f, err := parser.Parse(strings.NewReader(ver.Ebuild.RawText), "")
+			if err != nil {
+				continue
+			}
+
+			keywordAssignCount := 0
+			syntax.Walk(f, func(node syntax.Node) bool {
+				if assign, ok := node.(*syntax.Assign); ok {
+					if assign.Name != nil && assign.Name.Value == "KEYWORDS" {
+						keywordAssignCount++
+
+						// Check append
+						if assign.Append {
+							res := lints.LintResult{
+								RuleMetadata: ruleKeywordsSingleLine,
+								Message:      fmt.Sprintf("[%s] Ebuild %s appends to KEYWORDS. It must be defined at most once.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+								Package:      pkg.Category + "/" + pkg.Name,
+							}
+							res.RuleMetadata.Severity = severity
+							results = append(results, res)
+						}
+
+						// Check literal content and single line
+						hasVarRef := false
+						hasNewlines := false
+
+						syntax.Walk(assign.Value, func(inner syntax.Node) bool {
+							switch nx := inner.(type) {
+							case *syntax.ParamExp:
+								hasVarRef = true
+							case *syntax.Lit:
+								if strings.Contains(nx.Value, "\n") {
+									hasNewlines = true
+								}
+							}
+							return true
+						})
+
+						if hasVarRef {
+							res := lints.LintResult{
+								RuleMetadata: ruleKeywordsSingleLine,
+								Message:      fmt.Sprintf("[%s] Ebuild %s KEYWORDS contains variable references. It must have literal content.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+								Package:      pkg.Category + "/" + pkg.Name,
+							}
+							res.RuleMetadata.Severity = severity
+							results = append(results, res)
+						}
+						if hasNewlines {
+							res := lints.LintResult{
+								RuleMetadata: ruleKeywordsSingleLine,
+								Message:      fmt.Sprintf("[%s] Ebuild %s KEYWORDS contains newlines. It must be defined on a single line.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+								Package:      pkg.Category + "/" + pkg.Name,
+							}
+							res.RuleMetadata.Severity = severity
+							results = append(results, res)
+						}
+					}
+				}
+				return true
+			})
+
+			if keywordAssignCount > 1 {
+				res := lints.LintResult{
+					RuleMetadata: ruleKeywordsSingleLine,
+					Message:      fmt.Sprintf("[%s] Ebuild %s KEYWORDS is defined multiple times. It must be defined at most once.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+	return results
+}

--- a/lints/ebuild/keywords_single_line_test.go
+++ b/lints/ebuild/keywords_single_line_test.go
@@ -1,0 +1,45 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestKeywordsSingleLineLintRule(t *testing.T) {
+	rule := &ebuild.KeywordsSingleLineLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		rawText  string
+		want     int
+	}{
+		{"Valid KEYWORDS", "app-misc", "KEYWORDS=\"~amd64 ~x86\"", 0},
+		{"KEYWORDS on multiple lines", "app-misc", "KEYWORDS=\"~amd64\n~x86\"", 1},
+		{"KEYWORDS with variable", "app-misc", "KEYWORDS=\"~amd64 ${MY_KW}\"", 1},
+		{"KEYWORDS append", "app-misc", "KEYWORDS=\"~amd64\"\nKEYWORDS+=\" ~x86\"", 2}, // Appending and multiple definitions
+		{"KEYWORDS multiple defs", "app-misc", "KEYWORDS=\"~amd64\"\nKEYWORDS=\"~x86\"", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			warnings := rule.Lint(".", pkg)
+			if len(warnings) != tt.want {
+				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
+			}
+		})
+	}
+}

--- a/lints/ebuild/license_variables.go
+++ b/lints/ebuild/license_variables.go
@@ -1,0 +1,88 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleLicenseVariables = lints.RuleMetadata{
+	ID:          "LicenseVariables",
+	Title:       "LICENSE contains variables",
+	Description: "LICENSE must specify all license names verbatim, without referring to variables, except for appending.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/ebuild-format.html#pg0106",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0106"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleLicenseVariables)
+	lints.RegisterLintRule(&LicenseVariablesLintRule{})
+}
+
+type LicenseVariablesLintRule struct{}
+
+func (r *LicenseVariablesLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *LicenseVariablesLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if qa != nil {
+		if val, ok := qa.Policies["PG0106"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			parser := syntax.NewParser(syntax.KeepComments(true))
+			f, err := parser.Parse(strings.NewReader(ver.Ebuild.RawText), "")
+			if err != nil {
+				continue
+			}
+
+			syntax.Walk(f, func(node syntax.Node) bool {
+				if assign, ok := node.(*syntax.Assign); ok {
+					if assign.Name != nil && assign.Name.Value == "LICENSE" {
+						syntax.Walk(assign.Value, func(inner syntax.Node) bool {
+							switch nx := inner.(type) {
+							case *syntax.ParamExp:
+								if nx.Param.Value != "LICENSE" {
+									res := lints.LintResult{
+										RuleMetadata: ruleLicenseVariables,
+										Message:      fmt.Sprintf("[%s] Ebuild %s LICENSE contains variable '${%s}'. It must not contain variables other than ${LICENSE}.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version, nx.Param.Value),
+										Package:      pkg.Category + "/" + pkg.Name,
+									}
+									res.RuleMetadata.Severity = severity
+									results = append(results, res)
+								}
+							}
+							return true
+						})
+					}
+				}
+				return true
+			})
+		}
+	}
+	return results
+}

--- a/lints/ebuild/license_variables_test.go
+++ b/lints/ebuild/license_variables_test.go
@@ -1,0 +1,45 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestLicenseVariablesLintRule(t *testing.T) {
+	rule := &ebuild.LicenseVariablesLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		rawText  string
+		want     int
+	}{
+		{"Valid LICENSE", "app-misc", "LICENSE=\"GPL-2\"", 0},
+		{"LICENSE append", "app-misc", "LICENSE=\"${LICENSE} GPL-2\"", 0},
+		{"LICENSE append +=", "app-misc", "LICENSE+=\" GPL-2\"", 0},
+		{"Variable in LICENSE", "app-misc", "LICENSE=\"${MY_LIC}\"", 1},
+		{"Short Variable in LICENSE", "app-misc", "LICENSE=\"$MY_LIC\"", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			warnings := rule.Lint(".", pkg)
+			if len(warnings) != tt.want {
+				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
+			}
+		})
+	}
+}

--- a/lints/ebuild/srcuri_homepage.go
+++ b/lints/ebuild/srcuri_homepage.go
@@ -1,0 +1,88 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleSrcUriHomepage = lints.RuleMetadata{
+	ID:          "SrcUriHomepage",
+	Title:       "SRC_URI refers to HOMEPAGE",
+	Description: "SRC_URI must not refer to ${HOMEPAGE}.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/ebuild-format.html#pg0104",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0104"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleSrcUriHomepage)
+	lints.RegisterLintRule(&SrcUriHomepageLintRule{})
+}
+
+type SrcUriHomepageLintRule struct{}
+
+func (r *SrcUriHomepageLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *SrcUriHomepageLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if qa != nil {
+		if val, ok := qa.Policies["PG0104"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			parser := syntax.NewParser(syntax.KeepComments(true))
+			f, err := parser.Parse(strings.NewReader(ver.Ebuild.RawText), "")
+			if err != nil {
+				continue
+			}
+
+			syntax.Walk(f, func(node syntax.Node) bool {
+				if assign, ok := node.(*syntax.Assign); ok {
+					if assign.Name != nil && assign.Name.Value == "SRC_URI" {
+						syntax.Walk(assign.Value, func(inner syntax.Node) bool {
+							switch nx := inner.(type) {
+							case *syntax.ParamExp:
+								if nx.Param.Value == "HOMEPAGE" {
+									res := lints.LintResult{
+										RuleMetadata: ruleSrcUriHomepage,
+										Message:      fmt.Sprintf("[%s] Ebuild %s SRC_URI must not refer to ${HOMEPAGE}", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+										Package:      pkg.Category + "/" + pkg.Name,
+									}
+									res.RuleMetadata.Severity = severity
+									results = append(results, res)
+								}
+							}
+							return true
+						})
+					}
+				}
+				return true
+			})
+		}
+	}
+	return results
+}

--- a/lints/ebuild/srcuri_homepage_test.go
+++ b/lints/ebuild/srcuri_homepage_test.go
@@ -1,0 +1,42 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestSrcUriHomepageLintRule(t *testing.T) {
+	rule := &ebuild.SrcUriHomepageLintRule{}
+
+	tests := []struct {
+		name     string
+		category string
+		rawText  string
+		want     int
+	}{
+		{"Valid SRC_URI", "app-misc", "SRC_URI=\"https://example.com/foo.tar.gz\"", 0},
+		{"SRC_URI refers to HOMEPAGE", "app-misc", "SRC_URI=\"${HOMEPAGE}/foo.tar.gz\"", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			warnings := rule.Lint(".", pkg)
+			if len(warnings) != tt.want {
+				t.Errorf("got %d warnings, want %d", len(warnings), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements ebuild format validation rules based on the Gentoo QA Policy Guide (PG0101 through PG0107).

- **PG0101:** Rejects POSIX `[ ... ]` and `test` usage in favor of `[[ ... ]]`. Flags unbracketed variables like `$foo` while ignoring special shell variables.
- **PG0102:** Prevents external file sourcing via `source`, `.`, and `eval` to enforce code containment within ebuilds/eclasses.
- **PG0103:** Requires `HOMEPAGE` values to be literal strings without variable expansion.
- **PG0104:** Prohibits `SRC_URI` from referencing `${HOMEPAGE}`.
- **PG0105:** Validates that `KEYWORDS` is assigned exactly once, as a single literal line, without `+=` appends.
- **PG0106:** Disallows variables in `LICENSE` except for appending to `${LICENSE}`.
- **PG0107:** Restricts the use of `${D}` and `${ED}` variables to the `src_install` and `pkg_preinst` phases, throwing errors on global or other function usage.

All rules utilize the robust `mvdan.cc/sh/v3/syntax` AST parser and include comprehensive unit tests.

---
*PR created automatically by Jules for task [10995457004997718681](https://jules.google.com/task/10995457004997718681) started by @arran4*