### PR TITLE
fix: robustly inherit Gentoo categories for site generation via masters

### DIFF
--- a/cmd/g2/parse_repo.go
+++ b/cmd/g2/parse_repo.go
@@ -212,6 +212,25 @@ func parseRepoAuthors(repoDir string, site *g2.SiteData, remoteURL string) {
 	}
 }
 
+// isCategoryAllowed checks if a directory name should be accepted as a valid category.
+func isCategoryAllowed(repoCats map[string]bool, hasGentooMaster bool, mainCats map[string]bool, name string) bool {
+	if name == "virtual" || strings.HasPrefix(name, "virtual-") {
+		return true
+	}
+	if len(repoCats) > 0 && repoCats[name] {
+		return true
+	}
+	if hasGentooMaster && len(mainCats) > 0 && mainCats[name] {
+		return true
+	}
+	// Preserve backward compatibility for repos without profiles/categories.
+	// If the file is entirely absent or empty, allow all categories.
+	if len(repoCats) == 0 {
+		return true
+	}
+	return false
+}
+
 // parseRepoCategoriesAndPackages recursively crawls and parses the repo's categories, packages, and their ebuilds.
 func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string, fastGit bool, remoteURL string, site *g2.SiteData) error {
 	supportedCategories := make(map[string]bool)
@@ -261,6 +280,17 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 		infoPkgsMap[baseAtom] = true
 	}
 
+	hasGentooMaster := false
+	if site.LayoutConf != nil {
+		for _, master := range site.LayoutConf.Masters() {
+			if master == "gentoo" {
+				hasGentooMaster = true
+				break
+			}
+		}
+	}
+	mainCats := g2.FetchMainGentooCategories()
+
 	entries, err := fs.ReadDir(sysFS, filepath.ToSlash(repoDir))
 	if err != nil {
 		return fmt.Errorf("reading repo dir: %w", err)
@@ -275,15 +305,13 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 			continue
 		}
 
