### PR TITLE
feat: implement GLEP 82 layout.conf support

### DIFF
--- a/layout_conf.go
+++ b/layout_conf.go
@@ -150,3 +150,98 @@ func (lc *LayoutConf) GetValuesAsSlice(key string) []string {
 	}
 	return strings.Fields(val)
 }
+
+// Masters returns the list of master repositories.
+func (lc *LayoutConf) Masters() []string {
+	return lc.GetValuesAsSlice("masters")
+}
+
+// ManifestHashes returns the list of allowed manifest hashes.
+func (lc *LayoutConf) ManifestHashes() []string {
+	return lc.GetValuesAsSlice("manifest-hashes")
+}
+
+// ManifestRequiredHashes returns the list of required manifest hashes.
+func (lc *LayoutConf) ManifestRequiredHashes() []string {
+	return lc.GetValuesAsSlice("manifest-required-hashes")
+}
+
+// UseManifests returns the policy for creating and using Manifest files (e.g., strict, true, false).
+func (lc *LayoutConf) UseManifests() string {
+	return lc.GetValue("use-manifests")
+}
+
+// UpdateChangelog indicates whether development tools should write ChangeLog files.
+func (lc *LayoutConf) UpdateChangelog() bool {
+	return lc.GetValue("update-changelog") == "true"
+}
+
+// CacheFormats returns the cache formats used by the repository.
+func (lc *LayoutConf) CacheFormats() []string {
+	return lc.GetValuesAsSlice("cache-formats")
+}
+
+// EapisDeprecated returns the list of deprecated EAPIs for ebuilds.
+func (lc *LayoutConf) EapisDeprecated() []string {
+	return lc.GetValuesAsSlice("eapis-deprecated")
+}
+
+// EapisBanned returns the list of banned EAPIs for ebuilds.
+func (lc *LayoutConf) EapisBanned() []string {
+	return lc.GetValuesAsSlice("eapis-banned")
+}
+
+// EapisTesting returns the list of testing EAPIs for ebuilds.
+func (lc *LayoutConf) EapisTesting() []string {
+	return lc.GetValuesAsSlice("eapis-testing")
+}
+
+// ProfileEapisDeprecated returns the list of deprecated EAPIs for profiles.
+func (lc *LayoutConf) ProfileEapisDeprecated() []string {
+	return lc.GetValuesAsSlice("profile-eapis-deprecated")
+}
+
+// ProfileEapisBanned returns the list of banned EAPIs for profiles.
+func (lc *LayoutConf) ProfileEapisBanned() []string {
+	return lc.GetValuesAsSlice("profile-eapis-banned")
+}
+
+// RepoName returns the specified repository name.
+func (lc *LayoutConf) RepoName() string {
+	return lc.GetValue("repo-name")
+}
+
+// Aliases returns the list of alternative names for the repository.
+func (lc *LayoutConf) Aliases() []string {
+	return lc.GetValuesAsSlice("aliases")
+}
+
+// ThinManifests indicates whether thin manifests are used.
+func (lc *LayoutConf) ThinManifests() bool {
+	return lc.GetValue("thin-manifests") == "true"
+}
+
+// SignCommits indicates whether git commits should be signed.
+func (lc *LayoutConf) SignCommits() bool {
+	return lc.GetValue("sign-commits") == "true"
+}
+
+// SignManifests indicates whether individual package manifests should be signed.
+func (lc *LayoutConf) SignManifests() bool {
+	return lc.GetValue("sign-manifests") == "true"
+}
+
+// PropertiesAllowed returns the list of properties permitted in ebuilds.
+func (lc *LayoutConf) PropertiesAllowed() []string {
+	return lc.GetValuesAsSlice("properties-allowed")
+}
+
+// RestrictAllowed returns the list of restrict tokens permitted in ebuilds.
+func (lc *LayoutConf) RestrictAllowed() []string {
+	return lc.GetValuesAsSlice("restrict-allowed")
+}
+
+// ProfileFormats returns the formats used by profiles.
+func (lc *LayoutConf) ProfileFormats() []string {
+	return lc.GetValuesAsSlice("profile-formats")
+}

--- a/layout_conf_test.go
+++ b/layout_conf_test.go
@@ -100,3 +100,88 @@ cache-formats =
 		t.Errorf("expected false for non-existent")
 	}
 }
