### PR TITLE
🧪 Add test for ParsePackageMaskedFS

### DIFF
--- a/package_mask_test.go
+++ b/package_mask_test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"reflect"
 	"testing"
+	"testing/fstest"
 )
 
 //go:embed testdata/package.mask
@@ -90,5 +91,59 @@ func TestSerializePackageMasked(t *testing.T) {
 		if !reflect.DeepEqual(parsed[i], data[i]) {
 			t.Errorf("mismatch after serialization at index %d:\nExpected: %+v\nGot:      %+v", i, data[i], parsed[i])
 		}
+	}
+}
+
+func TestParsePackageMaskedFS(t *testing.T) {
+	mockFS := fstest.MapFS{
+		"profiles/package.mask": &fstest.MapFile{
+			Data: []byte(packageMaskTestInput),
+		},
+	}
+
+	expected := []PackageMasked{
+		{
+			Reason:      "Backwards compatibility package for pkg_resources that have been removed from >=dev-python/setuptools-82. Please migrate to importlib.{metadata,resources} and/or dev-python/packaging.",
+			Date:        "2026-03-25",
+			Author:      "Jane Doe",
+			AuthorEmail: "jane.doe@example.com",
+			Entries: []PackageMaskedEntry{
+				{Package: "dev-python/pkg-resources"},
+			},
+		},
+		{
+			Reason:      "The package has turned into complete AI slop. Every subsequent release introduces serious quality issues, and potential security concerns. Please ask upstreams to move away from it.",
+			Date:        "2025-11-25",
+			Author:      "John Smith",
+			AuthorEmail: "john.smith@example.com",
+			Entries: []PackageMaskedEntry{
+				{Package: "dev-python/autobahn"},
+			},
+		},
+	}
+
+	// Test successful parse
+	res, err := ParsePackageMaskedFS(mockFS, "profiles/package.mask")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != len(expected) {
+		t.Fatalf("expected %d entries, got %d", len(expected), len(res))
+	}
+
+	for i := range expected {
+		if !reflect.DeepEqual(res[i], expected[i]) {
+			t.Errorf("mismatch at index %d:\nExpected: %+v\nGot: %+v", i, expected[i], res[i])
+		}
+	}
+
+	// Test missing file
+	res, err = ParsePackageMaskedFS(mockFS, "missing/package.mask")
+	if err != nil {
+		t.Fatalf("unexpected error for missing file: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected nil result for missing file, got %v", res)
 	}
 }


### PR DESCRIPTION
🎯 **What:** The `ParsePackageMaskedFS` function in `package_mask.go` was previously untested. This function parses a package mask file using Go's `io/fs` filesystem interface. 

📊 **Coverage:** A new test `TestParsePackageMaskedFS` has been added to `package_mask_test.go` that uses `testing/fstest.MapFS` to mock a virtual file system. 
The test covers:
- The happy path (parsing a valid `profiles/package.mask` file successfully).
- The missing file error path (returning `nil, nil` when the file does not exist, verifying correct handling of `os.IsNotExist`).

✨ **Result:** Test coverage for `package_mask.go` has been improved, and regressions in filesystem-based masked package parsing will be caught in automated tests going forward.

---
*PR created automatically by Jules for task [16151786020030118425](https://jules.google.com/task/16151786020030118425) started by @arran4*