### PR TITLE
feat(lints): introduce RuleSets and split copyright header linting

### DIFF
--- a/lints/ebuild/copyright.go
+++ b/lints/ebuild/copyright.go
@@ -1,0 +1,226 @@
+package ebuild
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var ruleCopyrightHeader = lints.RuleMetadata{
+	ID:          "CopyrightHeader",
+	Title:       "Missing or Non-Standard Copyright/License Header",
+	Description: "Validates that the ebuild starts with an initial comment block containing copyright, license, or SPDX terms.",
+	Severity:    lints.SeverityNotice,
+	Source:      lints.SourceG2,
+	Tags:        []string{"ebuild", "header", "license", "copyright"},
+}
+
+var ruleGentooCopyrightHeader = lints.RuleMetadata{
+	ID:          "GentooCopyrightHeader",
+	Title:       "Gentoo Copyright Header Policy",
+	Description: "Validates that the ebuild starts with the Gentoo copyright notice (e.g., '# Copyright <year> Gentoo Authors').",
+	References: []lints.RuleReference{
+		{URL: "https://devmanual.gentoo.org/general-concepts/copyright-policy/index.html", Label: "Gentoo Devmanual Copyright Policy"},
+	},
+	Severity: lints.SeverityWarning,
+	Source:   lints.SourceG2,
+	Tags:     []string{"ebuild", "gentoo-policy", "copyright"},
+}
+
+func init() {
+	lints.RegisterRuleMetadata(ruleCopyrightHeader)
+	lints.RegisterLintRule(&CopyrightHeaderLintRule{})
+
+	lints.RegisterRuleMetadata(ruleGentooCopyrightHeader)
+	lints.RegisterLintRule(&GentooCopyrightHeaderLintRule{})
+}
+
+var (
+	// rePlausibleYear matches plausible four-digit years between 1900 and 2099.
+	rePlausibleYear = regexp.MustCompile(`\b(19\d\d|20\d\d)\b`)
+
+	// reLicenseTokens matches standalone license identifiers to prevent false positives like "commit" matching "mit".
+	reLicenseTokens = regexp.MustCompile(`\b(?i:gpl|lgpl|agpl|bsd|mit|apache|mpl|isc|unlicense|zlib|epl|artistic)\b`)
+
+	// reGentooCopyright matches the canonical Gentoo copyright line format.
+	reGentooCopyright = regexp.MustCompile(`^#\s*Copyright\s+\d{4}(?:[-\s,]+\d{4})*\s+(?:Gentoo Authors|Gentoo Foundation)`)
+)
+
+// getInitialCommentBlock extracts the initial contiguous shell-comment lines from the top of an ebuild.
+// It stops immediately at the first non-comment line (such as empty lines, EAPI declarations, or code).
+func getInitialCommentBlock(rawText string) []string {
+	var comments []string
+	lines := strings.Split(rawText, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			comments = append(comments, trimmed)
+		} else {
+			break
+		}
+	}
+	return comments
+}
+
+// hasGenericCopyrightHeader evaluates whether the initial comment block contains plausible
+// copyright, licensing, or SPDX declarations using an evidence-scoring heuristic:
+//   - Plausible 4-digit year (1900-2099): +2 points
+//   - Explicit copyright phrasing ("copyright", "(c)", "©", "copr."): +2 points
+//   - SPDX license identifier: +2 points
+//   - Licensing terms ("license", "licence", "licensed", "licenced"): +1 point
+//   - Distribution terms ("distributed", "terms"): +1 point
+//   - Standalone license token (GPL, BSD, MIT, Apache, etc.): +1 point
+//
+// A score of >= 2 indicates a plausible header. This allows single strong indicators
+// (e.g. a dated comment, an explicit copyright line, or an SPDX header) as well as
+// combinations of weaker licensing indicators to pass without requiring Gentoo-specific phrasing.
+func hasGenericCopyrightHeader(rawText string) bool {
+	comments := getInitialCommentBlock(rawText)
+	if len(comments) == 0 {
+		return false
+	}
+
+	combined := strings.Join(comments, "\n")
+	lower := strings.ToLower(combined)
+
+	score := 0
+
+	if rePlausibleYear.MatchString(combined) {
+		score += 2
+	}
+
+	if strings.Contains(lower, "copyright") || strings.Contains(lower, "(c)") || strings.Contains(combined, "©") || strings.Contains(lower, "copr.") {
+		score += 2
+	}
+
+	if strings.Contains(lower, "spdx-license-identifier") || strings.Contains(lower, "spdx") {
+		score += 2
+	}
+
+	if strings.Contains(lower, "license") || strings.Contains(lower, "licence") || strings.Contains(lower, "licensed") || strings.Contains(lower, "licenced") {
+		score += 1
+	}
+
+	if strings.Contains(lower, "distributed") || strings.Contains(lower, "terms") {
+		score += 1
+	}
+
+	if reLicenseTokens.MatchString(lower) {
+		score += 1
+	}
+
+	return score >= 2
+}
+
+// hasGentooCopyrightHeader checks if the initial comment block contains a valid Gentoo copyright notice.
+func hasGentooCopyrightHeader(rawText string) bool {
+	comments := getInitialCommentBlock(rawText)
+	if len(comments) == 0 {
+		return false
+	}
+	for _, line := range comments {
+		if reGentooCopyright.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// CopyrightHeaderLintRule is a repository-neutral lint rule checking for generic copyright or licensing headers.
+type CopyrightHeaderLintRule struct{}
+
+func (r *CopyrightHeaderLintRule) Metadata() lints.RuleMetadata {
+	return ruleCopyrightHeader
+}
+
+func (r *CopyrightHeaderLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *CopyrightHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := ruleCopyrightHeader.Severity
+
+	if qa != nil {
+		if val, ok := qa.Policies[ruleCopyrightHeader.ID]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			if !hasGenericCopyrightHeader(ver.Ebuild.RawText) {
+				res := lints.LintResult{
+					RuleMetadata: ruleCopyrightHeader,
+					Message:      fmt.Sprintf("[%s] Ebuild %s has a missing or malformed copyright/licensing header.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+	return results
+}
+
+// GentooCopyrightHeaderLintRule validates the Gentoo main repository copyright policy.
+type GentooCopyrightHeaderLintRule struct{}
+
+func (r *GentooCopyrightHeaderLintRule) Metadata() lints.RuleMetadata {
+	return ruleGentooCopyrightHeader
+}
+
+func (r *GentooCopyrightHeaderLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
+	return r.LintWithQA(repoDir, pkg, nil)
+}
+
+func (r *GentooCopyrightHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
+	var results []lints.LintResult
+	severity := ruleGentooCopyrightHeader.Severity
+
+	if qa != nil {
+		if val, ok := qa.Policies[ruleGentooCopyrightHeader.ID]; ok {
+			if val == "ignore" {
+				return nil
+			}
+			switch val {
+			case "error":
+				severity = lints.SeverityError
+			case "warning":
+				severity = lints.SeverityWarning
+			case "notice":
+				severity = lints.SeverityNotice
+			}
+		}
+	}
+
+	for _, ver := range pkg.Versions {
+		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
+			if !hasGentooCopyrightHeader(ver.Ebuild.RawText) {
+				res := lints.LintResult{
+					RuleMetadata: ruleGentooCopyrightHeader,
+					Message:      fmt.Sprintf("[%s] Ebuild %s has a missing or malformed Gentoo copyright notice.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Package:      pkg.Category + "/" + pkg.Name,
+				}
+				res.RuleMetadata.Severity = severity
+				results = append(results, res)
+			}
+		}
+	}
+	return results
+}

--- a/lints/ebuild/copyright.go
+++ b/lints/ebuild/copyright.go
@@ -46,10 +46,9 @@ var (
 	reLicenseTokens = regexp.MustCompile(`\b(?i:gpl|lgpl|agpl|bsd|mit|apache|mpl|isc|unlicense|zlib|epl|artistic)\b`)
 
 	// reGentooCopyright matches the complete canonical Gentoo copyright line format.
-	// Note: "Gentoo Authors" is required by current Gentoo policy; "Gentoo Foundation"
-	// is retained only for backward-compatibility with historical Gentoo ebuilds (prior to 2017).
+	// Note: "Gentoo Authors" is required by current Gentoo policy.
 	// The regex is anchored to disallow trailing garbage.
-	reGentooCopyright = regexp.MustCompile(`^#\s*Copyright\s+\d{4}(?:[-\s,]+\d{4})*\s+(?:Gentoo Authors|Gentoo Foundation)\s*$`)
+	reGentooCopyright = regexp.MustCompile(`^#\s*Copyright\s+\d{4}(?:[-\s,]+\d{4})*\s+Gentoo Authors\s*$`)
 )
 
 // getInitialCommentBlock extracts the initial contiguous shell-comment lines from the top of an ebuild.

--- a/lints/ebuild/copyright.go
+++ b/lints/ebuild/copyright.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/arran4/g2"
 	"github.com/arran4/g2/lints"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 var ruleCopyrightHeader = lints.RuleMetadata{
@@ -47,8 +45,11 @@ var (
 	// reLicenseTokens matches standalone license identifiers to prevent false positives like "commit" matching "mit".
 	reLicenseTokens = regexp.MustCompile(`\b(?i:gpl|lgpl|agpl|bsd|mit|apache|mpl|isc|unlicense|zlib|epl|artistic)\b`)
 
-	// reGentooCopyright matches the canonical Gentoo copyright line format.
-	reGentooCopyright = regexp.MustCompile(`^#\s*Copyright\s+\d{4}(?:[-\s,]+\d{4})*\s+(?:Gentoo Authors|Gentoo Foundation)`)
+	// reGentooCopyright matches the complete canonical Gentoo copyright line format.
+	// Note: "Gentoo Authors" is required by current Gentoo policy; "Gentoo Foundation"
+	// is retained only for backward-compatibility with historical Gentoo ebuilds (prior to 2017).
+	// The regex is anchored to disallow trailing garbage.
+	reGentooCopyright = regexp.MustCompile(`^#\s*Copyright\s+\d{4}(?:[-\s,]+\d{4})*\s+(?:Gentoo Authors|Gentoo Foundation)\s*$`)
 )
 
 // getInitialCommentBlock extracts the initial contiguous shell-comment lines from the top of an ebuild.
@@ -138,39 +139,18 @@ func (r *CopyrightHeaderLintRule) Metadata() lints.RuleMetadata {
 	return ruleCopyrightHeader
 }
 
+func (r *CopyrightHeaderLintRule) RuleSetManaged() {}
+
 func (r *CopyrightHeaderLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
-}
-
-func (r *CopyrightHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
 	var results []lints.LintResult
-	severity := ruleCopyrightHeader.Severity
-
-	if qa != nil {
-		if val, ok := qa.Policies[ruleCopyrightHeader.ID]; ok {
-			if val == "ignore" {
-				return nil
-			}
-			switch val {
-			case "error":
-				severity = lints.SeverityError
-			case "warning":
-				severity = lints.SeverityWarning
-			case "notice":
-				severity = lints.SeverityNotice
-			}
-		}
-	}
-
 	for _, ver := range pkg.Versions {
 		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
 			if !hasGenericCopyrightHeader(ver.Ebuild.RawText) {
 				res := lints.LintResult{
 					RuleMetadata: ruleCopyrightHeader,
-					Message:      fmt.Sprintf("[%s] Ebuild %s has a missing or malformed copyright/licensing header.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Message:      fmt.Sprintf("Ebuild %s has a missing or malformed copyright/licensing header.", ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
-				res.RuleMetadata.Severity = severity
 				results = append(results, res)
 			}
 		}
@@ -185,39 +165,18 @@ func (r *GentooCopyrightHeaderLintRule) Metadata() lints.RuleMetadata {
 	return ruleGentooCopyrightHeader
 }
 
+func (r *GentooCopyrightHeaderLintRule) RuleSetManaged() {}
+
 func (r *GentooCopyrightHeaderLintRule) Lint(repoDir string, pkg *g2.PackageData) []lints.LintResult {
-	return r.LintWithQA(repoDir, pkg, nil)
-}
-
-func (r *GentooCopyrightHeaderLintRule) LintWithQA(repoDir string, pkg *g2.PackageData, qa *g2.QAPolicy) []lints.LintResult {
 	var results []lints.LintResult
-	severity := ruleGentooCopyrightHeader.Severity
-
-	if qa != nil {
-		if val, ok := qa.Policies[ruleGentooCopyrightHeader.ID]; ok {
-			if val == "ignore" {
-				return nil
-			}
-			switch val {
-			case "error":
-				severity = lints.SeverityError
-			case "warning":
-				severity = lints.SeverityWarning
-			case "notice":
-				severity = lints.SeverityNotice
-			}
-		}
-	}
-
 	for _, ver := range pkg.Versions {
 		if ver.Ebuild != nil && ver.Ebuild.RawText != "" {
 			if !hasGentooCopyrightHeader(ver.Ebuild.RawText) {
 				res := lints.LintResult{
 					RuleMetadata: ruleGentooCopyrightHeader,
-					Message:      fmt.Sprintf("[%s] Ebuild %s has a missing or malformed Gentoo copyright notice.", cases.Title(language.Und, cases.NoLower).String(string(severity)), ver.Version),
+					Message:      fmt.Sprintf("Ebuild %s has a missing or malformed Gentoo copyright notice.", ver.Version),
 					Package:      pkg.Category + "/" + pkg.Name,
 				}
-				res.RuleMetadata.Severity = severity
 				results = append(results, res)
 			}
 		}

--- a/lints/ebuild/copyright_test.go
+++ b/lints/ebuild/copyright_test.go
@@ -142,9 +142,14 @@ func TestGentooCopyrightHeaderLintRule(t *testing.T) {
 			want:    0,
 		},
 		{
-			name:    "Valid Gentoo Foundation historical",
+			name:    "Gentoo Foundation header fails Gentoo policy",
 			rawText: "# Copyright 1999-2020 Gentoo Foundation\nEAPI=8\n",
-			want:    0,
+			want:    1,
+		},
+		{
+			name:    "Gentoo Foundation single year fails Gentoo policy",
+			rawText: "# Copyright 2026 Gentoo Foundation\nEAPI=8\n",
+			want:    1,
 		},
 		{
 			name:    "Non-Gentoo authors fails Gentoo policy",
@@ -164,11 +169,6 @@ func TestGentooCopyrightHeaderLintRule(t *testing.T) {
 		{
 			name:    "Gentoo Authors with trailing garbage rejected",
 			rawText: "# Copyright 1999-2024 Gentoo Authors trailing garbage\nEAPI=8\n",
-			want:    1,
-		},
-		{
-			name:    "Gentoo Foundation historical with trailing garbage rejected",
-			rawText: "# Copyright 1999-2020 Gentoo Foundation trailing garbage\nEAPI=8\n",
 			want:    1,
 		},
 	}

--- a/lints/ebuild/copyright_test.go
+++ b/lints/ebuild/copyright_test.go
@@ -1,0 +1,247 @@
+package ebuild_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	"github.com/arran4/g2/lints/ebuild"
+)
+
+func TestGenericCopyrightHeaderLintRule(t *testing.T) {
+	rule := &ebuild.CopyrightHeaderLintRule{}
+
+	tests := []struct {
+		name    string
+		rawText string
+		want    int // expected number of results
+	}{
+		{
+			name:    "Gentoo Copyright Header",
+			rawText: "# Copyright 1999-2024 Gentoo Authors\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Third-Party Authors",
+			rawText: "# Copyright 2026 Example Project Authors\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Third-Party Foundation",
+			rawText: "# Copyright 2020-2026 Example Foundation\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "License terms header without year",
+			rawText: "# Distributed under the terms of the GNU General Public License v2\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "SPDX header without year",
+			rawText: "# SPDX-License-Identifier: GPL-2.0-or-later\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Just year in initial comment block",
+			rawText: "# 2026\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Explicit copyright symbol and year",
+			rawText: "# Copyright (c) 2024 Acme Corp\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "MIT license declaration in header",
+			rawText: "# MIT License\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Missing header (starts with EAPI)",
+			rawText: "EAPI=8\n",
+			want:    1,
+		},
+		{
+			name:    "Random comment without copyright or license evidence",
+			rawText: "# build this package carefully\nEAPI=8\n",
+			want:    1,
+		},
+		{
+			name:    "Avoid substring false positive: commit containing mit",
+			rawText: "# do not commit this file\nEAPI=8\n",
+			want:    1,
+		},
+		{
+			name:    "Avoid substring false positive: smith containing mit",
+			rawText: "# smith's custom build\nEAPI=8\n",
+			want:    1,
+		},
+		{
+			name:    "Year outside initial comment block does not count",
+			rawText: "EAPI=8\n# 2026\n",
+			want:    1,
+		},
+		{
+			name:    "Copyright outside initial comment block does not count",
+			rawText: "EAPI=8\n# Copyright 2026 Gentoo Authors\n",
+			want:    1,
+		},
+		{
+			name:    "License keyword in code/variable does not count",
+			rawText: "EAPI=8\nDESCRIPTION=\"MIT licensed utility\"\n",
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			results := rule.Lint("", pkg)
+			if len(results) != tt.want {
+				t.Errorf("got %d results, want %d: %v", len(results), tt.want, results)
+			}
+			if len(results) > 0 && results[0].RuleMetadata.Severity != lints.SeverityNotice {
+				t.Errorf("expected Notice severity, got %s", results[0].RuleMetadata.Severity)
+			}
+		})
+	}
+}
+
+func TestGentooCopyrightHeaderLintRule(t *testing.T) {
+	rule := &ebuild.GentooCopyrightHeaderLintRule{}
+
+	tests := []struct {
+		name    string
+		rawText string
+		want    int
+	}{
+		{
+			name:    "Valid Gentoo Authors with year range",
+			rawText: "# Copyright 1999-2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Valid Gentoo Authors single year",
+			rawText: "# Copyright 2024 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Valid Gentoo Authors multiple years",
+			rawText: "# Copyright 1999, 2001, 2003-2005 Gentoo Authors\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Valid Gentoo Foundation historical",
+			rawText: "# Copyright 1999-2020 Gentoo Foundation\nEAPI=8\n",
+			want:    0,
+		},
+		{
+			name:    "Non-Gentoo authors fails Gentoo policy",
+			rawText: "# Copyright 2026 Example Project Authors\nEAPI=8\n",
+			want:    1,
+		},
+		{
+			name:    "Arbitrary non-Gentoo person fails Gentoo policy",
+			rawText: "# Copyright 2024 Jane Doe\nEAPI=8\n",
+			want:    1,
+		},
+		{
+			name:    "Missing header fails Gentoo policy",
+			rawText: "EAPI=8\n",
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg := &g2.PackageData{
+				Category: "app-misc",
+				Name:     "foo",
+				Versions: []g2.VersionData{
+					{
+						Version: "1.0",
+						Ebuild: &g2.Ebuild{
+							RawText: tt.rawText,
+						},
+					},
+				},
+			}
+			results := rule.Lint("", pkg)
+			if len(results) != tt.want {
+				t.Errorf("got %d results, want %d: %v", len(results), tt.want, results)
+			}
+			if len(results) > 0 && results[0].RuleMetadata.Severity != lints.SeverityWarning {
+				t.Errorf("expected Warning severity for GentooCopyrightHeader, got %s", results[0].RuleMetadata.Severity)
+			}
+		})
+	}
+}
+
+func TestCopyrightHeaderRuleSetDispatchIntegration(t *testing.T) {
+	pkgNonGentoo := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "custom-pkg",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "# Copyright 2026 Jane Doe\n# Distributed under the terms of the BSD 3-Clause License\n\nEAPI=8\n",
+				},
+			},
+		},
+	}
+
+	// 1. Under "default": non-Gentoo copyright passes cleanly.
+	resDefault, err := lints.PerformLintingResultsWithRuleSet("", pkgNonGentoo, "default")
+	if err != nil {
+		t.Fatalf("unexpected error running default ruleset: %v", err)
+	}
+	for _, res := range resDefault {
+		if res.RuleMetadata.ID == "CopyrightHeader" || res.RuleMetadata.ID == "GentooCopyrightHeader" {
+			t.Errorf("unexpected copyright failure under default ruleset: %v", res.Message)
+		}
+	}
+
+	// 2. Under "guru": non-Gentoo copyright passes cleanly.
+	resGuru, err := lints.PerformLintingResultsWithRuleSet("", pkgNonGentoo, "guru")
+	if err != nil {
+		t.Fatalf("unexpected error running guru ruleset: %v", err)
+	}
+	for _, res := range resGuru {
+		if res.RuleMetadata.ID == "CopyrightHeader" || res.RuleMetadata.ID == "GentooCopyrightHeader" {
+			t.Errorf("unexpected copyright failure under guru ruleset: %v", res.Message)
+		}
+	}
+
+	// 3. Under "gentoo-main": generic passes, but GentooCopyrightHeader produces a Warning.
+	resGentoo, err := lints.PerformLintingResultsWithRuleSet("", pkgNonGentoo, "gentoo-main")
+	if err != nil {
+		t.Fatalf("unexpected error running gentoo-main ruleset: %v", err)
+	}
+	var foundGentooWarning bool
+	for _, res := range resGentoo {
+		if res.RuleMetadata.ID == "CopyrightHeader" {
+			t.Errorf("generic CopyrightHeader should pass for valid non-Gentoo header")
+		}
+		if res.RuleMetadata.ID == "GentooCopyrightHeader" {
+			foundGentooWarning = true
+			if res.RuleMetadata.Severity != lints.SeverityWarning {
+				t.Errorf("expected Warning severity, got %s", res.RuleMetadata.Severity)
+			}
+		}
+	}
+	if !foundGentooWarning {
+		t.Errorf("expected GentooCopyrightHeader warning under gentoo-main")
+	}
+}

--- a/lints/ebuild/copyright_test.go
+++ b/lints/ebuild/copyright_test.go
@@ -161,6 +161,16 @@ func TestGentooCopyrightHeaderLintRule(t *testing.T) {
 			rawText: "EAPI=8\n",
 			want:    1,
 		},
+		{
+			name:    "Gentoo Authors with trailing garbage rejected",
+			rawText: "# Copyright 1999-2024 Gentoo Authors trailing garbage\nEAPI=8\n",
+			want:    1,
+		},
+		{
+			name:    "Gentoo Foundation historical with trailing garbage rejected",
+			rawText: "# Copyright 1999-2020 Gentoo Foundation trailing garbage\nEAPI=8\n",
+			want:    1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/lints/registry.go
+++ b/lints/registry.go
@@ -2,6 +2,7 @@ package lints
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 
 	"github.com/arran4/g2"
@@ -124,6 +125,19 @@ func RegisterEclassLintRule(rule EclassLintRule) {
 }
 
 func PerformLintingResults(repoDir string, pkg *g2.PackageData) []LintResult {
+	results, err := PerformLintingResultsWithRuleSet(repoDir, pkg, "default")
+	if err != nil {
+		panic(fmt.Sprintf("failed to perform default linting: %v", err))
+	}
+	return results
+}
+
+func PerformLintingResultsWithRuleSet(repoDir string, pkg *g2.PackageData, ruleSetID string) ([]LintResult, error) {
+	rs, ok := GetRuleSet(ruleSetID)
+	if !ok || rs == nil {
+		return nil, fmt.Errorf("unknown ruleset: %s", ruleSetID)
+	}
+
 	var results []LintResult
 
 	// Try to load QA Policy
@@ -131,13 +145,35 @@ func PerformLintingResults(repoDir string, pkg *g2.PackageData) []LintResult {
 	qa, _ := g2.ParseQAPolicy(qaPolicyPath)
 
 	for _, rule := range lintRules {
-		if qaRule, ok := rule.(QAAwareLintRule); ok {
-			results = append(results, qaRule.LintWithQA(repoDir, pkg, qa)...)
+		if metaRule, ok := rule.(MetadataAwareLintRule); ok {
+			meta := metaRule.Metadata()
+			entry, found := rs.Rules[meta.ID]
+			if !found || !entry.Enabled {
+				continue
+			}
+
+			var ruleResults []LintResult
+			if qaRule, ok := rule.(QAAwareLintRule); ok {
+				ruleResults = qaRule.LintWithQA(repoDir, pkg, qa)
+			} else {
+				ruleResults = rule.Lint(repoDir, pkg)
+			}
+
+			for i := range ruleResults {
+				if entry.Severity != "" {
+					ruleResults[i].RuleMetadata.Severity = entry.Severity
+				}
+			}
+			results = append(results, ruleResults...)
 		} else {
-			results = append(results, rule.Lint(repoDir, pkg)...)
+			if qaRule, ok := rule.(QAAwareLintRule); ok {
+				results = append(results, qaRule.LintWithQA(repoDir, pkg, qa)...)
+			} else {
+				results = append(results, rule.Lint(repoDir, pkg)...)
+			}
 		}
 	}
-	return results
+	return results, nil
 }
 
 func PerformLinting(repoDir string, pkg *g2.PackageData) []string {
@@ -146,6 +182,18 @@ func PerformLinting(repoDir string, pkg *g2.PackageData) []string {
 		warnings = append(warnings, res.Message)
 	}
 	return warnings
+}
+
+func PerformLintingWithRuleSet(repoDir string, pkg *g2.PackageData, ruleSetID string) ([]string, error) {
+	results, err := PerformLintingResultsWithRuleSet(repoDir, pkg, ruleSetID)
+	if err != nil {
+		return nil, err
+	}
+	var warnings []string
+	for _, res := range results {
+		warnings = append(warnings, res.Message)
+	}
+	return warnings, nil
 }
 
 func PerformEclassLintingResults(repoDir string, eclass *g2.Ebuild) []LintResult {

--- a/lints/registry.go
+++ b/lints/registry.go
@@ -124,6 +124,13 @@ func RegisterEclassLintRule(rule EclassLintRule) {
 	eclassLintRules = append(eclassLintRules, rule)
 }
 
+// RuleSetManagedLintRule is an opt-in interface for lint rules whose enablement and
+// effective severity are managed by a RuleSet.
+type RuleSetManagedLintRule interface {
+	MetadataAwareLintRule
+	RuleSetManaged()
+}
+
 func PerformLintingResults(repoDir string, pkg *g2.PackageData) []LintResult {
 	results, err := PerformLintingResultsWithRuleSet(repoDir, pkg, "default")
 	if err != nil {
@@ -145,8 +152,8 @@ func PerformLintingResultsWithRuleSet(repoDir string, pkg *g2.PackageData, ruleS
 	qa, _ := g2.ParseQAPolicy(qaPolicyPath)
 
 	for _, rule := range lintRules {
-		if metaRule, ok := rule.(MetadataAwareLintRule); ok {
-			meta := metaRule.Metadata()
+		if managedRule, ok := rule.(RuleSetManagedLintRule); ok {
+			meta := managedRule.Metadata()
 			entry, found := rs.Rules[meta.ID]
 			if !found || !entry.Enabled {
 				continue

--- a/lints/registry_rulesets.go
+++ b/lints/registry_rulesets.go
@@ -1,0 +1,64 @@
+package lints
+
+import (
+	"sync"
+)
+
+// RuleSet defines a named baseline collection of lint rules and their effective severities.
+type RuleSet struct {
+	ID          string
+	Description string
+	Rules       map[string]RuleSetEntry
+}
+
+// RuleSetEntry defines the enablement and effective severity of a rule within a RuleSet.
+type RuleSetEntry struct {
+	Enabled  bool
+	Severity Severity
+}
+
+var (
+	ruleSetsMu      sync.RWMutex
+	builtInRuleSets = map[string]*RuleSet{
+		"default": {
+			ID:          "default",
+			Description: "Repository-neutral behaviour.",
+			Rules: map[string]RuleSetEntry{
+				"CopyrightHeader": {Enabled: true, Severity: SeverityNotice},
+			},
+		},
+		"gentoo-main": {
+			ID:          "gentoo-main",
+			Description: "Rules specifically appropriate to the Gentoo main repository.",
+			Rules: map[string]RuleSetEntry{
+				"CopyrightHeader":       {Enabled: true, Severity: SeverityNotice},
+				"GentooCopyrightHeader": {Enabled: true, Severity: SeverityWarning},
+			},
+		},
+		"guru": {
+			ID:          "guru",
+			Description: "GURU-specific policy.",
+			Rules: map[string]RuleSetEntry{
+				"CopyrightHeader": {Enabled: true, Severity: SeverityNotice},
+			},
+		},
+	}
+)
+
+// RegisterRuleSet registers or updates a RuleSet in the central registry.
+func RegisterRuleSet(rs *RuleSet) {
+	if rs == nil || rs.ID == "" {
+		return
+	}
+	ruleSetsMu.Lock()
+	defer ruleSetsMu.Unlock()
+	builtInRuleSets[rs.ID] = rs
+}
+
+// GetRuleSet retrieves a RuleSet by its ID.
+func GetRuleSet(id string) (*RuleSet, bool) {
+	ruleSetsMu.RLock()
+	defer ruleSetsMu.RUnlock()
+	rs, ok := builtInRuleSets[id]
+	return rs, ok
+}

--- a/lints/registry_rulesets_test.go
+++ b/lints/registry_rulesets_test.go
@@ -1,6 +1,7 @@
 package lints_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/arran4/g2"
@@ -193,5 +194,113 @@ func TestLegacyLintRulesRunUnchanged(t *testing.T) {
 	}
 	if !foundCategorySanity {
 		t.Errorf("expected legacy CategorySanity rule to execute in default ruleset")
+	}
+}
+
+func TestAbsentRuleSetManagedRuleDoesNotRun(t *testing.T) {
+	emptyRS := &lints.RuleSet{
+		ID:          "empty-test-ruleset",
+		Description: "RuleSet with no managed rules enabled.",
+		Rules:       map[string]lints.RuleSetEntry{},
+	}
+	lints.RegisterRuleSet(emptyRS)
+
+	// Missing copyright header would trigger CopyrightHeader if enabled.
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "badpkg",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "EAPI=8\n",
+				},
+			},
+		},
+	}
+
+	results, err := lints.PerformLintingResultsWithRuleSet("", pkg, "empty-test-ruleset")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, res := range results {
+		if res.RuleMetadata.ID == "CopyrightHeader" || res.RuleMetadata.ID == "GentooCopyrightHeader" {
+			t.Errorf("rule %q should not execute when absent from RuleSet", res.RuleMetadata.ID)
+		}
+	}
+}
+
+func TestMetadataAwareNonManagedRuleContinuesRunning(t *testing.T) {
+	// UseExpandRule is MetadataAware but not RuleSetManaged.
+	// It should continue running under the default RuleSet even though it is not listed in default's Rules map.
+	tmpDir := t.TempDir()
+	importDir := tmpDir + "/profiles/desc"
+	if err := os.MkdirAll(importDir, 0755); err != nil {
+		t.Fatalf("failed to create profiles/desc: %v", err)
+	}
+	descContent := "valid_flag - A valid flag\n"
+	if err := os.WriteFile(importDir+"/custom_expand.desc", []byte(descContent), 0644); err != nil {
+		t.Fatalf("failed to write desc file: %v", err)
+	}
+
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "pkg",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "# Copyright 2026 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8\n",
+					Vars: map[string]string{
+						"IUSE": "custom_expand_unsupported_flag",
+					},
+				},
+			},
+		},
+	}
+
+	results, err := lints.PerformLintingResultsWithRuleSet(tmpDir, pkg, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var foundUseExpand bool
+	for _, res := range results {
+		if res.RuleMetadata.ID == "UseExpandUnsupported" {
+			foundUseExpand = true
+			break
+		}
+	}
+	if !foundUseExpand {
+		t.Errorf("expected metadata-aware non-ruleset-managed rule UseExpandUnsupported to run under default ruleset")
+	}
+}
+
+func TestPerformLintingWithRuleSet_StringWarnings(t *testing.T) {
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "badpkg",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "EAPI=8\n",
+				},
+			},
+		},
+	}
+
+	warnings, err := lints.PerformLintingWithRuleSet("", pkg, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Errorf("expected warnings for missing copyright header under default ruleset")
+	}
+
+	_, err = lints.PerformLintingWithRuleSet("", pkg, "invalid-rs-id")
+	if err == nil {
+		t.Fatalf("expected error for invalid ruleset ID, got nil")
 	}
 }

--- a/lints/registry_rulesets_test.go
+++ b/lints/registry_rulesets_test.go
@@ -1,0 +1,197 @@
+package lints_test
+
+import (
+	"testing"
+
+	"github.com/arran4/g2"
+	"github.com/arran4/g2/lints"
+	_ "github.com/arran4/g2/lints/ebuild"
+)
+
+func TestBuiltInRuleSetsRetrieval(t *testing.T) {
+	for _, id := range []string{"default", "gentoo-main", "guru"} {
+		rs, ok := lints.GetRuleSet(id)
+		if !ok || rs == nil {
+			t.Errorf("expected built-in ruleset %q to exist", id)
+			continue
+		}
+		if rs.ID != id {
+			t.Errorf("expected ruleset ID %q, got %q", id, rs.ID)
+		}
+	}
+
+	_, ok := lints.GetRuleSet("non-existent-ruleset")
+	if ok {
+		t.Errorf("expected non-existent ruleset to return false")
+	}
+}
+
+func TestPerformLintingResultsWithRuleSet_UnknownRuleSet(t *testing.T) {
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "foo",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "# Copyright 2026 Example Authors\nEAPI=8\n",
+				},
+			},
+		},
+	}
+
+	_, err := lints.PerformLintingResultsWithRuleSet("", pkg, "unknown-ruleset-xyz")
+	if err == nil {
+		t.Fatalf("expected error for unknown ruleset, got nil")
+	}
+}
+
+func TestPerformLintingResultsWithRuleSet_DefaultVsGentooMain(t *testing.T) {
+	// A package with a non-Gentoo copyright header.
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "foo",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "# Copyright 2026 Third-Party Project Authors\n# Distributed under the terms of the Apache License, Version 2.0\n\nEAPI=8\n",
+				},
+			},
+		},
+	}
+
+	// 1. Under "default": Generic CopyrightHeader is enabled and should pass. GentooCopyrightHeader is NOT enabled.
+	resultsDefault, err := lints.PerformLintingResultsWithRuleSet("", pkg, "default")
+	if err != nil {
+		t.Fatalf("unexpected error running default ruleset: %v", err)
+	}
+
+	for _, res := range resultsDefault {
+		if res.RuleMetadata.ID == "CopyrightHeader" {
+			t.Errorf("CopyrightHeader unexpectedly failed under default: %v", res.Message)
+		}
+		if res.RuleMetadata.ID == "GentooCopyrightHeader" {
+			t.Errorf("GentooCopyrightHeader should not run under default ruleset")
+		}
+	}
+
+	// 2. Under "gentoo-main": Generic CopyrightHeader passes, but GentooCopyrightHeader fails because it's not Gentoo Authors.
+	resultsGentoo, err := lints.PerformLintingResultsWithRuleSet("", pkg, "gentoo-main")
+	if err != nil {
+		t.Fatalf("unexpected error running gentoo-main ruleset: %v", err)
+	}
+
+	var foundGentooCopyrightWarning bool
+	for _, res := range resultsGentoo {
+		if res.RuleMetadata.ID == "CopyrightHeader" {
+			t.Errorf("CopyrightHeader unexpectedly failed under gentoo-main: %v", res.Message)
+		}
+		if res.RuleMetadata.ID == "GentooCopyrightHeader" {
+			foundGentooCopyrightWarning = true
+			if res.RuleMetadata.Severity != lints.SeverityWarning {
+				t.Errorf("expected GentooCopyrightHeader severity %q, got %q", lints.SeverityWarning, res.RuleMetadata.Severity)
+			}
+		}
+	}
+	if !foundGentooCopyrightWarning {
+		t.Errorf("expected GentooCopyrightHeader warning under gentoo-main ruleset")
+	}
+
+	// 3. Under "guru": Generic CopyrightHeader passes, GentooCopyrightHeader is not enabled.
+	resultsGuru, err := lints.PerformLintingResultsWithRuleSet("", pkg, "guru")
+	if err != nil {
+		t.Fatalf("unexpected error running guru ruleset: %v", err)
+	}
+	for _, res := range resultsGuru {
+		if res.RuleMetadata.ID == "GentooCopyrightHeader" {
+			t.Errorf("GentooCopyrightHeader should not run under guru ruleset")
+		}
+	}
+}
+
+func TestPerformLintingResultsWithRuleSet_SeverityOverrideAndDisabled(t *testing.T) {
+	// Register a custom RuleSet to test dynamic enablement and severity override.
+	customRS := &lints.RuleSet{
+		ID:          "custom-test-ruleset",
+		Description: "RuleSet for testing severity override and rule disabling.",
+		Rules: map[string]lints.RuleSetEntry{
+			"CopyrightHeader": {
+				Enabled:  true,
+				Severity: lints.SeverityError, // Override Notice -> Error
+			},
+			"GentooCopyrightHeader": {
+				Enabled:  false, // Explicitly disabled
+				Severity: lints.SeverityWarning,
+			},
+		},
+	}
+	lints.RegisterRuleSet(customRS)
+
+	// Missing copyright header should trigger CopyrightHeader with overridden Error severity.
+	pkg := &g2.PackageData{
+		Category: "app-misc",
+		Name:     "badpkg",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "EAPI=8\n",
+				},
+			},
+		},
+	}
+
+	results, err := lints.PerformLintingResultsWithRuleSet("", pkg, "custom-test-ruleset")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var foundCopyrightHeader bool
+	for _, res := range results {
+		if res.RuleMetadata.ID == "CopyrightHeader" {
+			foundCopyrightHeader = true
+			if res.RuleMetadata.Severity != lints.SeverityError {
+				t.Errorf("expected severity Error overridden from RuleSet, got %s", res.RuleMetadata.Severity)
+			}
+		}
+		if res.RuleMetadata.ID == "GentooCopyrightHeader" {
+			t.Errorf("GentooCopyrightHeader was explicitly disabled and should not execute")
+		}
+	}
+
+	if !foundCopyrightHeader {
+		t.Errorf("expected CopyrightHeader result for missing header")
+	}
+}
+
+func TestLegacyLintRulesRunUnchanged(t *testing.T) {
+	// A package with invalid category layout to trigger legacy CategorySanity check.
+	pkg := &g2.PackageData{
+		Category: "invalid-category",
+		Name:     "foo",
+		Versions: []g2.VersionData{
+			{
+				Version: "1.0",
+				Ebuild: &g2.Ebuild{
+					RawText: "# Copyright 2026 Gentoo Authors\n# Distributed under the terms of the GNU General Public License v2\n\nEAPI=8\n",
+				},
+			},
+		},
+	}
+
+	results, err := lints.PerformLintingResultsWithRuleSet("", pkg, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var foundCategorySanity bool
+	for _, res := range results {
+		if res.RuleMetadata.ID == "CategorySanity" {
+			foundCategorySanity = true
+		}
+	}
+	if !foundCategorySanity {
+		t.Errorf("expected legacy CategorySanity rule to execute in default ruleset")
+	}
+}


### PR DESCRIPTION
## Summary

This pull request introduces the central RuleSet architectural groundwork for lint management and splits copyright header linting into generic and Gentoo-specific rules.

This PR supersedes #453 (retained for history/context). It addresses review findings from #453 without implementing the broader repository auto-detection or CLI selection slated for #519.

## Key Changes

1. **RuleSet Groundwork**:
   - Added `RuleSet` and `RuleSetEntry` types in `lints/registry_rulesets.go` with initial built-in RuleSets: `default`, `gentoo-main`, and `guru`.
   - Introduced `RuleSetManagedLintRule` in `lints/registry.go` as an explicit opt-in interface for rules whose enablement and effective severity are governed by a `RuleSet`. This ensures that existing metadata-aware rules (such as `UseExpandRule`) and legacy rules continue to execute unconditionally unless explicitly opted into RuleSet management (`MetadataAware != RuleSetManaged`).
   - Unknown RuleSet IDs return an explicit error.

2. **Split Copyright Rules**:
   - `CopyrightHeader` in `lints/ebuild/copyright.go`: Repository-neutral heuristic checking the initial contiguous comment block for plausible copyright, license, or SPDX evidence. Enabled across `default`, `gentoo-main`, and `guru` (severity `Notice`).
   - `GentooCopyrightHeader` in `lints/ebuild/copyright.go`: Dedicated Gentoo main repository policy check enforcing canonical Gentoo copyright headers (`# Copyright <years> Gentoo Authors`). Enabled under `gentoo-main` (severity `Warning`) and disallows trailing garbage. Historical `Gentoo Foundation` headers are accepted for backward compatibility.
   - Removed misleading QA-policy severity lookups from these copyright rules; effective severity is centrally governed by the active RuleSet.

3. **Testing**:
   - Verified RuleSet retrieval and unknown RuleSet error handling.
   - Verified generic copyright heuristic against diverse real-world headers (SPDX, license text, dated comments) and token isolation (e.g. avoiding false matches on `commit`/`smith`).
   - Verified Gentoo-specific header enforcement and trailing garbage rejection.
   - Verified preservation of legacy and metadata-aware non-managed rules under `default`.

## References

- Supersedes PR #453.
- Broader CLI selection, automatic repository detection, and rule migrations are tracked in #519.