+
+func TestLayoutConfTypedGetters(t *testing.T) {
+	content := `masters = gentoo other
+manifest-hashes = BLAKE2B SHA512
+manifest-required-hashes = BLAKE2B
+use-manifests = strict
+update-changelog = true
+cache-formats = md5-dict pms
+eapis-deprecated = 0 1 2 3 4
+eapis-banned = 5
+eapis-testing = 6
+profile-eapis-deprecated = 1 2
+profile-eapis-banned = 0
+repo-name = myrepo
+aliases = alias1 alias2
+thin-manifests = true
+sign-commits = false
+sign-manifests = true
+properties-allowed = live
+restrict-allowed = test
+profile-formats = pms portage-2
+`
+	lc, err := ParseLayoutConfFromReader(strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if masters := lc.Masters(); len(masters) != 2 || masters[0] != "gentoo" || masters[1] != "other" {
+		t.Errorf("Masters() = %v", masters)
+	}
+	if hashes := lc.ManifestHashes(); len(hashes) != 2 || hashes[0] != "BLAKE2B" || hashes[1] != "SHA512" {
+		t.Errorf("ManifestHashes() = %v", hashes)
+	}
+	if hashes := lc.ManifestRequiredHashes(); len(hashes) != 1 || hashes[0] != "BLAKE2B" {
+		t.Errorf("ManifestRequiredHashes() = %v", hashes)
+	}
+	if um := lc.UseManifests(); um != "strict" {
+		t.Errorf("UseManifests() = %q", um)
+	}
+	if uc := lc.UpdateChangelog(); uc != true {
+		t.Errorf("UpdateChangelog() = %v", uc)
+	}
+	if formats := lc.CacheFormats(); len(formats) != 2 || formats[0] != "md5-dict" || formats[1] != "pms" {
+		t.Errorf("CacheFormats() = %v", formats)
+	}
+	if eapis := lc.EapisDeprecated(); len(eapis) != 5 || eapis[0] != "0" {
+		t.Errorf("EapisDeprecated() = %v", eapis)
+	}
+	if eapis := lc.EapisBanned(); len(eapis) != 1 || eapis[0] != "5" {
+		t.Errorf("EapisBanned() = %v", eapis)
+	}
+	if eapis := lc.EapisTesting(); len(eapis) != 1 || eapis[0] != "6" {
+		t.Errorf("EapisTesting() = %v", eapis)
+	}
+	if eapis := lc.ProfileEapisDeprecated(); len(eapis) != 2 || eapis[0] != "1" {
+		t.Errorf("ProfileEapisDeprecated() = %v", eapis)
+	}
+	if eapis := lc.ProfileEapisBanned(); len(eapis) != 1 || eapis[0] != "0" {
+		t.Errorf("ProfileEapisBanned() = %v", eapis)
+	}
+	if repoName := lc.RepoName(); repoName != "myrepo" {
+		t.Errorf("RepoName() = %q", repoName)
+	}
+	if aliases := lc.Aliases(); len(aliases) != 2 || aliases[0] != "alias1" || aliases[1] != "alias2" {
+		t.Errorf("Aliases() = %v", aliases)
+	}
+	if tm := lc.ThinManifests(); tm != true {
+		t.Errorf("ThinManifests() = %v", tm)
+	}
+	if sc := lc.SignCommits(); sc != false {
+		t.Errorf("SignCommits() = %v", sc)
+	}
+	if sm := lc.SignManifests(); sm != true {
+		t.Errorf("SignManifests() = %v", sm)
+	}
+	if props := lc.PropertiesAllowed(); len(props) != 1 || props[0] != "live" {
+		t.Errorf("PropertiesAllowed() = %v", props)
+	}
+	if restr := lc.RestrictAllowed(); len(restr) != 1 || restr[0] != "test" {
+		t.Errorf("RestrictAllowed() = %v", restr)
+	}
+	if formats := lc.ProfileFormats(); len(formats) != 2 || formats[0] != "pms" || formats[1] != "portage-2" {
+		t.Errorf("ProfileFormats() = %v", formats)
+	}
+}

--- a/lints/metadata/layout_conf_repo.go
+++ b/lints/metadata/layout_conf_repo.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints"
@@ -110,7 +111,13 @@ func (r *LayoutConfRepoLintRule) LintRepo(repoDir string, site *g2.SiteData) []l
 		} else if validator := validKeys[entry.Key]; validator != nil {
 			// Validate the specific format/content of the key here
 			// using the defined func(contents ...string) error.
-			if err := validator(entry.Value); err != nil {
+
+			// For the validator, pass the fields if the value is meant to be space-separated
+			// We pass the fields to match the `contents ...string` signature,
+			// except if it's supposed to be treated as a single token we might pass it differently.
+			// Let's just pass `strings.Fields(entry.Value)...`.
+			// Wait, if it's a single token, `strings.Fields` splits on spaces. This works well for boolean and space-separated lists.
+			if err := validator(strings.Fields(entry.Value)...); err != nil {
 				res := lints.LintResult{
 					RuleMetadata: ruleLayoutConfRepo,
 					Message:      fmt.Sprintf("[%s] layout.conf key validation failed %s: %s", lints.SeverityError, entry.Key, err.Error()),

--- a/lints/metadata/layout_conf_repo.go
+++ b/lints/metadata/layout_conf_repo.go
@@ -75,36 +75,40 @@ func (r *LayoutConfRepoLintRule) LintRepo(repoDir string, site *g2.SiteData) []l
 	}
 
 	// 4. Check for unknown keys
-	validKeys := map[string]bool{
-		"masters":                  true,
-		"manifest-hashes":          true,
-		"manifest-required-hashes": true,
-		"use-manifests":            true,
-		"update-changelog":         true,
-		"cache-formats":            true,
-		"eapis-deprecated":         true,
-		"eapis-banned":             true,
-		"eapis-testing":            true,
-		"profile-eapis-deprecated": true,
-		"profile-eapis-banned":     true,
-		"repo-name":                true,
-		"aliases":                  true,
-		"thin-manifests":           true,
-		"sign-commits":             true,
-		"sign-manifests":           true,
-		"properties-allowed":       true,
-		"restrict-allowed":         true,
-		"profile-formats":          true,
+	validKeys := map[string]func(contents ...string) error{
+		"masters":                  nil,
+		"manifest-hashes":          nil,
+		"manifest-required-hashes": nil,
+		"use-manifests":            nil,
+		"update-changelog":         nil,
+		"cache-formats":            nil,
+		"eapis-deprecated":         nil,
+		"eapis-banned":             nil,
+		"eapis-testing":            nil,
+		"profile-eapis-deprecated": nil,
+		"profile-eapis-banned":     nil,
+		"repo-name":                nil,
+		"aliases":                  nil,
+		"thin-manifests":           nil,
+		"sign-commits":             nil,
+		"sign-manifests":           nil,
+		"properties-allowed":       nil,
+		"restrict-allowed":         nil,
+		"profile-formats":          nil,
 	}
 
 	for _, entry := range lc.Entries {
-		if !validKeys[entry.Key] {
+		if _, ok := validKeys[entry.Key]; !ok {
 			res := lints.LintResult{
 				RuleMetadata: ruleLayoutConfRepo,
 				Message:      fmt.Sprintf("[%s] layout.conf contains unknown key: %s", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityNotice)), entry.Key),
 			}
 			res.RuleMetadata.Severity = lints.SeverityNotice
 			results = append(results, res)
+		} else if validator := validKeys[entry.Key]; validator != nil {
+			// (Optional) We could validate the specific format/content of the key here
+			// using the defined func(contents ...string) error.
+			// This placeholder respects the PR reviewer's type requirement.
 		}
 	}
 

--- a/lints/metadata/layout_conf_repo.go
+++ b/lints/metadata/layout_conf_repo.go
@@ -49,52 +49,54 @@ func (r *LayoutConfRepoLintRule) LintRepo(repoDir string, site *g2.SiteData) []l
 		})
 	}
 
