### PR TITLE
🧪 Test ParseProjectsFromReader read errors

### DIFF
--- a/cmd/g2/lint_changed_test.go
+++ b/cmd/g2/lint_changed_test.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
-
 )
 
 func TestGetGitModifiedPackagesChanged(t *testing.T) {
@@ -36,9 +35,13 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 
 	// 2. Initial state
 	err = os.MkdirAll(filepath.Join(tmpDir, "app-misc", "foo"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, "app-misc", "foo", "foo-1.ebuild"), []byte(""), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	runCmd("git", "add", ".")
 	runCmd("git", "commit", "-m", "Initial commit")
@@ -53,44 +56,70 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 
 	// 4. Create an unstaged modification
 	err = os.WriteFile(filepath.Join(tmpDir, "app-misc", "foo", "foo-1.ebuild"), []byte("modified"), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// 5. Create a staged modification (rename/add)
 	err = os.MkdirAll(filepath.Join(tmpDir, "dev-util", "bar"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, "dev-util", "bar", "bar-2.ebuild"), []byte("staged"), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	runCmd("git", "add", "dev-util/bar/bar-2.ebuild")
 
 	// 6. Create an untracked file
 	err = os.MkdirAll(filepath.Join(tmpDir, "sys-apps", "baz"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, "sys-apps", "baz", "baz-3.ebuild"), []byte("untracked"), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// 7. Whitespace filename
 	err = os.MkdirAll(filepath.Join(tmpDir, "sys-apps", "white space"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, "sys-apps", "white space", "white space-3.ebuild"), []byte("untracked whitespace"), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// 8. Repository metadata change (should be ignored)
 	err = os.MkdirAll(filepath.Join(tmpDir, "metadata"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, "metadata", "layout.conf"), []byte(""), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Also some random infra file
 	err = os.MkdirAll(filepath.Join(tmpDir, ".github", "workflows"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, ".github", "workflows", "ci.yml"), []byte(""), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// And a script path that isn't a category
 	err = os.MkdirAll(filepath.Join(tmpDir, "scripts", "foo"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, "scripts", "foo", "bar"), []byte(""), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Run without explicit base (no upstream configured)
 	pkgs, err := getGitModifiedPackagesChanged(tmpDir, "")
@@ -103,10 +132,18 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 		foundMap[p] = true
 	}
 
-	if !foundMap["app-misc/foo"] { t.Errorf("Missing unstaged app-misc/foo") }
-	if !foundMap["dev-util/bar"] { t.Errorf("Missing staged dev-util/bar") }
-	if !foundMap["sys-apps/baz"] { t.Errorf("Missing untracked sys-apps/baz") }
-	if !foundMap["sys-apps/white space"] { t.Errorf("Missing whitespace sys-apps/white space") }
+	if !foundMap["app-misc/foo"] {
+		t.Errorf("Missing unstaged app-misc/foo")
+	}
+	if !foundMap["dev-util/bar"] {
+		t.Errorf("Missing staged dev-util/bar")
+	}
+	if !foundMap["sys-apps/baz"] {
+		t.Errorf("Missing untracked sys-apps/baz")
+	}
+	if !foundMap["sys-apps/white space"] {
+		t.Errorf("Missing whitespace sys-apps/white space")
+	}
 	if foundMap["metadata/layout.conf"] || foundMap["metadata"] || foundMap[".github/workflows"] || foundMap["scripts/foo"] {
 		t.Errorf("Should not include non-package infrastructure files as packages")
 	}
@@ -114,14 +151,18 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	// 9. Committed branch change with upstream
 	runCmd("git", "checkout", "-b", "feature")
 	err = os.WriteFile(filepath.Join(tmpDir, "sys-apps", "baz", "baz-3.ebuild"), []byte("committed"), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	runCmd("git", "add", "sys-apps/baz/baz-3.ebuild")
 	runCmd("git", "commit", "-m", "Add baz")
 	runCmd("git", "branch", "--set-upstream-to=main", "feature")
 
 	// 10. Genuine git rename
 	err = os.MkdirAll(filepath.Join(tmpDir, "app-misc", "foo2"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	runCmd("git", "mv", "app-misc/foo/foo-1.ebuild", "app-misc/foo2/foo-1.ebuild")
 
 	// 11. Explicit base
@@ -133,18 +174,30 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	for _, p := range pkgs {
 		foundMap[p] = true
 	}
-	if !foundMap["sys-apps/baz"] { t.Errorf("Missing committed sys-apps/baz against explicit base main") }
+	if !foundMap["sys-apps/baz"] {
+		t.Errorf("Missing committed sys-apps/baz against explicit base main")
+	}
 
-	if foundMap["app-misc/foo"] { t.Errorf("Vanished rename source app-misc/foo should not be returned") }
-	if !foundMap["app-misc/foo2"] { t.Errorf("Missing rename destination app-misc/foo2") }
+	if foundMap["app-misc/foo"] {
+		t.Errorf("Vanished rename source app-misc/foo should not be returned")
+	}
+	if !foundMap["app-misc/foo2"] {
+		t.Errorf("Missing rename destination app-misc/foo2")
+	}
 
 	// 12. Deleting final ebuild leaves stale metadata.xml
 	err = os.MkdirAll(filepath.Join(tmpDir, "dev-util", "stale"), 0755)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, "dev-util", "stale", "metadata.xml"), []byte(""), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = os.WriteFile(filepath.Join(tmpDir, "dev-util", "stale", "stale-1.ebuild"), []byte(""), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	runCmd("git", "add", "dev-util/stale")
 	runCmd("git", "commit", "-m", "Add stale package")
@@ -159,11 +212,15 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	for _, p := range pkgs {
 		foundMap[p] = true
 	}
-	if foundMap["dev-util/stale"] { t.Errorf("Package with deleted final ebuild should not be selected") }
+	if foundMap["dev-util/stale"] {
+		t.Errorf("Package with deleted final ebuild should not be selected")
+	}
 
 	// 13. Deleting one file but another ebuild remains
 	err = os.WriteFile(filepath.Join(tmpDir, "dev-util", "bar", "bar-3.ebuild"), []byte("new file"), 0644)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	runCmd("git", "add", "dev-util/bar/bar-3.ebuild")
 	runCmd("git", "commit", "-m", "Add another ebuild to bar")
@@ -177,7 +234,9 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	for _, p := range pkgs {
 		foundMap[p] = true
 	}
-	if !foundMap["dev-util/bar"] { t.Errorf("Package with deleted ebuild but remaining ebuilds should be selected") }
+	if !foundMap["dev-util/bar"] {
+		t.Errorf("Package with deleted ebuild but remaining ebuilds should be selected")
+	}
 
 	// Test deterministic order
 	isSorted := true

--- a/cmd/g2/lint_changed_test.go
+++ b/cmd/g2/lint_changed_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
 )
 
 func TestGetGitModifiedPackagesChanged(t *testing.T) {
@@ -35,13 +36,9 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 
 	// 2. Initial state
 	err = os.MkdirAll(filepath.Join(tmpDir, "app-misc", "foo"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, "app-misc", "foo", "foo-1.ebuild"), []byte(""), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	runCmd("git", "add", ".")
 	runCmd("git", "commit", "-m", "Initial commit")
@@ -56,70 +53,44 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 
 	// 4. Create an unstaged modification
 	err = os.WriteFile(filepath.Join(tmpDir, "app-misc", "foo", "foo-1.ebuild"), []byte("modified"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	// 5. Create a staged modification (rename/add)
 	err = os.MkdirAll(filepath.Join(tmpDir, "dev-util", "bar"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, "dev-util", "bar", "bar-2.ebuild"), []byte("staged"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	runCmd("git", "add", "dev-util/bar/bar-2.ebuild")
 
 	// 6. Create an untracked file
 	err = os.MkdirAll(filepath.Join(tmpDir, "sys-apps", "baz"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, "sys-apps", "baz", "baz-3.ebuild"), []byte("untracked"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	// 7. Whitespace filename
 	err = os.MkdirAll(filepath.Join(tmpDir, "sys-apps", "white space"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, "sys-apps", "white space", "white space-3.ebuild"), []byte("untracked whitespace"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	// 8. Repository metadata change (should be ignored)
 	err = os.MkdirAll(filepath.Join(tmpDir, "metadata"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, "metadata", "layout.conf"), []byte(""), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	// Also some random infra file
 	err = os.MkdirAll(filepath.Join(tmpDir, ".github", "workflows"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, ".github", "workflows", "ci.yml"), []byte(""), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	// And a script path that isn't a category
 	err = os.MkdirAll(filepath.Join(tmpDir, "scripts", "foo"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, "scripts", "foo", "bar"), []byte(""), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	// Run without explicit base (no upstream configured)
 	pkgs, err := getGitModifiedPackagesChanged(tmpDir, "")
@@ -132,18 +103,10 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 		foundMap[p] = true
 	}
 
-	if !foundMap["app-misc/foo"] {
-		t.Errorf("Missing unstaged app-misc/foo")
-	}
-	if !foundMap["dev-util/bar"] {
-		t.Errorf("Missing staged dev-util/bar")
-	}
-	if !foundMap["sys-apps/baz"] {
-		t.Errorf("Missing untracked sys-apps/baz")
-	}
-	if !foundMap["sys-apps/white space"] {
-		t.Errorf("Missing whitespace sys-apps/white space")
-	}
+	if !foundMap["app-misc/foo"] { t.Errorf("Missing unstaged app-misc/foo") }
+	if !foundMap["dev-util/bar"] { t.Errorf("Missing staged dev-util/bar") }
+	if !foundMap["sys-apps/baz"] { t.Errorf("Missing untracked sys-apps/baz") }
+	if !foundMap["sys-apps/white space"] { t.Errorf("Missing whitespace sys-apps/white space") }
 	if foundMap["metadata/layout.conf"] || foundMap["metadata"] || foundMap[".github/workflows"] || foundMap["scripts/foo"] {
 		t.Errorf("Should not include non-package infrastructure files as packages")
 	}
@@ -151,18 +114,14 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	// 9. Committed branch change with upstream
 	runCmd("git", "checkout", "-b", "feature")
 	err = os.WriteFile(filepath.Join(tmpDir, "sys-apps", "baz", "baz-3.ebuild"), []byte("committed"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	runCmd("git", "add", "sys-apps/baz/baz-3.ebuild")
 	runCmd("git", "commit", "-m", "Add baz")
 	runCmd("git", "branch", "--set-upstream-to=main", "feature")
 
 	// 10. Genuine git rename
 	err = os.MkdirAll(filepath.Join(tmpDir, "app-misc", "foo2"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	runCmd("git", "mv", "app-misc/foo/foo-1.ebuild", "app-misc/foo2/foo-1.ebuild")
 
 	// 11. Explicit base
@@ -174,30 +133,18 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	for _, p := range pkgs {
 		foundMap[p] = true
 	}
-	if !foundMap["sys-apps/baz"] {
-		t.Errorf("Missing committed sys-apps/baz against explicit base main")
-	}
+	if !foundMap["sys-apps/baz"] { t.Errorf("Missing committed sys-apps/baz against explicit base main") }
 
-	if foundMap["app-misc/foo"] {
-		t.Errorf("Vanished rename source app-misc/foo should not be returned")
-	}
-	if !foundMap["app-misc/foo2"] {
-		t.Errorf("Missing rename destination app-misc/foo2")
-	}
+	if foundMap["app-misc/foo"] { t.Errorf("Vanished rename source app-misc/foo should not be returned") }
+	if !foundMap["app-misc/foo2"] { t.Errorf("Missing rename destination app-misc/foo2") }
 
 	// 12. Deleting final ebuild leaves stale metadata.xml
 	err = os.MkdirAll(filepath.Join(tmpDir, "dev-util", "stale"), 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, "dev-util", "stale", "metadata.xml"), []byte(""), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 	err = os.WriteFile(filepath.Join(tmpDir, "dev-util", "stale", "stale-1.ebuild"), []byte(""), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	runCmd("git", "add", "dev-util/stale")
 	runCmd("git", "commit", "-m", "Add stale package")
@@ -212,15 +159,11 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	for _, p := range pkgs {
 		foundMap[p] = true
 	}
-	if foundMap["dev-util/stale"] {
-		t.Errorf("Package with deleted final ebuild should not be selected")
-	}
+	if foundMap["dev-util/stale"] { t.Errorf("Package with deleted final ebuild should not be selected") }
 
 	// 13. Deleting one file but another ebuild remains
 	err = os.WriteFile(filepath.Join(tmpDir, "dev-util", "bar", "bar-3.ebuild"), []byte("new file"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	if err != nil { t.Fatal(err) }
 
 	runCmd("git", "add", "dev-util/bar/bar-3.ebuild")
 	runCmd("git", "commit", "-m", "Add another ebuild to bar")
@@ -234,9 +177,7 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	for _, p := range pkgs {
 		foundMap[p] = true
 	}
-	if !foundMap["dev-util/bar"] {
-		t.Errorf("Package with deleted ebuild but remaining ebuilds should be selected")
-	}
+	if !foundMap["dev-util/bar"] { t.Errorf("Package with deleted ebuild but remaining ebuilds should be selected") }
 
 	// Test deterministic order
 	isSorted := true

--- a/projects_test.go
+++ b/projects_test.go
@@ -1,6 +1,9 @@
 package g2
 
 import (
+	"fmt"
+	"io"
+	"strings"
 	"encoding/xml"
 	"os"
 	"path/filepath"
@@ -119,4 +122,103 @@ func TestParseProjects(t *testing.T) {
 			t.Error("ParseProjects() expected error for non-existent file, got nil")
 		}
 	})
+}
+
+
+type projectErrorReader struct{}
+
+func (projectErrorReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("read error")
+}
+
+func TestParseProjectsFromReader(t *testing.T) {
+	tests := []struct {
+		name    string
+		reader  io.Reader
+		want    *Projects
+		wantErr bool
+	}{
+		{
+			name: "valid XML",
+			reader: strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
+<projects>
+	<project>
+		<email>test@example.com</email>
+		<name>Test Project</name>
+		<url>https://example.com/test</url>
+		<description>A test project description.</description>
+		<subproject inherit-members="1" ref="sub1">Subproject Text</subproject>
+		<member is-lead="1">
+			<email>lead@example.com</email>
+			<name>Lead Dev</name>
+			<role>Developer</role>
+		</member>
+	</project>
+</projects>`),
+			want: &Projects{
+				XMLName: xml.Name{Local: "projects"},
+				Projects: []Project{
+					{
+						Email:       "test@example.com",
+						Name:        "Test Project",
+						URL:         "https://example.com/test",
+						Description: "A test project description.",
+						Subprojects: []Subproject{
+							{
+								Text:           "Subproject Text",
+								InheritMembers: "1",
+								Ref:            "sub1",
+							},
+						},
+						Members: []Member{
+							{
+								IsLead: "1",
+								Email:  "lead@example.com",
+								Name:   "Lead Dev",
+								Role:   "Developer",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid XML",
+			reader:  strings.NewReader(`<projects><project>broken xml`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid root tag",
+			reader:  strings.NewReader(`<wrongroot></wrongroot>`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "read error",
+			reader:  projectErrorReader{},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseProjectsFromReader(tt.reader)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseProjectsFromReader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil {
+				got.XMLName.Space = "" // ignore space comparison
+			}
+			if tt.want != nil {
+				tt.want.XMLName.Space = ""
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseProjectsFromReader() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/projects_test.go
+++ b/projects_test.go
@@ -1,10 +1,8 @@
 package g2
 
 import (
-	"fmt"
-	"io"
-	"strings"
 	"encoding/xml"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -124,101 +122,22 @@ func TestParseProjects(t *testing.T) {
 	})
 }
 
+var errTestRead = errors.New("test read error")
 
-type projectErrorReader struct{}
+type projectErrorReader struct {
+	err error
+}
 
-func (projectErrorReader) Read(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("read error")
+func (r projectErrorReader) Read(p []byte) (n int, err error) {
+	return 0, r.err
 }
 
 func TestParseProjectsFromReader(t *testing.T) {
-	tests := []struct {
-		name    string
-		reader  io.Reader
-		want    *Projects
-		wantErr bool
-	}{
-		{
-			name: "valid XML",
-			reader: strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
-<projects>
-	<project>
-		<email>test@example.com</email>
-		<name>Test Project</name>
-		<url>https://example.com/test</url>
-		<description>A test project description.</description>
-		<subproject inherit-members="1" ref="sub1">Subproject Text</subproject>
-		<member is-lead="1">
-			<email>lead@example.com</email>
-			<name>Lead Dev</name>
-			<role>Developer</role>
-		</member>
-	</project>
-</projects>`),
-			want: &Projects{
-				XMLName: xml.Name{Local: "projects"},
-				Projects: []Project{
-					{
-						Email:       "test@example.com",
-						Name:        "Test Project",
-						URL:         "https://example.com/test",
-						Description: "A test project description.",
-						Subprojects: []Subproject{
-							{
-								Text:           "Subproject Text",
-								InheritMembers: "1",
-								Ref:            "sub1",
-							},
-						},
-						Members: []Member{
-							{
-								IsLead: "1",
-								Email:  "lead@example.com",
-								Name:   "Lead Dev",
-								Role:   "Developer",
-							},
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:    "invalid XML",
-			reader:  strings.NewReader(`<projects><project>broken xml`),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name:    "invalid root tag",
-			reader:  strings.NewReader(`<wrongroot></wrongroot>`),
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name:    "read error",
-			reader:  projectErrorReader{},
-			want:    nil,
-			wantErr: true,
-		},
+	got, err := ParseProjectsFromReader(projectErrorReader{err: errTestRead})
+	if !errors.Is(err, errTestRead) {
+		t.Errorf("ParseProjectsFromReader() error = %v, wantErr %v", err, errTestRead)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseProjectsFromReader(tt.reader)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseProjectsFromReader() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != nil {
-				got.XMLName.Space = "" // ignore space comparison
-			}
-			if tt.want != nil {
-				tt.want.XMLName.Space = ""
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseProjectsFromReader() got = %v, want %v", got, tt.want)
-			}
-		})
+	if got != nil {
+		t.Errorf("ParseProjectsFromReader() got = %v, want nil", got)
 	}
 }

--- a/use_desc_test.go
+++ b/use_desc_test.go
@@ -134,7 +134,3 @@ zebra - Zebra description
 		t.Errorf("Write() = \n%v\nwant \n%v", buf.String(), expected)
 	}
 }
-
-
-
-


### PR DESCRIPTION
Adds focused coverage for the missing `io.Reader` failure path in `ParseProjectsFromReader`.

`ParseProjectsBytes` already delegates directly to `ParseProjectsFromReader`, and its existing tests cover successful XML parsing, malformed XML, invalid root elements, and decoded `Projects` contents. This PR therefore focuses on the behavior that was not previously covered: propagating an error returned while reading from the supplied `io.Reader`.

### Intended coverage

- A reader failure returns `nil` projects and a non-nil error.
- The original reader error remains identifiable with `errors.Is`.
- Existing parsing tests remain the source of coverage for valid XML, malformed XML, and invalid roots rather than duplicating those fixtures.

### Verification

- `go fmt ./...`
- `go test ./...`

---
*PR created automatically by Jules for task [7586977170582937386](https://jules.google.com/task/7586977170582937386) started by @arran4*