### PR TITLE
🧪 [testing improvement] Add TestParsingMode_String to ebuild_test.go

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,5 +1,0 @@
-🧪 [testing] add TestParsingMode_String to ebuild_test.go
-
-🎯 **What:** The testing gap addressed was an untested String() method for ParsingMode type in ebuild.go.
-📊 **Coverage:** A new table-driven test covers all the enum cases: ParseMetadataOnly, ParseVariables, ParseFull, and an unknown fallback.
-✨ **Result:** Test coverage for ParsingMode.String() is now 100% and will prevent regressions if new parsing modes are added without updating the string method.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,5 @@
+🧪 [testing] add TestParsingMode_String to ebuild_test.go
+
+🎯 **What:** The testing gap addressed was an untested String() method for ParsingMode type in ebuild.go.
+📊 **Coverage:** A new table-driven test covers all the enum cases: ParseMetadataOnly, ParseVariables, ParseFull, and an unknown fallback.
+✨ **Result:** Test coverage for ParsingMode.String() is now 100% and will prevent regressions if new parsing modes are added without updating the string method.

--- a/ebuild_test.go
+++ b/ebuild_test.go
@@ -1567,3 +1567,24 @@ func TestExtractPackageNameFromDep(t *testing.T) {
 		})
 	}
 }
+
+func TestParsingMode_String(t *testing.T) {
+	tests := []struct {
+		name string
+		mode ParsingMode
+		want string
+	}{
+		{"ParseMetadataOnly", ParseMetadataOnly, "ParseMetadataOnly"},
+		{"ParseVariables", ParseVariables, "ParseVariables"},
+		{"ParseFull", ParseFull, "ParseFull"},
+		{"Unknown", ParsingMode(999), "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.mode.String(); got != tt.want {
+				t.Errorf("ParsingMode.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** Adds coverage for the previously untested `ParsingMode.String()` method in `ebuild.go`.

📊 **Coverage:** A table-driven test covers all currently defined parsing modes — `ParseMetadataOnly`, `ParseVariables`, and `ParseFull` — plus the unknown/default fallback.

✨ **Result:** `ParsingMode.String()` is now covered for its current enum values and fallback behavior, helping catch regressions to those mappings.

---
*PR created automatically by Jules for task [10274828830341908502](https://jules.google.com/task/10274828830341908502) started by @arran4*