-	// 2. Check use-manifests
-	if lc.HasKey("use-manifests") {
-		um := lc.UseManifests()
-		if um != "strict" && um != "true" && um != "false" {
-			results = append(results, lints.LintResult{
-				RuleMetadata: ruleLayoutConfRepo,
-				Message:      fmt.Sprintf("[%s] layout.conf has invalid 'use-manifests' value: %s", lints.SeverityError, um),
-			})
+	// Helper validator for booleans
+	validateBool := func(contents ...string) error {
+		if len(contents) != 1 {
+			return fmt.Errorf("expected 1 value, got %d", len(contents))
 		}
+		if contents[0] != "true" && contents[0] != "false" {
+			return fmt.Errorf("must be 'true' or 'false'")
+		}
+		return nil
 	}
 
-	// 3. Check boolean values
-	boolKeys := []string{"update-changelog", "thin-manifests", "sign-commits", "sign-manifests"}
-	for _, key := range boolKeys {
-		if lc.HasKey(key) {
-			val := lc.GetValue(key)
-			if val != "true" && val != "false" {
-				results = append(results, lints.LintResult{
-					RuleMetadata: ruleLayoutConfRepo,
-					Message:      fmt.Sprintf("[%s] layout.conf has invalid boolean value for '%s': %s", lints.SeverityError, key, val),
-				})
-			}
-		}
+	// Helper validator for space-separated lists
+	validateList := func(contents ...string) error {
+		// Content is already the raw string, we just consider it valid if it's there
+		return nil
 	}
 
 	// 4. Check for unknown keys
 	validKeys := map[string]func(contents ...string) error{
-		"masters":                  nil,
-		"manifest-hashes":          nil,
-		"manifest-required-hashes": nil,
-		"use-manifests":            nil,
-		"update-changelog":         nil,
-		"cache-formats":            nil,
-		"eapis-deprecated":         nil,
-		"eapis-banned":             nil,
-		"eapis-testing":            nil,
-		"profile-eapis-deprecated": nil,
-		"profile-eapis-banned":     nil,
-		"repo-name":                nil,
-		"aliases":                  nil,
-		"thin-manifests":           nil,
-		"sign-commits":             nil,
-		"sign-manifests":           nil,
-		"properties-allowed":       nil,
-		"restrict-allowed":         nil,
-		"profile-formats":          nil,
+		"masters":                  validateList,
+		"manifest-hashes":          validateList,
+		"manifest-required-hashes": validateList,
+		"use-manifests": func(contents ...string) error {
+			if len(contents) != 1 {
+				return fmt.Errorf("expected 1 value, got %d", len(contents))
+			}
+			if contents[0] != "strict" && contents[0] != "true" && contents[0] != "false" {
+				return fmt.Errorf("must be 'strict', 'true', or 'false'")
+			}
+			return nil
+		},
+		"update-changelog":         validateBool,
+		"cache-formats":            validateList,
+		"eapis-deprecated":         validateList,
+		"eapis-banned":             validateList,
+		"eapis-testing":            validateList,
+		"profile-eapis-deprecated": validateList,
+		"profile-eapis-banned":     validateList,
+		"repo-name": func(contents ...string) error {
+			return nil // Any string is fine
+		},
+		"aliases":            validateList,
+		"thin-manifests":     validateBool,
+		"sign-commits":       validateBool,
+		"sign-manifests":     validateBool,
+		"properties-allowed": validateList,
+		"restrict-allowed":   validateList,
+		"profile-formats":    validateList,
 	}
 
 	for _, entry := range lc.Entries {

--- a/lints/metadata/layout_conf_repo.go
+++ b/lints/metadata/layout_conf_repo.go
@@ -106,9 +106,15 @@ func (r *LayoutConfRepoLintRule) LintRepo(repoDir string, site *g2.SiteData) []l
 			res.RuleMetadata.Severity = lints.SeverityNotice
 			results = append(results, res)
 		} else if validator := validKeys[entry.Key]; validator != nil {
-			// (Optional) We could validate the specific format/content of the key here
+			// Validate the specific format/content of the key here
 			// using the defined func(contents ...string) error.
-			// This placeholder respects the PR reviewer's type requirement.
+			if err := validator(entry.Value); err != nil {
+				res := lints.LintResult{
+					RuleMetadata: ruleLayoutConfRepo,
+					Message:      fmt.Sprintf("[%s] layout.conf key validation failed %s: %s", lints.SeverityError, entry.Key, err.Error()),
+				}
+				results = append(results, res)
+			}
 		}
 	}
 

--- a/lints/metadata/layout_conf_repo.go
+++ b/lints/metadata/layout_conf_repo.go
@@ -1,0 +1,118 @@
+package metadata
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleLayoutConfRepo = lints.RuleMetadata{
+	ID:          "LayoutConfRepo",
+	Title:       "Layout Conf Repository Checks",
+	Description: "Ensures the layout.conf file exists and conforms to GLEP 82.",
+	URL:         "https://www.gentoo.org/glep/glep-0082.html",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"repo-layout", "metadata"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleLayoutConfRepo)
+	lints.RegisterRepoLintRule(&LayoutConfRepoLintRule{})
+}
+
+type LayoutConfRepoLintRule struct{}
+
+func (r *LayoutConfRepoLintRule) LintRepo(repoDir string, site *g2.SiteData) []lints.LintResult {
+	var results []lints.LintResult
+
+	layoutConfPath := filepath.Join(repoDir, "metadata", "layout.conf")
+	lc, err := g2.ParseLayoutConf(layoutConfPath)
+	if err != nil {
+		// layout.conf is missing or unparseable, GLEP 82 requires it to exist
+		results = append(results, lints.LintResult{
+			RuleMetadata: ruleLayoutConfRepo,
+			Message:      fmt.Sprintf("[%s] layout.conf is missing or unparseable", lints.SeverityError),
+		})
+		return results
+	}
+
+	// 1. Check masters (Required key)
+	if !lc.HasKey("masters") {
+		results = append(results, lints.LintResult{
+			RuleMetadata: ruleLayoutConfRepo,
+			Message:      fmt.Sprintf("[%s] layout.conf is missing the required 'masters' key", lints.SeverityError),
+		})
+	}
+
+	// 2. Check use-manifests
+	if lc.HasKey("use-manifests") {
+		um := lc.UseManifests()
+		if um != "strict" && um != "true" && um != "false" {
+			results = append(results, lints.LintResult{
+				RuleMetadata: ruleLayoutConfRepo,
+				Message:      fmt.Sprintf("[%s] layout.conf has invalid 'use-manifests' value: %s", lints.SeverityError, um),
+			})
+		}
+	}
+
+	// 3. Check boolean values
+	boolKeys := []string{"update-changelog", "thin-manifests", "sign-commits", "sign-manifests"}
+	for _, key := range boolKeys {
+		if lc.HasKey(key) {
+			val := lc.GetValue(key)
+			if val != "true" && val != "false" {
+				results = append(results, lints.LintResult{
+					RuleMetadata: ruleLayoutConfRepo,
+					Message:      fmt.Sprintf("[%s] layout.conf has invalid boolean value for '%s': %s", lints.SeverityError, key, val),
+				})
+			}
+		}
+	}
+
+	// 4. Check for unknown keys
+	validKeys := map[string]bool{
+		"masters":                  true,
+		"manifest-hashes":          true,
+		"manifest-required-hashes": true,
+		"use-manifests":            true,
+		"update-changelog":         true,
+		"cache-formats":            true,
+		"eapis-deprecated":         true,
+		"eapis-banned":             true,
+		"eapis-testing":            true,
+		"profile-eapis-deprecated": true,
+		"profile-eapis-banned":     true,
+		"repo-name":                true,
+		"aliases":                  true,
+		"thin-manifests":           true,
+		"sign-commits":             true,
+		"sign-manifests":           true,
+		"properties-allowed":       true,
+		"restrict-allowed":         true,
+		"profile-formats":          true,
+	}
+
+	for _, entry := range lc.Entries {
+		if !validKeys[entry.Key] {
+			res := lints.LintResult{
+				RuleMetadata: ruleLayoutConfRepo,
+				Message:      fmt.Sprintf("[%s] layout.conf contains unknown key: %s", cases.Title(language.Und, cases.NoLower).String(string(lints.SeverityNotice)), entry.Key),
+			}
+			res.RuleMetadata.Severity = lints.SeverityNotice
+			results = append(results, res)
+		}
+	}
+
+	// Add package fields for nicer formatting, although it's a repo-level rule
+	// Using "metadata/layout.conf" as file indicator
+	for i := range results {
+		results[i].File = "metadata/layout.conf"
+	}
+
+	return results
+}

--- a/lints/metadata/layout_conf_repo.go
+++ b/lints/metadata/layout_conf_repo.go
@@ -67,11 +67,31 @@ func (r *LayoutConfRepoLintRule) LintRepo(repoDir string, site *g2.SiteData) []l
 		return nil
 	}
 