-		if len(supportedCategories) > 0 && !supportedCategories[name] && name != "virtual" && !strings.HasPrefix(name, "virtual-") {
+		if !isCategoryAllowed(supportedCategories, hasGentooMaster, mainCats, name) {
 			continue
 		}
 
 		catData := g2.CategoryData{Name: name}
 		catPath := filepath.Join(repoDir, name)
 
-		inRepo := len(supportedCategories) == 0 || supportedCategories[name]
-		mainCats := g2.FetchMainGentooCategories()
 		inMain := len(mainCats) == 0 || mainCats[name]
 
 		pkgEntries, err := fs.ReadDir(sysFS, filepath.ToSlash(catPath))
@@ -537,8 +565,10 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 
 			pkgData.LintWarnings = lints.PerformLinting(repoDir, &g2PkgData)
 
-			if len(supportedCategories) > 0 && !inRepo {
-				if inMain {
+			if len(supportedCategories) > 0 && !supportedCategories[name] {
+				if hasGentooMaster && mainCats[name] {
+					// No warning, perfectly valid inherited category
+				} else if inMain {
 					pkgData.LintWarnings = append(pkgData.LintWarnings, fmt.Sprintf("Warning: category '%s' is not listed in repo's profiles/categories", name))
 				} else {
 					pkgData.LintWarnings = append(pkgData.LintWarnings, fmt.Sprintf("Error: category '%s' is not listed in repo's profiles/categories or the main gentoo categories list", name))
@@ -551,8 +581,10 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 		}
 
 		if len(catData.Packages) > 0 {
-			if len(supportedCategories) > 0 && !inRepo {
-				if inMain {
+			if len(supportedCategories) > 0 && !supportedCategories[name] {
+				if hasGentooMaster && mainCats[name] {
+					// No warning, perfectly valid inherited category
+				} else if inMain {
 					log.Printf("Warning: category '%s' is not listed in repo's profiles/categories", name)
 				} else {
 					log.Printf("Error: category '%s' is not listed in repo's profiles/categories or the main gentoo categories list", name)

--- a/cmd/g2/parse_repo_test.go
+++ b/cmd/g2/parse_repo_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIsCategoryAllowed(t *testing.T) {
+	tests := []struct {
+		name            string
+		repoCats        map[string]bool
+		hasGentooMaster bool
+		mainCats        map[string]bool
+		catName         string
+		want            bool
+	}{
+		{
+			name:            "category explicitly listed by the overlay -> included",
+			repoCats:        map[string]bool{"sys-foo": true},
+			hasGentooMaster: false,
+			mainCats:        map[string]bool{},
+			catName:         "sys-foo",
+			want:            true,
+		},
+		{
+			name:            "category not locally listed but present in Gentoo -> included when masters = gentoo",
+			repoCats:        map[string]bool{"sys-foo": true},
+			hasGentooMaster: true,
+			mainCats:        map[string]bool{"dev-util": true},
+			catName:         "dev-util",
+			want:            true,
+		},
+		{
+			name:            "the same Gentoo category -> not automatically inherited by a repository without masters = gentoo",
+			repoCats:        map[string]bool{"sys-foo": true},
+			hasGentooMaster: false,
+			mainCats:        map[string]bool{"dev-util": true},
+			catName:         "dev-util",
+			want:            false,
+		},
+		{
+			name:            "category absent from both allowed sets -> rejected",
+			repoCats:        map[string]bool{"sys-foo": true},
+			hasGentooMaster: true,
+			mainCats:        map[string]bool{"dev-util": true},
+			catName:         "dev-python",
+			want:            false,
+		},
+		{
+			name:            "virtual category -> continue to work",
+			repoCats:        map[string]bool{"sys-foo": true},
+			hasGentooMaster: false,
+			mainCats:        map[string]bool{"dev-util": true},
+			catName:         "virtual",
+			want:            true,
+		},
+		{
+			name:            "virtual-* category -> continue to work",
+			repoCats:        map[string]bool{"sys-foo": true},
+			hasGentooMaster: false,
+			mainCats:        map[string]bool{"dev-util": true},
+			catName:         "virtual-python",
+			want:            true,
+		},
+		{
+			name:            "unavailable/empty Gentoo category data does not cause arbitrary directories to be accepted",
+			repoCats:        map[string]bool{"sys-foo": true},
+			hasGentooMaster: true,
+			mainCats:        map[string]bool{},
+			catName:         "dev-util",
+			want:            false,
+		},
+		{
+			name:            "absent profiles/categories allows anything (fallback)",
+			repoCats:        map[string]bool{},
+			hasGentooMaster: true,
+			mainCats:        map[string]bool{"dev-util": true},
+			catName:         "random-dir",
+			want:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCategoryAllowed(tt.repoCats, tt.hasGentooMaster, tt.mainCats, tt.catName); got != tt.want {
+				t.Errorf("isCategoryAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/lints/ebuild/category_sanity.go
+++ b/lints/ebuild/category_sanity.go
@@ -76,12 +76,23 @@ func (l *CategorySanityLintRule) Lint(repoDir string, pkg *g2.PackageData) []lin
 		l.mu.Unlock()
 	}
 
-	inRepo := len(supportedCategories) == 0 || supportedCategories[name]
+	hasGentooMaster := false
+	if lc, err := g2.ParseLayoutConf(filepath.Join(repoDir, "metadata", "layout.conf")); err == nil && lc != nil {
+		for _, m := range lc.Masters() {
+			if m == "gentoo" {
+				hasGentooMaster = true
+				break
+			}
+		}
+	}
+
 	mainCats := g2.FetchMainGentooCategories()
 	inMain := len(mainCats) == 0 || mainCats[name]
 
-	if len(supportedCategories) > 0 && !inRepo {
-		if inMain {
+	if len(supportedCategories) > 0 && !supportedCategories[name] {
+		if hasGentooMaster && mainCats[name] {
+			// No warning, perfectly valid inherited category
+		} else if inMain {
 			res := lints.LintResult{
 				RuleMetadata: ruleCategorySanity,
 				Message:      fmt.Sprintf("Warning: category '%s' is not listed in repo's profiles/categories", name),

--- a/lints/layout/layout.go
+++ b/lints/layout/layout.go
@@ -125,7 +125,18 @@ func (l *RepoLayoutLintRule) LintRepo(repoDir string, site *g2.SiteData) []lints
 				continue
 			}
 			inRepo := repoCategories[name]
-			inUpstream := upstreamCategories != nil && upstreamCategories[name]
+
+			hasGentooMaster := false
+			if site != nil && site.LayoutConf != nil {
+				for _, m := range site.LayoutConf.Masters() {
+					if m == "gentoo" {
+						hasGentooMaster = true
+						break
+					}
+				}
+			}
+
+			inUpstream := hasGentooMaster && upstreamCategories != nil && upstreamCategories[name]
 			if !inRepo && !inUpstream {
 				results = append(results, lints.LintResult{
 					RuleMetadata: ruleRepoLayout,


### PR DESCRIPTION
Fixes a bug where overlay repositories defining `gentoo` as their master but containing an explicit list of only custom local categories in their `profiles/categories` would incorrectly drop valid inherited Gentoo packages during site generation.

The fix introduces a centralized `isCategoryAllowed` helper and standardizes the definition of category validation across site generation parsing, category sanity linting, and layout linting. It explicitly evaluates `site.LayoutConf.Masters()` (or dynamically parses it in the case of `CategorySanityLintRule`) to conditionally accept inherited categories that exist in the main Gentoo category set, while securely failing back to defaults during network/upstream-absence errors.

---
*PR created automatically by Jules for task [2448849363451098431](https://jules.google.com/task/2448849363451098431) started by @arran4*