### PR TITLE
🧪 Add unit test for ParsePkgDescIndexFile and support fs.FS

### DIFF
--- a/cmd/g2/pkg_desc_index.go
+++ b/cmd/g2/pkg_desc_index.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -110,16 +112,17 @@ func (cfg *MainArgConfig) cmdPkgDescIndexVerify(args []string) error {
 		return err
 	}
 
-	indexPath := filepath.Join(*repoDir, "metadata", "pkg_desc_index")
-	index, err := g2.ParsePkgDescIndexFile(indexPath)
+	cfs := g2.NewOsCacheFS(*repoDir)
+	indexPath := "metadata/pkg_desc_index"
+
+	index, err := g2.ParsePkgDescIndexFile(indexPath, cfs)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("pkg_desc_index not found at %s. run generate first", indexPath)
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("pkg_desc_index not found at %s. run generate first", filepath.Join(*repoDir, indexPath))
 		}
 		return fmt.Errorf("parsing existing index: %w", err)
 	}
 
-	cfs := g2.NewOsCacheFS(*repoDir)
 	siteData, err := parseRepo(cfs, ".", "Pkg Desc Index Verification", true, nil)
 	if err != nil {
 		return fmt.Errorf("parsing repo: %w", err)

--- a/pkg_desc_index.go
+++ b/pkg_desc_index.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"sort"
 	"strings"
@@ -73,9 +74,24 @@ func ParsePkgDescIndex(r io.Reader) (*PkgDescIndex, error) {
 	return &index, nil
 }
 
-// ParsePkgDescIndexFile reads and parses a pkg_desc_index file from disk.
-func ParsePkgDescIndexFile(path string) (*PkgDescIndex, error) {
-	file, err := os.Open(path)
+// ParsePkgDescIndexFile reads and parses a pkg_desc_index file.
+// It optionally accepts an fs.FS to read from via type-switched variadic args.
+// If no fs.FS is provided, it falls back to os.Open.
+func ParsePkgDescIndexFile(path string, opts ...any) (*PkgDescIndex, error) {
+	var fsys fs.FS
+	for _, opt := range opts {
+		if v, ok := opt.(fs.FS); ok {
+			fsys = v
+		}
+	}
+
+	var file io.ReadCloser
+	var err error
+	if fsys != nil {
+		file, err = fsys.Open(path)
+	} else {
+		file, err = os.Open(path)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("opening file: %w", err)
 	}

--- a/pkg_desc_index_test.go
+++ b/pkg_desc_index_test.go
@@ -2,8 +2,11 @@ package g2
 
 import (
 	"bytes"
+	"errors"
+	"io/fs"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 func TestParsePkgDescIndex(t *testing.T) {
@@ -73,5 +76,39 @@ app-admin/amazon-ec2-init 20101127-r2: Init script to setup Amazon EC2 instance 
 `
 	if buf.String() != expected {
 		t.Errorf("Serialize mismatch.\nExpected:\n%s\nGot:\n%s", expected, buf.String())
+	}
+}
+
+func TestParsePkgDescIndexFile(t *testing.T) {
+	input := "app-admin/aerospike-amc-community 4.0.19-r2 5.0.0: Web UI based monitoring tool for Aerospike Community Edition Server\n" +
+		"app-admin/amazon-ec2-init 20101127-r2: Init script to setup Amazon EC2 instance parameters\n"
+	fsys := fstest.MapFS{
+		"pkg_desc_index": &fstest.MapFile{Data: []byte(input)},
+	}
+
+	idx, err := ParsePkgDescIndexFile("pkg_desc_index", fsys)
+	if err != nil {
+		t.Fatalf("ParsePkgDescIndexFile failed: %v", err)
+	}
+
+	if len(idx.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(idx.Entries))
+	}
+
+	e1 := idx.Entries[0]
+	if e1.Category != "app-admin" || e1.Package != "aerospike-amc-community" {
+		t.Errorf("entry 1 path wrong: %s/%s", e1.Category, e1.Package)
+	}
+	if len(e1.Versions) != 2 || e1.Versions[0] != "4.0.19-r2" || e1.Versions[1] != "5.0.0" {
+		t.Errorf("entry 1 versions wrong: %v", e1.Versions)
+	}
+	if e1.Description != "Web UI based monitoring tool for Aerospike Community Edition Server" {
+		t.Errorf("entry 1 description wrong: %s", e1.Description)
+	}
+
+	// Test with non-existent file
+	_, err = ParsePkgDescIndexFile("non_existent_file", fsys)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ParsePkgDescIndexFile should fail with fs.ErrNotExist for non-existent file, got: %v", err)
 	}
 }


### PR DESCRIPTION
This PR supersedes #420 with a clean diff against current `main`.

### Summary of Changes
- Updated `ParsePkgDescIndexFile` to optionally accept an `fs.FS` through type-switched variadic arguments while retaining backwards-compatible `os.Open` fallback when no `fs.FS` is provided.
- Updated `cmdPkgDescIndexVerify` to pass the repo cache filesystem (`cfs`) to `ParsePkgDescIndexFile` with an `fs.FS`-appropriate repository-relative path (`metadata/pkg_desc_index`).
- Updated missing-file detection in `cmdPkgDescIndexVerify` to use `errors.Is(err, fs.ErrNotExist)` so wrapped errors are detected accurately without misclassifying other I/O errors.
- Added `TestParsePkgDescIndexFile` in `pkg_desc_index_test.go` using `testing/fstest.MapFS` and verified `errors.Is(err, fs.ErrNotExist)` handling for missing files.
- Omitted all unrelated modifications/churn from previous iterations (such as `layout_conf.go`).

Supersedes: #420