+	// Validator for hashes
+	validateHashes := func(contents ...string) error {
+		validHashes := map[string]bool{
+			"BLAKE2B": true,
+			"BLAKE2S": true,
+			"SHA512":  true,
+			"SHA256":  true,
+			"WHIRLPOOL": true,
+			"RMD160": true,
+			"SHA1": true,
+			"MD5": true,
+		}
+		for _, hash := range contents {
+			if !validHashes[hash] {
+				return fmt.Errorf("unknown hash algorithm '%s'", hash)
+			}
+		}
+		return nil
+	}
+
 	// 4. Check for unknown keys
 	validKeys := map[string]func(contents ...string) error{
 		"masters":                  validateList,
-		"manifest-hashes":          validateList,
-		"manifest-required-hashes": validateList,
+		"manifest-hashes":          validateHashes,
+		"manifest-required-hashes": validateHashes,
 		"use-manifests": func(contents ...string) error {
 			if len(contents) != 1 {
 				return fmt.Errorf("expected 1 value, got %d", len(contents))

--- a/lints/metadata/layout_conf_repo_test.go
+++ b/lints/metadata/layout_conf_repo_test.go
@@ -1,0 +1,97 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arran4/g2/lints"
+)
+
+func TestLayoutConfRepoLintRule(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "layout-conf-repo-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	metadataDir := filepath.Join(tempDir, "metadata")
+	if err := os.MkdirAll(metadataDir, 0755); err != nil {
+		t.Fatalf("failed to create metadata dir: %v", err)
+	}
+
+	rule := &LayoutConfRepoLintRule{}
+
+	// Test 1: Missing layout.conf
+	results := rule.LintRepo(tempDir, nil)
+	if len(results) != 1 {
+		t.Fatalf("Test 1: expected 1 result, got %d", len(results))
+	}
+	if results[0].RuleMetadata.Severity != lints.SeverityError {
+		t.Errorf("Test 1: expected error severity")
+	}
+
+	// Test 2: Missing masters
+	layoutConf := "sign-commits = true\n"
+	if err := os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644); err != nil {
+		t.Fatalf("failed to write layout.conf: %v", err)
+	}
+	results = rule.LintRepo(tempDir, nil)
+	if len(results) != 1 {
+		t.Fatalf("Test 2: expected 1 result, got %d", len(results))
+	}
+	if results[0].RuleMetadata.Severity != lints.SeverityError {
+		t.Errorf("Test 2: expected error severity")
+	}
+
+	// Test 3: Invalid use-manifests
+	layoutConf = "masters = gentoo\nuse-manifests = maybe\n"
+	if err := os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644); err != nil {
+		t.Fatalf("failed to write layout.conf: %v", err)
+	}
+	results = rule.LintRepo(tempDir, nil)
+	if len(results) != 1 {
+		t.Fatalf("Test 3: expected 1 result, got %d", len(results))
+	}
+	if results[0].RuleMetadata.Severity != lints.SeverityError {
+		t.Errorf("Test 3: expected error severity")
+	}
+
+	// Test 4: Invalid boolean values
+	layoutConf = "masters = gentoo\nthin-manifests = yes\nsign-commits = false\n"
+	if err := os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644); err != nil {
+		t.Fatalf("failed to write layout.conf: %v", err)
+	}
+	results = rule.LintRepo(tempDir, nil)
+	if len(results) != 1 {
+		t.Fatalf("Test 4: expected 1 result, got %d", len(results))
+	}
+	if results[0].RuleMetadata.Severity != lints.SeverityError {
+		t.Errorf("Test 4: expected error severity")
+	}
+
+	// Test 5: Unknown keys
+	layoutConf = "masters = gentoo\nunknown-key = something\n"
+	if err := os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644); err != nil {
+		t.Fatalf("failed to write layout.conf: %v", err)
+	}
+	results = rule.LintRepo(tempDir, nil)
+	if len(results) != 1 {
+		t.Fatalf("Test 5: expected 1 result, got %d", len(results))
+	}
+	if results[0].RuleMetadata.Severity != lints.SeverityNotice {
+		t.Errorf("Test 5: expected notice severity")
+	}
+
+	// Test 6: Valid layout.conf
+	layoutConf = "masters = gentoo\nuse-manifests = strict\nthin-manifests = true\n"
+	if err := os.WriteFile(filepath.Join(metadataDir, "layout.conf"), []byte(layoutConf), 0644); err != nil {
+		t.Fatalf("failed to write layout.conf: %v", err)
+	}
+	results = rule.LintRepo(tempDir, nil)
+	if len(results) != 0 {
+		t.Fatalf("Test 6: expected 0 results, got %d", len(results))
+	}
+}


### PR DESCRIPTION
Implements the parsing, typed data structures, and linting rules required to fully support the Gentoo GLEP 82 specification for repository configuration files (`metadata/layout.conf`).

---
*PR created automatically by Jules for task [14201669030837567927](https://jules.google.com/task/14201669030837567927) started by @arran4*