### PR TITLE
fix: support main gentoo categories even if overlay restricts categories

### DIFF
--- a/cmd/g2/parse_repo.go
+++ b/cmd/g2/parse_repo.go
@@ -275,16 +275,16 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 			continue
 		}
 
-		if len(supportedCategories) > 0 && !supportedCategories[name] && name != "virtual" && !strings.HasPrefix(name, "virtual-") {
+		inRepo := len(supportedCategories) == 0 || supportedCategories[name]
+		mainCats := g2.FetchMainGentooCategories()
+		inMain := len(mainCats) == 0 || mainCats[name]
+
+		if len(supportedCategories) > 0 && !inRepo && !inMain && name != "virtual" && !strings.HasPrefix(name, "virtual-") {
 			continue
 		}
 
 		catData := g2.CategoryData{Name: name}
 		catPath := filepath.Join(repoDir, name)
-
-		inRepo := len(supportedCategories) == 0 || supportedCategories[name]
-		mainCats := g2.FetchMainGentooCategories()
-		inMain := len(mainCats) == 0 || mainCats[name]
 
 		pkgEntries, err := fs.ReadDir(sysFS, filepath.ToSlash(catPath))
 		if err != nil {


### PR DESCRIPTION
Overlays like Guru often provide a restricted `profiles/categories` list containing only their custom categories. They rely on the main portage tree to define the standard categories (like `dev-util`). Previously, `g2` site generation would skip valid directories if they were not listed in the overlay's custom categories list, leading to missing packages on the static site. This change allows directories that are part of the main Gentoo categories list to be processed.

---
*PR created automatically by Jules for task [5673616112108073467](https://jules.google.com/task/5673616112108073467) started by @arran4*