### PR TITLE
feat(lints): add UseConditionalCodeLintRule for ebuild use flag checks

### DIFF
--- a/lints/ebuild/use_conditional_code.go
+++ b/lints/ebuild/use_conditional_code.go
@@ -1,0 +1,89 @@
+package ebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var ruleUseConditionalCode = lints.RuleMetadata{
+	ID:          "UseConditionalCode",
+	Title:       "USE flag conditional code",
+	Description: "Checks for deprecated useq and invalid [ \"`use foo`\" ] syntax.",
+	URL:         "https://devmanual.gentoo.org/ebuild-writing/use-conditional-code/index.html",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "gentoo-policy", "use"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleUseConditionalCode)
+	lints.RegisterLintRule(&UseConditionalCodeLintRule{})
+}
+
+type UseConditionalCodeLintRule struct{}
+
+func (l *UseConditionalCodeLintRule) Lint(repoDir string, pkgData *g2.PackageData) []lints.LintResult {
+	var results []lints.LintResult
+
+	for _, version := range pkgData.Versions {
+		if version.Ebuild == nil {
+			continue
+		}
+
+		parser := syntax.NewParser()
+		f, err := parser.Parse(strings.NewReader(version.Ebuild.RawText), "")
+		if err != nil {
+			continue
+		}
+
+		syntax.Walk(f, func(node syntax.Node) bool {
+			if call, ok := node.(*syntax.CallExpr); ok && len(call.Args) > 0 {
+				if len(call.Args[0].Parts) == 1 {
+					if lit, ok := call.Args[0].Parts[0].(*syntax.Lit); ok {
+						if lit.Value == "useq" {
+							res := lints.LintResult{
+								RuleMetadata: ruleUseConditionalCode,
+								Message:      fmt.Sprintf("[Warning] Ebuild %s uses 'useq', which is a deprecated synonym for 'use'.", version.Version),
+								Package:      pkgData.Category + "/" + pkgData.Name,
+							}
+							res.RuleMetadata.Severity = lints.SeverityWarning
+							results = append(results, res)
+						}
+					}
+				}
+			}
+
+			if subst, ok := node.(*syntax.CmdSubst); ok {
+				// Check if the command substitution consists of exactly one statement,
+				// and that statement is just a bare call to `use`.
+				if len(subst.Stmts) == 1 {
+					stmt := subst.Stmts[0]
+					if stmt.Background || stmt.Negated || stmt.Redirs != nil {
+						return true
+					}
+					if call, ok := stmt.Cmd.(*syntax.CallExpr); ok && len(call.Args) > 0 {
+						if len(call.Args[0].Parts) == 1 {
+							if lit, ok := call.Args[0].Parts[0].(*syntax.Lit); ok {
+								if lit.Value == "use" {
+									res := lints.LintResult{
+										RuleMetadata: ruleUseConditionalCode,
+										Message:      fmt.Sprintf("[Error] Ebuild %s uses 'use' inside a command substitution (e.g. \"`use foo`\"). The 'use' function does not produce output, so this will evaluate to an empty string.", version.Version),
+										Package:      pkgData.Category + "/" + pkgData.Name,
+									}
+									results = append(results, res)
+								}
+							}
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	return results
+}

--- a/lints/ebuild/use_conditional_code_test.go
+++ b/lints/ebuild/use_conditional_code_test.go
@@ -1,0 +1,105 @@
+package ebuild_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestUseConditionalCodeLintRule(t *testing.T) {
+	rule := &ebuild.UseConditionalCodeLintRule{}
+
+	tests := []struct {
+		name         string
+		script       string
+		expectedErrs int
+		expectedWarn int
+	}{
+		{
+			name:         "Standard use",
+			script:       "if use foo; then\n  echo \"foo\"\nfi",
+			expectedErrs: 0,
+			expectedWarn: 0,
+		},
+		{
+			name:         "Inverse use",
+			script:       "if ! use foo; then\n  echo \"no foo\"\nfi",
+			expectedErrs: 0,
+			expectedWarn: 0,
+		},
+		{
+			name:         "Deprecated useq",
+			script:       "if useq foo; then\n  echo \"foo\"\nfi",
+			expectedErrs: 0,
+			expectedWarn: 1,
+		},
+		{
+			name:         "use inside backticks (invalid)",
+			script:       "if [ \"`use foo`\" ]; then\n  echo \"foo\"\nfi",
+			expectedErrs: 1,
+			expectedWarn: 0,
+		},
+		{
+			name:         "use inside $() (invalid)",
+			script:       "if [ -n \"$(use foo)\" ]; then\n  echo \"foo\"\nfi",
+			expectedErrs: 1,
+			expectedWarn: 0,
+		},
+		{
+			name:         "Both useq and use inside command substitution",
+			script:       "useq foo\n[ \"`use foo`\" ]",
+			expectedErrs: 1,
+			expectedWarn: 1,
+		},
+		{
+			name:         "Valid use inside cmd substitution (exit code check)",
+			script:       "MY_CONF=\"$(use foo && echo \"--enable-foo\")\"",
+			expectedErrs: 0,
+			expectedWarn: 0,
+		},
+		{
+			name:         "Valid use inside if in cmd substitution",
+			script:       "VAR=$(if use qt5; then echo \"qt5\"; fi)",
+			expectedErrs: 0,
+			expectedWarn: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: "sys-apps",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							Vars:    map[string]string{},
+							RawText: tt.script,
+						},
+					},
+				},
+			}
+			results := rule.Lint(".", pkg)
+
+			errs := 0
+			warns := 0
+			for _, res := range results {
+				if strings.HasPrefix(res.Message, "[Error]") {
+					errs++
+				} else if strings.HasPrefix(res.Message, "[Warning]") {
+					warns++
+				}
+			}
+
+			if errs != tt.expectedErrs {
+				t.Errorf("expected %d errors, got %d. Results: %v", tt.expectedErrs, errs, results)
+			}
+			if warns != tt.expectedWarn {
+				t.Errorf("expected %d warnings, got %d. Results: %v", tt.expectedWarn, warns, results)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added `UseConditionalCodeLintRule` to enforce "USE flag conditional code" guidelines. This includes catching deprecated `useq` and checking for `use` incorrectly placed in a command substitution.

---
*PR created automatically by Jules for task [17292971306438528407](https://jules.google.com/task/17292971306438528407) started by @arran4*