### PR TITLE
feat: add head and tail usage lint rules

### DIFF
--- a/lints/ebuild/head_tail.go
+++ b/lints/ebuild/head_tail.go
@@ -1,0 +1,163 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleHeadTail = lints.RuleMetadata{
+	ID:          "HeadAndTailUsage",
+	Title:       "Head and tail usage",
+	Description: "Checks for improper or deprecated use of head and tail commands, such as deprecated syntax, clumsy line counting, and unnecessary chaining with sed.",
+	URL:         "https://devmanual.gentoo.org/tools-reference/head-and-tail/index.html",
+	Severity:    lints.SeverityWarning,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "qa", "tools"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleHeadTail)
+	lints.RegisterLintRule(&HeadTailLintRule{})
+}
+
+type HeadTailLintRule struct{}
+
+func (l *HeadTailLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, version := range pkgData.Versions {
+		if version.Ebuild == nil {
+			continue
+		}
+
+		parser := syntax.NewParser()
+		f, err := parser.Parse(strings.NewReader(version.Ebuild.RawText), "")
+		if err != nil {
+			continue
+		}
+
+		syntax.Walk(f, func(node syntax.Node) bool {
+			// Check for deprecated syntax e.g. head -5
+			if call, ok := node.(*syntax.CallExpr); ok && len(call.Args) > 0 {
+				if lit, ok := call.Args[0].Parts[0].(*syntax.Lit); ok {
+					cmd := lit.Value
+					if cmd == "head" || cmd == "tail" {
+						for _, arg := range call.Args {
+							if len(arg.Parts) > 0 {
+								if argLit, ok := arg.Parts[0].(*syntax.Lit); ok {
+									if strings.HasPrefix(argLit.Value, "-") && len(argLit.Value) > 1 && argLit.Value[1] >= '0' && argLit.Value[1] <= '9' {
+										res := lints.LintResult{
+											RuleMetadata: ruleHeadTail,
+											Message:      fmt.Sprintf("%s -N syntax is deprecated and not POSIX compliant, use %s -n N instead.", cmd, cmd),
+											Package:      pkgData.Category + "/" + pkgData.Name,
+										}
+										results = append(results, res)
+									}
+								}
+							}
+						}
+
+						// Check for clumsily computing line count for tail
+						if cmd == "tail" {
+							for _, arg := range call.Args {
+								hasWc := false
+								syntax.Walk(arg, func(n syntax.Node) bool {
+									if c, ok := n.(*syntax.CallExpr); ok && len(c.Args) > 0 {
+										if l, ok := c.Args[0].Parts[0].(*syntax.Lit); ok {
+											if l.Value == "wc" {
+												hasWc = true
+											}
+										}
+									}
+									return true
+								})
+								if hasWc {
+									// Also need to check if it's inside a command substitution or arithmetic expansion
+									isComputing := false
+									syntax.Walk(arg, func(n syntax.Node) bool {
+										if _, ok := n.(*syntax.CmdSubst); ok {
+											isComputing = true
+										}
+										if _, ok := n.(*syntax.ArithmExp); ok {
+											isComputing = true
+										}
+										return true
+									})
+									if isComputing {
+										res := lints.LintResult{
+											RuleMetadata: ruleHeadTail,
+											Message:      "Clumsily computing line count for tail, use tail -n +X instead.",
+											Package:      pkgData.Category + "/" + pkgData.Name,
+										}
+										results = append(results, res)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// Check for chaining head or tail with sed
+			if binaryCmd, ok := node.(*syntax.BinaryCmd); ok {
+				if binaryCmd.Op == syntax.Pipe {
+					leftCmd := getBaseCommand(binaryCmd.X)
+					rightCmd := getBaseCommand(binaryCmd.Y)
+
+					if (leftCmd == "head" || leftCmd == "tail") && rightCmd == "sed" {
+						res := lints.LintResult{
+							RuleMetadata: ruleHeadTail,
+							Message:      "Chaining head or tail with sed is usually unnecessary. Use of addresses and early exit can do the same thing with a single sed call.",
+							Package:      pkgData.Category + "/" + pkgData.Name,
+						}
+						results = append(results, res)
+					}
+					if leftCmd == "sed" && (rightCmd == "head" || rightCmd == "tail") {
+						res := lints.LintResult{
+							RuleMetadata: ruleHeadTail,
+							Message:      "Chaining head or tail with sed is usually unnecessary. Use of addresses and early exit can do the same thing with a single sed call.",
+							Package:      pkgData.Category + "/" + pkgData.Name,
+						}
+						results = append(results, res)
+					}
+				}
+			}
+
+			return true
+		})
+	}
+
+	return results
+}
+
+func getBaseCommand(node syntax.Node) string {
+	var cmdName string
+	syntax.Walk(node, func(n syntax.Node) bool {
+		if cmdName != "" {
+			return false
+		}
+
+		if call, ok := n.(*syntax.CallExpr); ok && len(call.Args) > 0 {
+			if len(call.Args[0].Parts) > 0 {
+				if lit, ok := call.Args[0].Parts[0].(*syntax.Lit); ok {
+					cmdName = lit.Value
+					return false
+				}
+			}
+		}
+
+		if _, ok := n.(*syntax.Subshell); ok {
+			return false
+		}
+		if _, ok := n.(*syntax.CmdSubst); ok {
+			return false
+		}
+
+		return true
+	})
+	return cmdName
+}

--- a/lints/ebuild/head_tail_test.go
+++ b/lints/ebuild/head_tail_test.go
@@ -1,0 +1,94 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestHeadTailLintRule(t *testing.T) {
+	rule := &HeadTailLintRule{}
+
+	tests := []struct {
+		name     string
+		ebuild   string
+		expected int
+	}{
+		{
+			name:     "clean ebuild",
+			ebuild:   `echo "hello" | grep "h"`,
+			expected: 0,
+		},
+		{
+			name:     "head -N deprecated syntax",
+			ebuild:   `head -5 input.txt`,
+			expected: 1,
+		},
+		{
+			name:     "tail -N deprecated syntax",
+			ebuild:   `tail -5 input.txt`,
+			expected: 1,
+		},
+		{
+			name:     "tail clumsy computing",
+			ebuild:   `tail -n $(($(wc -l in.txt | awk '{print $1}') - 5)) in.txt > out.txt`,
+			expected: 1,
+		},
+		{
+			name:     "head | sed chaining",
+			ebuild:   `head -n 5 input.txt | sed -e 's/foo/bar/g' > output.txt`,
+			expected: 1,
+		},
+		{
+			name:     "sed | head chaining",
+			ebuild:   `foo=$(sed -n -e '/somestring/p' input.txt | head -n 1)`,
+			expected: 1,
+		},
+		{
+			name:     "sed | tail chaining",
+			ebuild:   `sed -n -e '/somestring/p' input.txt | tail -n 1`,
+			expected: 1,
+		},
+		{
+			name:     "valid head syntax",
+			ebuild:   `head -n 5 input.txt`,
+			expected: 0,
+		},
+		{
+			name:     "valid tail syntax",
+			ebuild:   `tail -n 5 input.txt`,
+			expected: 0,
+		},
+		{
+			name:     "valid sed early exit",
+			ebuild:   `foo=$(sed -n -e '/somestring/{ p ; q }' input.txt )`,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: "sys-apps",
+				Name:     "testpkg",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.ebuild,
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkg)
+
+			if len(results) != tt.expected {
+				t.Errorf("expected %d results, got %d", tt.expected, len(results))
+				for _, r := range results {
+					t.Logf("Result: %s", r.Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new ebuild lint rule to enforce guidelines for using `head` and `tail` in ebuilds.

---
*PR created automatically by Jules for task [17746365339544274112](https://jules.google.com/task/17746365339544274112) started by @arran4*