### PR TITLE
Update EbuildHeader lint rule for GLEP-76 compliance

### DIFF
--- a/lints/ebuild/ebuild_header.go
+++ b/lints/ebuild/ebuild_header.go
@@ -20,7 +20,7 @@ var ruleEbuildHeader = lints.RuleMetadata{
 	Tags:        []string{"ebuild", "gentoo-policy"},
 }
 
-var validHeaderRegex = regexp.MustCompile(`^# Copyright (?:\d{4}-)?\d{4} .+\n# Distributed under the terms of the GNU General Public License v2\n\n`)
+var validHeaderRegex = regexp.MustCompile(`^# Copyright \d{4}(?:[-\s,]+\d{4})* .+\n# Distributed under the terms of the GNU General Public License v2\n\n`)
 
 func init() {
 	lints.RegisterRuleMetadata(ruleEbuildHeader)

--- a/lints/ebuild/ebuild_header.go
+++ b/lints/ebuild/ebuild_header.go
@@ -20,7 +20,7 @@ var ruleEbuildHeader = lints.RuleMetadata{
 	Tags:        []string{"ebuild", "gentoo-policy"},
 }
 
-var validHeaderRegex = regexp.MustCompile(`^# Copyright 1999-\d{4} Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\n`)
+var validHeaderRegex = regexp.MustCompile(`^# Copyright (?:\d{4}-)?\d{4} .+\n# Distributed under the terms of the GNU General Public License v2\n\n`)
 
 func init() {
 	lints.RegisterRuleMetadata(ruleEbuildHeader)
@@ -58,7 +58,7 @@ func (r *EbuildHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, q
 			if !validHeaderRegex.MatchString(ver.Ebuild.RawText) {
 				res := lints.LintResult{
 					RuleMetadata: ruleEbuildHeader,
-					Message:      fmt.Sprintf("[%s] Ebuild %s has an invalid header. It should exactly match the first two lines of header.txt followed by an empty line.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Message:      fmt.Sprintf("[%s] Ebuild %s has an invalid header. It should start with a valid copyright line (e.g., '# Copyright YEARS MAIN-CONTRIBUTOR') and the GPLv2 distribution text followed by an empty line.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
 				res.RuleMetadata.Severity = severity

--- a/lints/ebuild/ebuild_header_test.go
+++ b/lints/ebuild/ebuild_header_test.go
@@ -97,6 +97,22 @@ func TestEbuildHeaderLintRule(t *testing.T) {
 			expected: 0,
 		},
 		{
+			name: "Valid header complex years",
+			pkg: &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: "# Copyright 1999, 2001, 2003-2005 Main Contributor\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8",
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
 			name: "Malformed copyright string",
 			pkg: &g2.PackageData{
 				Category: "app-misc",

--- a/lints/ebuild/ebuild_header_test.go
+++ b/lints/ebuild/ebuild_header_test.go
@@ -49,7 +49,7 @@ func TestEbuildHeaderLintRule(t *testing.T) {
 			expected: 1,
 		},
 		{
-			name: "Incorrect year start",
+			name: "Valid header single year",
 			pkg: &g2.PackageData{
 				Category: "app-misc",
 				Name:     "foo",
@@ -57,7 +57,55 @@ func TestEbuildHeaderLintRule(t *testing.T) {
 					{
 						Version: "1.0",
 						Ebuild: &g2.Ebuild{
-							RawText: "# Copyright 2000-2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8",
+							RawText: "# Copyright 2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8",
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "Valid header alternative contributor",
+			pkg: &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: "# Copyright 2024 Main Contributor\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8",
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "Valid header range alternative contributor",
+			pkg: &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: "# Copyright 1999-2024 Main Contributor\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8",
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "Malformed copyright string",
+			pkg: &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: "# Copyright 200X Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8",
 						},
 					},
 				},


### PR DESCRIPTION
Update EbuildHeader lint rule for GLEP-76 compliance

---
*PR created automatically by Jules for task [16058562058351828192](https://jules.google.com/task/16058562058351828192) started by @arran4*