### PR TITLE
Lint: Enhance enews validation based on GLEP 42

### DIFF
--- a/lints/news/news.go
+++ b/lints/news/news.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -238,9 +239,22 @@ func (r *NewsValidityLintRule) lintNewsItem(content string, relPath string) []li
 	hasPosted := false
 	hasRevision := false
 	hasFormat := false
+	hasContentType := false
+	newsItemFormat := ""
+	contentTypeVal := ""
 
 	for lineNum, line := range lines {
 		if inBody {
+			if strings.Contains(line, "\t") {
+				res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Body lines should not contain tab characters", lints.SeverityWarning), File: relPath, Line: lineNum + 1}
+				res.RuleMetadata.Severity = lints.SeverityWarning
+				results = append(results, res)
+			}
+			if len(line) > 72 {
+				res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Body lines should wrap at 72 characters", lints.SeverityWarning), File: relPath, Line: lineNum + 1}
+				res.RuleMetadata.Severity = lints.SeverityWarning
+				results = append(results, res)
+			}
 			continue
 		}
 		if strings.TrimSpace(line) == "" {
@@ -275,6 +289,10 @@ func (r *NewsValidityLintRule) lintNewsItem(content string, relPath string) []li
 				res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Title cannot be empty", lints.SeverityError), File: relPath, Line: lineNum + 1}
 				res.RuleMetadata.Severity = lints.SeverityError
 				results = append(results, res)
+			} else if len(val) > 50 {
+				res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Title exceeds maximum length of 50 characters", lints.SeverityError), File: relPath, Line: lineNum + 1}
+				res.RuleMetadata.Severity = lints.SeverityError
+				results = append(results, res)
 			}
 		case "Author":
 			hasAuthor = true
@@ -303,9 +321,25 @@ func (r *NewsValidityLintRule) lintNewsItem(content string, relPath string) []li
 				res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Revision cannot be empty", lints.SeverityError), File: relPath, Line: lineNum + 1}
 				res.RuleMetadata.Severity = lints.SeverityError
 				results = append(results, res)
+			} else {
+				_, err := strconv.Atoi(val)
+				if err != nil {
+					res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Revision must be an integer: '%s'", lints.SeverityError, val), File: relPath, Line: lineNum + 1}
+					res.RuleMetadata.Severity = lints.SeverityError
+					results = append(results, res)
+				}
+			}
+		case "Content-Type":
+			hasContentType = true
+			contentTypeVal = val
+			if val != "text/plain" {
+				res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Content-Type must be 'text/plain', got: '%s'", lints.SeverityError, val), File: relPath, Line: lineNum + 1}
+				res.RuleMetadata.Severity = lints.SeverityError
+				results = append(results, res)
 			}
 		case "News-Item-Format":
 			hasFormat = true
+			newsItemFormat = val
 			if val != "1.0" && val != "2.0" {
 				res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Unsupported News-Item-Format: '%s'", lints.SeverityWarning, val), File: relPath, Line: lineNum + 1}
 				res.RuleMetadata.Severity = lints.SeverityWarning
@@ -348,6 +382,10 @@ func (r *NewsValidityLintRule) lintNewsItem(content string, relPath string) []li
 	}
 	if !hasFormat {
 		res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Missing required header: News-Item-Format", lints.SeverityError), File: relPath}
+		res.RuleMetadata.Severity = lints.SeverityError
+		results = append(results, res)
+	} else if newsItemFormat == "1.0" && (!hasContentType || contentTypeVal != "text/plain") {
+		res := lints.LintResult{RuleMetadata: ruleNewsValidity, Message: fmt.Sprintf("[%s] Content-Type: text/plain is mandatory for News-Item-Format 1.0", lints.SeverityError), File: relPath}
 		res.RuleMetadata.Severity = lints.SeverityError
 		results = append(results, res)
 	}

--- a/lints/news/news_test.go
+++ b/lints/news/news_test.go
@@ -53,6 +53,15 @@ News-Item-Format: 2.0
 
 Body
 `)},
+		"metadata/news/2024-01-06-invalid-fields/2024-01-06-invalid-fields.en.txt": &fstest.MapFile{Data: []byte(`Title: This Title Is Much Longer Than Fifty Characters So It Should Fail The Linting Check
+Author: John Doe <john@example.com>
+Posted: 2024-01-06
+Revision: 1a
+News-Item-Format: 1.0
+Content-Type: text/html
+
+This	body contains a tab character and is definitely way too long, far exceeding the seventy-two character limit that is mandated by the standard we are supposed to be following here.
+`)},
 	}
 
 	rule := NewNewsValidityLintRule(WithFS(fsys))
@@ -67,6 +76,8 @@ Body
 
 	var hasAuthorErr, hasDisplayErr bool
 	var hasInvalidDirErr, hasInvalidFileErr, hasMismatchErr bool
+	var hasTitleLengthErr, hasRevisionIntErr, hasContentTypeErr, hasFormatOneErr bool
+	var hasTabErr, hasWrapErr bool
 	for _, res := range results {
 		if strings.Contains(res.Message, "Invalid Author format") {
 			hasAuthorErr = true
@@ -82,6 +93,24 @@ Body
 		}
 		if strings.Contains(res.Message, "does not match directory name") {
 			hasMismatchErr = true
+		}
+		if strings.Contains(res.Message, "Title exceeds maximum length of 50 characters") {
+			hasTitleLengthErr = true
+		}
+		if strings.Contains(res.Message, "Revision must be an integer") {
+			hasRevisionIntErr = true
+		}
+		if strings.Contains(res.Message, "Content-Type must be 'text/plain'") {
+			hasContentTypeErr = true
+		}
+		if strings.Contains(res.Message, "Content-Type: text/plain is mandatory for News-Item-Format 1.0") {
+			hasFormatOneErr = true
+		}
+		if strings.Contains(res.Message, "Body lines should not contain tab characters") {
+			hasTabErr = true
+		}
+		if strings.Contains(res.Message, "Body lines should wrap at 72 characters") {
+			hasWrapErr = true
 		}
 	}
 
@@ -99,5 +128,23 @@ Body
 	}
 	if !hasMismatchErr {
 		t.Errorf("expected prefix mismatch error")
+	}
+	if !hasTitleLengthErr {
+		t.Errorf("expected Title length error")
+	}
+	if !hasRevisionIntErr {
+		t.Errorf("expected Revision integer error")
+	}
+	if !hasContentTypeErr {
+		t.Errorf("expected Content-Type error")
+	}
+	if !hasFormatOneErr {
+		t.Errorf("expected Format 1.0 mandatory Content-Type error")
+	}
+	if !hasTabErr {
+		t.Errorf("expected Body tab character error")
+	}
+	if !hasWrapErr {
+		t.Errorf("expected Body line wrap error")
 	}
 }


### PR DESCRIPTION
Implement additional GLEP 42 validations for Gentoo enews linting (Title length, Revision type, Content-Type, and body formatting checks).

---
*PR created automatically by Jules for task [14261726610195383001](https://jules.google.com/task/14261726610195383001) started by @arran4*