### PR TITLE
feat: implement Gentoo QA PG0701-PG0704 for other metadata

### DIFF
--- a/lints/ebuild/dynamic_slots.go
+++ b/lints/ebuild/dynamic_slots.go
@@ -1,0 +1,79 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleDynamicSlots = lints.RuleMetadata{
+	ID:          "DynamicSlots",
+	Title:       "Dynamic Slots (multislot flag)",
+	Description: "The use of multislot to alter SLOT values (as well as any other USE-dependent slot values) in the Gentoo repository is forbidden.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/other-metadata.html#pg0701",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0701"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleDynamicSlots)
+	lints.RegisterLintRule(&DynamicSlotsLintRule{})
+}
+
+type DynamicSlotsLintRule struct{}
+
+func (r *DynamicSlotsLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *DynamicSlotsLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := ruleDynamicSlots.Severity
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0701"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			iuseStr := ver.Ebuild.Vars["IUSE"]
+			hasMultislot := false
+			for _, token := range strings.Fields(iuseStr) {
+				if token == "multislot" || token == "+multislot" || token == "-multislot" {
+					hasMultislot = true
+					break
+				}
+			}
+
+			if hasMultislot {
+				res := lints.LintResult{
+					RuleMetadata: ruleDynamicSlots,
+					Message:      fmt.Sprintf("[%s] Ebuild %s uses 'multislot' in IUSE which is forbidden", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/dynamic_slots_test.go
+++ b/lints/ebuild/dynamic_slots_test.go
@@ -1,0 +1,48 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestDynamicSlotsLintRule(t *testing.T) {
+	tests := []struct {
+		name     string
+		category string
+		iuse     string
+		expected int
+	}{
+		{"Valid no multislot", "sys-devel", "", 0},
+		{"Invalid multislot in IUSE", "sys-devel", "multislot", 1},
+		{"Invalid +multislot in IUSE", "sys-devel", "+multislot", 1},
+		{"Invalid -multislot in IUSE", "sys-devel", "test -multislot", 1},
+	}
+
+	rule := &DynamicSlotsLintRule{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Name:     "gcc",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"IUSE": tt.iuse,
+							},
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkg)
+
+			if len(results) != tt.expected {
+				t.Errorf("Expected %d results, got %d", tt.expected, len(results))
+			}
+		})
+	}
+}

--- a/lints/ebuild/license.go
+++ b/lints/ebuild/license.go
@@ -1,0 +1,77 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleLicense = lints.RuleMetadata{
+	ID:          "License",
+	Title:       "LICENSE variable must explicitly list all licenses",
+	Description: "The LICENSE variable must explicitly list all licenses pertaining to the corresponding source of the files installed by the package.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/other-metadata.html#pg0704",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0704"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleLicense)
+	lints.RegisterLintRule(&LicenseLintRule{})
+}
+
+type LicenseLintRule struct{}
+
+func (r *LicenseLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *LicenseLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := ruleLicense.Severity
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0704"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			license := strings.TrimSpace(ver.Ebuild.Vars["LICENSE"])
+
+			// Virtuals don't require LICENSE
+			if pkg.Category == "virtual" {
+			    continue
+			}
+
+			if license == "" {
+				res := lints.LintResult{
+					RuleMetadata: ruleLicense,
+					Message:      fmt.Sprintf("[%s] Ebuild %s does not specify LICENSE", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/license_test.go
+++ b/lints/ebuild/license_test.go
@@ -1,0 +1,47 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestLicenseLintRule(t *testing.T) {
+	tests := []struct {
+		name     string
+		category string
+		license  string
+		expected int
+	}{
+		{"Has license", "app-misc", "GPL-2", 0},
+		{"No license", "app-misc", "", 1},
+		{"Virtual with no license", "virtual", "", 0},
+	}
+
+	rule := &LicenseLintRule{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Name:     "example",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"LICENSE": tt.license,
+							},
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkg)
+
+			if len(results) != tt.expected {
+				t.Errorf("Expected %d results, got %d", tt.expected, len(results))
+			}
+		})
+	}
+}

--- a/lints/ebuild/meaningful_homepage.go
+++ b/lints/ebuild/meaningful_homepage.go
@@ -1,0 +1,74 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleMeaningfulHomepage = lints.RuleMetadata{
+	ID:          "MeaningfulHomepage",
+	Title:       "HOMEPAGE value must be meaningful",
+	Description: "HOMEPAGE must be meaningful. Packages must not use https://www.gentoo.org/ or a similar generic homepage.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/other-metadata.html#pg0702",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0702"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleMeaningfulHomepage)
+	lints.RegisterLintRule(&MeaningfulHomepageLintRule{})
+}
+
+type MeaningfulHomepageLintRule struct{}
+
+func (r *MeaningfulHomepageLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *MeaningfulHomepageLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := ruleMeaningfulHomepage.Severity
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0702"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			homepage := strings.TrimSpace(ver.Ebuild.Vars["HOMEPAGE"])
+			fields := strings.Fields(homepage)
+			for _, hp := range fields {
+				if hp == "https://www.gentoo.org/" || hp == "http://www.gentoo.org/" || hp == "https://www.gentoo.org" || hp == "http://www.gentoo.org" {
+					res := lints.LintResult{
+						RuleMetadata: ruleMeaningfulHomepage,
+						Message:      fmt.Sprintf("[%s] Ebuild %s uses a generic Gentoo HOMEPAGE which is not meaningful", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+						Package:      pkg.Category + "/" + pkg.Name,
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+				}
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/meaningful_homepage_test.go
+++ b/lints/ebuild/meaningful_homepage_test.go
@@ -1,0 +1,48 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestMeaningfulHomepageLintRule(t *testing.T) {
+	tests := []struct {
+		name     string
+		category string
+		homepage string
+		expected int
+	}{
+		{"Valid HOMEPAGE", "app-misc", "https://example.com", 0},
+		{"Generic Gentoo HOMEPAGE", "app-misc", "https://www.gentoo.org/", 1},
+		{"Generic Gentoo HOMEPAGE no trailing slash", "app-misc", "https://www.gentoo.org", 1},
+		{"Valid and generic HOMEPAGE", "app-misc", "https://example.com https://www.gentoo.org/", 1},
+	}
+
+	rule := &MeaningfulHomepageLintRule{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: tt.category,
+				Name:     "example",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"HOMEPAGE": tt.homepage,
+							},
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkg)
+
+			if len(results) != tt.expected {
+				t.Errorf("Expected %d results, got %d", tt.expected, len(results))
+			}
+		})
+	}
+}

