### PR TITLE
feat: Add GLEP 67 and 68 support to metadata parsing and linting

### DIFF
--- a/lints/metadata/maintainer_type.go
+++ b/lints/metadata/maintainer_type.go
@@ -1,0 +1,69 @@
+package metadata
+
+import (
+	"fmt"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleMaintainerType = lints.RuleMetadata{
+	ID:          "MaintainerType",
+	Title:       "Maintainer Type Must Be Explicit",
+	Description: "Ensures that all Gentoo maintainers in metadata.xml have their type explicitly set to either person or project.",
+	URL:         "https://www.gentoo.org/glep/glep-0067.html#new-metadata-xml-format",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"metadata.xml", "site-quality", "GLEP67"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleMaintainerType)
+	lints.RegisterLintRule(&MaintainerTypeLintRule{})
+}
+
+type MaintainerTypeLintRule struct{}
+
+func (r *MaintainerTypeLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *MaintainerTypeLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["GLEP67"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	if pkg.Metadata != nil {
+		for _, m := range pkg.Metadata.Maintainers {
+			if m.Type != "person" && m.Type != "project" {
+				res := lints.LintResult{
+					RuleMetadata: ruleMaintainerType,
+					Message:      fmt.Sprintf("[%s] Maintainer '%s' must explicitly set type to 'person' or 'project'", cases.Title(language.Und, cases.NoLower).String(string(severity)), m.Email),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/metadata/maintainer_type_test.go
+++ b/lints/metadata/maintainer_type_test.go
@@ -1,0 +1,72 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/metadata"
+)
+
+func TestMaintainerTypeLintRule(t *testing.T) {
+	rule := &metadata.MaintainerTypeLintRule{}
+
+	t.Run("Valid person maintainer", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "person@example.com", Type: "person"},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Valid project maintainer", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "project@example.com", Type: "project"},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Missing type attribute", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "missing@example.com"},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for missing type, got none")
+		} else if warnings[0].RuleMetadata.ID != "MaintainerType" {
+			t.Errorf("expected MaintainerType rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+
+	t.Run("Invalid type attribute", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Maintainers: []g2.Maintainer{
+					{Email: "unknown@example.com", Type: "unknown"},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for invalid type, got none")
+		} else if warnings[0].RuleMetadata.ID != "MaintainerType" {
+			t.Errorf("expected MaintainerType rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+}

--- a/lints/metadata/projects_xml.go
+++ b/lints/metadata/projects_xml.go
@@ -1,0 +1,56 @@
+package metadata
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleProjectsXML = lints.RuleMetadata{
+	ID:          "ProjectsXML",
+	Title:       "Projects XML Rules",
+	Description: "Validates metadata/projects.xml structural integrity.",
+	URL:         "https://www.gentoo.org/glep/glep-0067.html#projects-xml-and-herds-xml",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"projects.xml", "site-quality", "GLEP67"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleProjectsXML)
+	lints.RegisterRepoLintRule(&ProjectsXMLLintRule{})
+}
+
+type ProjectsXMLLintRule struct{}
+
+func (r *ProjectsXMLLintRule) LintRepo(repoDir string, site *g2.SiteData) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if site != nil && site.Projects != nil {
+		projectEmails := make(map[string]bool)
+		for _, proj := range site.Projects.Projects {
+			projectEmails[proj.Email] = true
+		}
+
+		for _, proj := range site.Projects.Projects {
+			for _, sub := range proj.Subprojects {
+				if !projectEmails[sub.Ref] {
+					res := lints.LintResult{
+						RuleMetadata: ruleProjectsXML,
+						Message:      fmt.Sprintf("[%s] Subproject ref '%s' in project '%s' does not exist", cases.Title(language.Und, cases.NoLower).String(string(severity)), sub.Ref, proj.Email),
+						File:         filepath.Join("metadata", "projects.xml"),
+					}
+					res.RuleMetadata.Severity = severity
+					results = append(results, res)
+				}
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/metadata/projects_xml_test.go
+++ b/lints/metadata/projects_xml_test.go
@@ -1,0 +1,50 @@
+package metadata_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/metadata"
+)
+
+func TestProjectsXMLLintRule(t *testing.T) {
+	rule := &metadata.ProjectsXMLLintRule{}
+
+	t.Run("Valid projects.xml", func(t *testing.T) {
+		site := &g2.SiteData{
+			Projects: &g2.Projects{
+				Projects: []g2.Project{
+					{Email: "parent@example.com", Subprojects: []g2.Subproject{{Ref: "child@example.com"}}},
+					{Email: "child@example.com"},
+				},
+			},
+		}
+		warnings := rule.LintRepo(".", site)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Invalid subproject ref", func(t *testing.T) {
+		site := &g2.SiteData{
+			Projects: &g2.Projects{
+				Projects: []g2.Project{
+					{Email: "parent@example.com", Subprojects: []g2.Subproject{{Ref: "missing@example.com"}}},
+				},
+			},
+		}
+		warnings := rule.LintRepo(".", site)
+		if len(warnings) == 0 {
+			t.Error("expected warning for missing subproject ref, got none")
+		} else {
+			if warnings[0].RuleMetadata.ID != "ProjectsXML" {
+				t.Errorf("expected ProjectsXML rule, got %s", warnings[0].RuleMetadata.ID)
+			}
+			expectedFile := filepath.Join("metadata", "projects.xml")
+			if warnings[0].File != expectedFile {
+				t.Errorf("expected file %s, got %s", expectedFile, warnings[0].File)
+			}
+		}
+	})
+}

--- a/lints/metadata/remote_id.go
+++ b/lints/metadata/remote_id.go
@@ -1,0 +1,62 @@
+package metadata
+
+import (
+	"fmt"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleRemoteIDType = lints.RuleMetadata{
+	ID:          "RemoteIDType",
+	Title:       "Valid Remote ID Type",
+	Description: "Validates that the type attribute for <remote-id> elements matches the allowed enumeration in the DTD.",
+	URL:         "https://devmanual.gentoo.org/ebuild-writing/misc-files/metadata.xml/#upstream",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"metadata.xml", "site-quality"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleRemoteIDType)
+	lints.RegisterLintRule(&RemoteIDTypeLintRule{})
+}
+
+type RemoteIDTypeLintRule struct{}
+
+var validRemoteIDTypes = map[string]bool{
+	"bitbucket": true, "codeberg": true, "cpan": true, "cpan-module": true,
+	"cpe": true, "cran": true, "ctan": true, "freedesktop-gitlab": true,
+	"gentoo": true, "github": true, "gitlab": true, "gnome-gitlab": true,
+	"google-code": true, "hackage": true, "heptapod": true, "kde-invent": true,
+	"launchpad": true, "osdn": true, "pear": true, "pecl": true,
+	"pypi": true, "rubygems": true, "savannah": true, "savannah-nongnu": true,
+	"sourceforge": true, "sourcehut": true, "vim": true,
+}
+
+func (r *RemoteIDTypeLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *RemoteIDTypeLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+
+	if pkg.Metadata != nil && pkg.Metadata.Upstream != nil {
+		for _, rid := range pkg.Metadata.Upstream.RemoteID {
+			if !validRemoteIDTypes[rid.Type] {
+				res := lints.LintResult{
+					RuleMetadata: ruleRemoteIDType,
+					Message:      fmt.Sprintf("[%s] Invalid remote-id type '%s'", cases.Title(language.Und, cases.NoLower).String(string(severity)), rid.Type),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/metadata/remote_id_test.go
+++ b/lints/metadata/remote_id_test.go
@@ -1,0 +1,47 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/metadata"
+)
+
+func TestRemoteIDTypeLintRule(t *testing.T) {
+	rule := &metadata.RemoteIDTypeLintRule{}
+
+	t.Run("Valid remote id", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Upstream: &g2.Upstream{
+					RemoteID: []g2.RemoteID{
+						{Type: "github", Text: "foo/bar"},
+						{Type: "pypi", Text: "foo"},
+					},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Invalid remote id", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Upstream: &g2.Upstream{
+					RemoteID: []g2.RemoteID{
+						{Type: "invalid-type", Text: "foo"},
+					},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for invalid remote-id type, got none")
+		} else if warnings[0].RuleMetadata.ID != "RemoteIDType" {
+			t.Errorf("expected RemoteIDType rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+}

--- a/lints/metadata/upstream_maintainer.go
+++ b/lints/metadata/upstream_maintainer.go
@@ -1,0 +1,78 @@
+package metadata
+
+import (
+	"fmt"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleUpstreamMaintainer = lints.RuleMetadata{
+	ID:          "UpstreamMaintainer",
+	Title:       "Upstream Maintainer Rule",
+	Description: "Ensures that maintainers listed inside the <upstream> block do not use description or restrict tags/attributes.",
+	URL:         "https://www.gentoo.org/glep/glep-0068.html#upstream-block",
+	Severity:    lints.SeverityError,
+	Source:      lints.SourceG2,
+	Tags:        []string{"metadata.xml", "site-quality", "GLEP68"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleUpstreamMaintainer)
+	lints.RegisterLintRule(&UpstreamMaintainerLintRule{})
+}
+
+type UpstreamMaintainerLintRule struct{}
+
+func (r *UpstreamMaintainerLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *UpstreamMaintainerLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := lints.SeverityError
+	if qa != nil && qa.Policies != nil {
+		if val, ok := qa.Policies["GLEP68"]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			if val == "notice" || val == "error" || val == "warning" {
+				switch val {
+				case "notice":
+					severity = lints.SeverityNotice
+				case "error":
+					severity = lints.SeverityError
+				case "warning":
+					severity = lints.SeverityWarning
+				}
+			}
+		}
+	}
+
+	if pkg.Metadata != nil && pkg.Metadata.Upstream != nil {
+		for _, m := range pkg.Metadata.Upstream.Maintainers {
+			if m.Description != "" {
+				res := lints.LintResult{
+					RuleMetadata: ruleUpstreamMaintainer,
+					Message:      fmt.Sprintf("[%s] Upstream maintainer '%s' must not have a description", cases.Title(language.Und, cases.NoLower).String(string(severity)), m.Name),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+			if m.Restrict != "" {
+				res := lints.LintResult{
+					RuleMetadata: ruleUpstreamMaintainer,
+					Message:      fmt.Sprintf("[%s] Upstream maintainer '%s' must not have a restrict attribute", cases.Title(language.Und, cases.NoLower).String(string(severity)), m.Name),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+
+	return results
+}

--- a/lints/metadata/upstream_maintainer_test.go
+++ b/lints/metadata/upstream_maintainer_test.go
@@ -1,0 +1,64 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints/metadata"
+)
+
+func TestUpstreamMaintainerLintRule(t *testing.T) {
+	rule := &metadata.UpstreamMaintainerLintRule{}
+
+	t.Run("Valid upstream maintainer", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Upstream: &g2.Upstream{
+					Maintainers: []g2.Maintainer{
+						{Name: "Upstream Dev"},
+					},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("Upstream maintainer with description", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Upstream: &g2.Upstream{
+					Maintainers: []g2.Maintainer{
+						{Name: "Upstream Dev", Description: "Primary Dev"},
+					},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for description, got none")
+		} else if warnings[0].RuleMetadata.ID != "UpstreamMaintainer" {
+			t.Errorf("expected UpstreamMaintainer rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+
+	t.Run("Upstream maintainer with restrict", func(t *testing.T) {
+		pkg := &g2.PackageData{
+			Metadata: &g2.PkgMetadata{
+				Upstream: &g2.Upstream{
+					Maintainers: []g2.Maintainer{
+						{Name: "Upstream Dev", Restrict: "test"},
+					},
+				},
+			},
+		}
+		warnings := rule.Lint(".", pkg)
+		if len(warnings) == 0 {
+			t.Error("expected warning for restrict, got none")
+		} else if warnings[0].RuleMetadata.ID != "UpstreamMaintainer" {
+			t.Errorf("expected UpstreamMaintainer rule, got %s", warnings[0].RuleMetadata.ID)
+		}
+	})
+}

--- a/metadata.go
+++ b/metadata.go
@@ -34,6 +34,14 @@ func (s *StabilizeAllArches) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 	return e.EncodeElement("", start)
 }
 
+type StraightToStable struct {
+	Restrict string `xml:"restrict,attr,omitempty"`
+}
+
+func (s *StraightToStable) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement("", start)
+}
+
 // MetadataComments represents a list of XML comments.
 type MetadataComments []string
 
@@ -59,6 +67,7 @@ type PkgMetadata struct {
 	LongDescription    []LongDescription   `xml:"longdescription"`
 	Slots              *Slots              `xml:"slots"`
 	StabilizeAllArches *StabilizeAllArches `xml:"stabilize-allarches"`
+	StraightToStable   *StraightToStable   `xml:"straight-to-stable"`
 	Use                []Use               `xml:"use"`
 	Upstream           *Upstream           `xml:"upstream"`
 }

--- a/projects.go
+++ b/projects.go
@@ -18,8 +18,8 @@ type Projects struct {
 type Project struct {
 	Email       string       `xml:"email"`
 	Name        string       `xml:"name"`
-	URL         string       `xml:"url"`
-	Description string       `xml:"description"`
+	URL         string       `xml:"url,omitempty"`
+	Description string       `xml:"description,omitempty"`
 	Subprojects []Subproject `xml:"subproject"`
 	Members     []Member     `xml:"member"`
 }
@@ -33,8 +33,8 @@ type Subproject struct {
 type Member struct {
 	IsLead string `xml:"is-lead,attr,omitempty"` // 0|1
 	Email  string `xml:"email"`
-	Name   string `xml:"name"`
-	Role   string `xml:"role"`
+	Name   string `xml:"name,omitempty"`
+	Role   string `xml:"role,omitempty"`
 }
 
 // ParseProjects parses a projects.xml file and returns a Projects pointer, or an error.

--- a/testdata/models/pkgmetadata.txtar
+++ b/testdata/models/pkgmetadata.txtar
@@ -13,6 +13,7 @@ test: PkgMetadata serialization
 		<subslots>sub</subslots>
 	</slots>
 	<stabilize-allarches restrict="test"></stabilize-allarches>
+	<straight-to-stable restrict="test"></straight-to-stable>
 	<use lang="en">
 		<flag name="foo" restrict="test">Enable foo</flag>
 	</use>
@@ -61,6 +62,9 @@ test: PkgMetadata serialization
 		"Lang": "en"
 	},
 	"StabilizeAllArches": {
+		"Restrict": "test"
+	},
+	"StraightToStable": {
 		"Restrict": "test"
 	},
 	"Use": [

--- a/testdata/models_json/pkgmetadata.txtar
+++ b/testdata/models_json/pkgmetadata.txtar
@@ -36,6 +36,9 @@ test: PkgMetadata JSON to XML serialization
 	"StabilizeAllArches": {
 		"Restrict": "test"
 	},
+	"StraightToStable": {
+		"Restrict": "test"
+	},
 	"Use": [
 		{
 			"Flags": [
@@ -88,6 +91,7 @@ test: PkgMetadata JSON to XML serialization
 		<subslots>sub</subslots>
 	</slots>
 	<stabilize-allarches restrict="test"></stabilize-allarches>
+	<straight-to-stable restrict="test"></straight-to-stable>
 	<use lang="en">
 		<flag name="foo" restrict="test">Enable foo</flag>
 	</use>
@@ -136,6 +140,9 @@ test: PkgMetadata JSON to XML serialization
 		"Lang": "en"
 	},
 	"StabilizeAllArches": {
+		"Restrict": "test"
+	},
+	"StraightToStable": {
 		"Restrict": "test"
 	},
 	"Use": [

--- a/testdata/txtar/metadata_skel.txtar
+++ b/testdata/txtar/metadata_skel.txtar
@@ -100,6 +100,7 @@ not relevant for general metadata.xml files.
   ],
   "Slots": null,
   "StabilizeAllArches": null,
+  "StraightToStable": null,
   "Use": [
     {
       "Flags": [


### PR DESCRIPTION
This submission adds support for Gentoo GLEP 67 and GLEP 68 metadata policies.

Changes include:
1. Updated `metadata.go` parser to add the `StraightToStable` element.
2. Updated `projects.go` parser to make `URL`, `Description`, `Name`, and `Role` fields omit-able.
3. Updated test txtar templates to reflect new parser output.
4. Added `MaintainerTypeLintRule` to ensure `<maintainer>` tags specify a `type` attribute (GLEP 67).
5. Added `UpstreamMaintainerLintRule` to restrict `description` and `restrict` attributes in `<upstream>` maintainers (GLEP 68).
6. Added `RemoteIDTypeLintRule` to enforce valid types for `<remote-id>` elements.
7. Added `ProjectsXMLLintRule` (a RepoLintRule) to check structural integrity of `<subproject>` references against valid projects.
8. Added test coverage for all new lint rules.

---
*PR created automatically by Jules for task [2841696227718442845](https://jules.google.com/task/2841696227718442845) started by @arran4*