--- a/lints/ebuild/restrict_test_rule.go
+++ b/lints/ebuild/restrict_test_rule.go
@@ -1,0 +1,131 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleRestrictTest = lints.RuleMetadata{
+	ID:          "RestrictTest",
+	Title:       "RESTRICT=test for USE=-test",
+	Description: "Whenever the package uses test flag to control test prerequisites (or another flag with a similar purpose), it must explicitly restrict tests when the flag is unset.",
+	URL:         "https://projects.gentoo.org/qa/policy-guide/other-metadata.html#pg0703",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceQA,
+	Tags:        []string{"ebuild", "gentoo-policy", "PG0703"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleRestrictTest)
+	lints.RegisterLintRule(&RestrictTestLintRule{})
+}
+
+type RestrictTestLintRule struct{}
+
+func (r *RestrictTestLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func hasRestrictTestForUnsetTest(restrictStr string) bool {
+	tokens := strings.Fields(restrictStr)
+	var conditions []string
+
+	for i := 0; i < len(tokens); i++ {
+		token := tokens[i]
+		if strings.HasSuffix(token, "?") {
+			cond := token
+			if i+1 < len(tokens) && tokens[i+1] == "(" {
+				conditions = append(conditions, cond)
+				i++ // skip "("
+			} else {
+				// single token
+				if i+1 < len(tokens) {
+					if tokens[i+1] == "test" {
+						if cond == "!test?" || len(conditions) == 0 {
+                            if cond == "!test?" {
+                                return true
+                            }
+						}
+					}
+					i++ // consume the token
+				}
+			}
+		} else if token == ")" {
+			if len(conditions) > 0 {
+				conditions = conditions[:len(conditions)-1]
+			}
+		} else if token == "test" {
+			if len(conditions) == 0 {
+				return true // Unconditional restrict
+			}
+			for _, c := range conditions {
+				if c == "!test?" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (r *RestrictTestLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := ruleRestrictTest.Severity
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["PG0703"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.Vars != nil {
+			iuseStr := ver.Ebuild.Vars["IUSE"]
+			if !strings.Contains(iuseStr, "test") {
+				continue
+			}
+
+            // Check if test is actually in IUSE (accounting for +test or -test)
+            hasTestIUSE := false
+            for _, token := range strings.Fields(iuseStr) {
+                if token == "test" || token == "+test" || token == "-test" {
+                    hasTestIUSE = true
+                    break
+                }
+            }
+
+            if !hasTestIUSE {
+                continue
+            }
+
+			restrictStr := ver.Ebuild.Vars["RESTRICT"]
+			if !hasRestrictTestForUnsetTest(restrictStr) {
+				res := lints.LintResult{
+					RuleMetadata: ruleRestrictTest,
+					Message:      fmt.Sprintf("[%s] Ebuild %s has 'test' in IUSE but does not have RESTRICT=\"!test? ( test )\"", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/ebuild/restrict_test_rule_test.go
+++ b/lints/ebuild/restrict_test_rule_test.go
@@ -1,0 +1,50 @@
+package ebuild
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func TestRestrictTestLintRule(t *testing.T) {
+	tests := []struct {
+		name     string
+		iuse     string
+		restrict string
+		expected int
+	}{
+		{"No test in IUSE", "doc", "", 0},
+		{"Test in IUSE, explicit restrict", "test", "!test? ( test )", 0},
+		{"Test in IUSE, unconditional restrict", "test", "test", 0},
+		{"Test in IUSE, missing restrict", "test", "", 1},
+		{"Test in IUSE, wrong restrict condition", "test", "foo? ( test )", 1},
+	}
+
+	rule := &RestrictTestLintRule{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: "app-misc",
+				Name:     "example",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars: map[string]string{
+								"IUSE":     tt.iuse,
+								"RESTRICT": tt.restrict,
+							},
+						},
+					},
+				},
+			}
+
+			results := rule.Lint("", pkg)
+
+			if len(results) != tt.expected {
+				t.Errorf("Expected %d results, got %d", tt.expected, len(results))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements linting rules for the Gentoo QA "Other metadata variables" policies (PG0701 to PG0704):
- **PG0701:** Forbids the use of `multislot` in `IUSE` to alter SLOT values.
- **PG0702:** Warns if `HOMEPAGE` is set to generic URLs like `https://www.gentoo.org/`.
- **PG0703:** Checks that if `test` is in `IUSE`, `RESTRICT` must include `!test? ( test )` or `test`.
- **PG0704:** Validates that the `LICENSE` variable is defined for non-virtual packages.

---
*PR created automatically by Jules for task [16070566360343468807](https://jules.google.com/task/16070566360343468807) started by @arran4*