### PR TITLE
ci: fix multiple GitHub release creators by enforcing GoReleaser as sole owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,8 @@
+# Agent rules for generation:
+# https://arran4.github.io/blog/post/2026/042-simplified-github-ci-release-safe/
+# Release safety details:
+# https://arran4.github.io/blog/post/2026/041-release-safe-single-owner-github-ci/
+
 name: CI/CD
 
 on:
@@ -228,6 +233,10 @@ jobs:
           clean_tag="${next_tag#v}"; clean_tag="${clean_tag%%-*}"
           IFS='.' read -r maj min pat <<< "$clean_tag"
           echo "next_version=${maj:-0}.${min:-0}.$(( ${pat:-0} + 1 ))-SNAPSHOT" >> "$GITHUB_OUTPUT"
+
+          # Create and push the tag to trigger the actual release pipeline
+          git tag "$next_tag"
+          git push origin "$next_tag"
   gitleaks:
     name: Secret scan
     needs: [route, discover]
@@ -485,8 +494,8 @@ jobs:
   goreleaser:
     name: GoReleaser
     # In practice, include all quality gates here (for example: go-test, go-vet, go-lint, format).
-    needs: [route, discover, go-test, prepare-release-tag]
-    if: ${{ needs.discover.outputs.has_go == 'true' && needs.discover.outputs.has_goreleaser == 'true' && (((github.event_name == 'push') && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-'))) }}
+    needs: [route, discover, go-test]
+    if: ${{ needs.discover.outputs.has_go == 'true' && needs.discover.outputs.has_goreleaser == 'true' && (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -495,9 +504,6 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Tag commit locally
-        if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-') }}
-        run: git tag ${{ needs.prepare-release-tag.outputs.release_tag }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -505,42 +511,13 @@ jobs:
           version: '~> v2'
           args: >-
             release --clean
-            ${{ (github.event_name == 'workflow_dispatch' && (inputs.mode == 'release-test' || inputs.mode == 'release-rc' || inputs.mode == 'release-alpha')) && '--snapshot' || '' }}
+            ${{ contains(github.ref, '-test') && '--snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }} # inject secrets.TAP_GITHUB_TOKEN
-          GORELEASER_CURRENT_TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
-  publish-draft:
-    name: Publish draft release assets
-    needs:
-      - goreleaser
-    if: ${{ needs.route.outputs.run_release == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Collect artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist-release
-      - name: Publish draft GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          files: dist-release/**
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  promote-release:
-    name: Promote draft to published
-    needs: [publish-draft]
-    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-')) }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Release promoted via upstream process
-        run: echo "Promotion step placeholder (gh api patch release draft=false)"
-
   prepare-next-version-pr:
     name: Prepare next development iteration PR
-    needs: [publish-draft]
+    needs: [prepare-release-tag]
     if: ${{ github.event_name == 'workflow_dispatch' && (startsWith(inputs.mode, 'release-') || inputs.mode == 'release-test') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,3 +536,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }} # inject secrets.TAP_GITHUB_TOKEN
           GORELEASER_CURRENT_TAG: ${{ needs.prepare-release-tag.outputs.release_tag || '' }}
+
+  release-graph-validation:
+    name: Validate Release Graph Policy
+    needs: [route]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install PyYAML
+        run: pip install pyyaml
+      - name: Run release graph validation
+        run: python3 .github/workflows/validate_release_graph.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,7 +496,7 @@ jobs:
       always() &&
       needs.discover.outputs.has_go == 'true' &&
       needs.discover.outputs.has_goreleaser == 'true' &&
-      (needs.go-test.result == 'success' || needs.go-test.result == 'skipped') &&
+      (needs.go-test.result == 'success') &&
       (needs.prepare-release-tag.result == 'success' || needs.prepare-release-tag.result == 'skipped') &&
       (((github.event_name == 'push') && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/test-'))) || (github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-')))
     runs-on: ubuntu-latest
@@ -510,8 +510,21 @@ jobs:
       - name: Tag commit locally and push (manual runs)
         if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-') && inputs.mode != 'release-test' }}
         run: |
-          git tag ${{ needs.prepare-release-tag.outputs.release_tag }}
-          git push origin ${{ needs.prepare-release-tag.outputs.release_tag }}
+          set -euo pipefail
+          TAG="${{ needs.prepare-release-tag.outputs.release_tag }}"
+
+          git fetch --tags --force
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+             TAG_SHA=$(git rev-list -n 1 "$TAG")
+             if [[ "$TAG_SHA" != "${{ github.sha }}" ]]; then
+               echo "Error: Tag $TAG exists but points to $TAG_SHA instead of ${{ github.sha }}."
+               exit 1
+             fi
+             echo "Tag $TAG already exists and points to correct SHA."
+          else
+             git tag "$TAG"
+             git push origin "$TAG"
+          fi
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,9 +234,6 @@ jobs:
           IFS='.' read -r maj min pat <<< "$clean_tag"
           echo "next_version=${maj:-0}.${min:-0}.$(( ${pat:-0} + 1 ))-SNAPSHOT" >> "$GITHUB_OUTPUT"
 
-          # Create and push the tag to trigger the actual release pipeline
-          git tag "$next_tag"
-          git push origin "$next_tag"
   gitleaks:
     name: Secret scan
     needs: [route, discover]
@@ -501,7 +498,7 @@ jobs:
       needs.discover.outputs.has_goreleaser == 'true' &&
       (needs.go-test.result == 'success' || needs.go-test.result == 'skipped') &&
       (needs.prepare-release-tag.result == 'success' || needs.prepare-release-tag.result == 'skipped') &&
-      (((github.event_name == 'push') && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-')))
+      (((github.event_name == 'push') && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/test-'))) || (github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -510,46 +507,19 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Tag commit locally and push (manual runs)
+        if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-') && inputs.mode != 'release-test' }}
+        run: |
+          git tag ${{ needs.prepare-release-tag.outputs.release_tag }}
+          git push origin ${{ needs.prepare-release-tag.outputs.release_tag }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: '~> v2'
           args: >-
-            release --clean ${{ (github.event_name == 'workflow_dispatch' && (inputs.mode == 'release-test' || inputs.mode == 'release-rc' || inputs.mode == 'release-alpha')) && '--snapshot' || '' }} ${{ (github.event_name == 'push' && (contains(github.ref, '-test') || contains(github.ref, '-rc') || contains(github.ref, '-alpha'))) && '--snapshot' || '' }}
+            release --clean ${{ (github.event_name == 'workflow_dispatch' && inputs.mode == 'release-test') && '--snapshot' || '' }} ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/test-')) && '--snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }} # inject secrets.TAP_GITHUB_TOKEN
           GORELEASER_CURRENT_TAG: ${{ needs.prepare-release-tag.outputs.release_tag || '' }}
-  prepare-next-version-pr:
-    name: Prepare next development iteration PR
-    needs: [prepare-release-tag, goreleaser]
-    if: |
-      always() &&
-      (needs.prepare-release-tag.result == 'success' || needs.prepare-release-tag.result == 'skipped') &&
-      (needs.goreleaser.result == 'success') &&
-      github.event_name == 'workflow_dispatch' &&
-      (startsWith(inputs.mode, 'release-') || inputs.mode == 'release-test')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Bump to next version and open PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          NEXT_VERSION="${{ needs.prepare-release-tag.outputs.next_version || '' }}"
-          [[ -z "$NEXT_VERSION" ]] && { echo "No next version calculated; skipping."; exit 0; }
-
-          BRANCH="bump-version-$NEXT_VERSION"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
-
-          # Replace with repo-specific version bump command(s)
-          # mvn versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
-
-          git add -A
-          git commit -m "Prepare next development iteration $NEXT_VERSION"
-          git push -u origin "$BRANCH"
-          gh pr create --title "Prepare next development iteration $NEXT_VERSION" --body "Automated PR for next iteration." --base main --head "$BRANCH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,8 +494,14 @@ jobs:
   goreleaser:
     name: GoReleaser
     # In practice, include all quality gates here (for example: go-test, go-vet, go-lint, format).
-    needs: [route, discover, go-test]
-    if: ${{ needs.discover.outputs.has_go == 'true' && needs.discover.outputs.has_goreleaser == 'true' && (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
+    needs: [route, discover, go-test, prepare-release-tag]
+    if: |
+      always() &&
+      needs.discover.outputs.has_go == 'true' &&
+      needs.discover.outputs.has_goreleaser == 'true' &&
+      (needs.go-test.result == 'success' || needs.go-test.result == 'skipped') &&
+      (needs.prepare-release-tag.result == 'success' || needs.prepare-release-tag.result == 'skipped') &&
+      (((github.event_name == 'push') && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -510,15 +516,20 @@ jobs:
           distribution: goreleaser
           version: '~> v2'
           args: >-
-            release --clean
-            ${{ contains(github.ref, '-test') && '--snapshot' || '' }}
+            release --clean ${{ (github.event_name == 'workflow_dispatch' && (inputs.mode == 'release-test' || inputs.mode == 'release-rc' || inputs.mode == 'release-alpha')) && '--snapshot' || '' }} ${{ (github.event_name == 'push' && (contains(github.ref, '-test') || contains(github.ref, '-rc') || contains(github.ref, '-alpha'))) && '--snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }} # inject secrets.TAP_GITHUB_TOKEN
+          GORELEASER_CURRENT_TAG: ${{ needs.prepare-release-tag.outputs.release_tag || '' }}
   prepare-next-version-pr:
     name: Prepare next development iteration PR
-    needs: [prepare-release-tag]
-    if: ${{ github.event_name == 'workflow_dispatch' && (startsWith(inputs.mode, 'release-') || inputs.mode == 'release-test') }}
+    needs: [prepare-release-tag, goreleaser]
+    if: |
+      always() &&
+      (needs.prepare-release-tag.result == 'success' || needs.prepare-release-tag.result == 'skipped') &&
+      (needs.goreleaser.result == 'success') &&
+      github.event_name == 'workflow_dispatch' &&
+      (startsWith(inputs.mode, 'release-') || inputs.mode == 'release-test')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate_release_graph.py
+++ b/.github/workflows/validate_release_graph.py
@@ -7,6 +7,12 @@ def run_tests():
 
     jobs = ci.get('jobs', {})
 
+    # Check 0: prepare-release-tag must be restricted to workflow_dispatch release-*
+    prepare = jobs.get('prepare-release-tag')
+    assert prepare, "prepare-release-tag missing"
+    assert "github.event_name == 'workflow_dispatch'" in prepare.get('if', ''), "prepare-release-tag must require workflow_dispatch"
+    assert "startsWith(inputs.mode, 'release-')" in prepare.get('if', ''), "prepare-release-tag must require release- mode"
+
     # Check 7: Only GoReleaser owns GitHub Release publication
     assert "publish-draft" not in jobs, "competing draft publish job remains"
     assert "promote-release" not in jobs, "competing promote job remains"
@@ -17,6 +23,8 @@ def run_tests():
 
     # Check 1: manual workflow_dispatch release-* enters goreleaser only with go-test == success
     # Check 6: failed/skipped test gates cannot publish
+    assert "github.event_name == 'workflow_dispatch'" in g_if, "goreleaser must support workflow_dispatch trigger"
+    assert "startsWith(inputs.mode, 'release-')" in g_if, "goreleaser must support release-* modes on dispatch"
     assert "needs.go-test.result == 'success'" in g_if, "failed test gate must prevent publish"
     assert "needs.go-test.result == 'skipped'" not in g_if, "skipped test gate must prevent publish"
 

--- a/.github/workflows/validate_release_graph.py
+++ b/.github/workflows/validate_release_graph.py
@@ -1,0 +1,52 @@
+import yaml
+import sys
+
+def run_tests():
+    with open(".github/workflows/ci.yml") as f:
+        ci = yaml.safe_load(f)
+
+    jobs = ci.get('jobs', {})
+
+    # 1. Check prepare-release-tag skipped on pushed v*
+    prepare = jobs.get('prepare-release-tag')
+    assert prepare, "prepare-release-tag missing"
+    assert "github.event_name == 'workflow_dispatch'" in prepare.get('if', ''), "prepare-release-tag must be workflow_dispatch only"
+
+    # 2. Check goreleaser requirements
+    goreleaser = jobs.get('goreleaser')
+    assert goreleaser, "goreleaser job missing"
+    assert "needs.go-test.result == 'success'" in goreleaser.get('if', ''), "failed test gate must prevent publish"
+    assert "needs.go-test.result == 'skipped'" not in goreleaser.get('if', ''), "skipped test gate must prevent publish"
+    assert "needs.prepare-release-tag.result == 'skipped'" in goreleaser.get('if', ''), "must allow skipped prepare-release-tag"
+
+    # 3. Check RC/Alpha are publish, test is snapshot
+    steps = goreleaser.get('steps', [])
+    run_goreleaser_step = next(s for s in steps if "Run GoReleaser" in s.get('name', ''))
+    args = run_goreleaser_step.get('with', {}).get('args', '')
+
+    assert "release-test" in args and "snapshot" in args, "release-test must snapshot"
+    assert "test-" in args and "snapshot" in args, "test- tags must snapshot"
+    assert "release-rc" not in args, "release-rc must not trigger snapshot"
+    assert "release-alpha" not in args, "release-alpha must not trigger snapshot"
+
+    # 4. Check manual tagging idempotency and correct SHA handling
+    tag_step = next((s for s in steps if "Tag commit locally and push" in s.get('name', '')), None)
+    assert tag_step, "tag step missing"
+
+    # Needs to not run on release-test
+    assert "inputs.mode != 'release-test'" in tag_step.get('if', ''), "manual test mode must not push a permanent tag"
+
+    run_script = tag_step.get('run', '')
+    assert "git fetch --tags" in run_script, "must fetch tags"
+    assert "TAG_SHA=$(git rev-list -n 1 \"$TAG\")" in run_script, "must check tag SHA"
+    assert "exit 1" in run_script, "must fail heavily on mismatched SHA"
+    assert "git push origin \"$TAG\"" in run_script, "must push tag if correct"
+
+    # 5. Check no duplicate publishing paths
+    assert "publish-draft" not in jobs, "competing draft publish job remains"
+    assert "promote-release" not in jobs, "competing promote job remains"
+
+    print("✅ All static release graph checks passed!")
+
+if __name__ == '__main__':
+    run_tests()

--- a/.github/workflows/validate_release_graph.py
+++ b/.github/workflows/validate_release_graph.py
@@ -7,44 +7,50 @@ def run_tests():
 
     jobs = ci.get('jobs', {})
 
-    # 1. Check prepare-release-tag skipped on pushed v*
-    prepare = jobs.get('prepare-release-tag')
-    assert prepare, "prepare-release-tag missing"
-    assert "github.event_name == 'workflow_dispatch'" in prepare.get('if', ''), "prepare-release-tag must be workflow_dispatch only"
+    # Check 7: Only GoReleaser owns GitHub Release publication
+    assert "publish-draft" not in jobs, "competing draft publish job remains"
+    assert "promote-release" not in jobs, "competing promote job remains"
 
-    # 2. Check goreleaser requirements
     goreleaser = jobs.get('goreleaser')
     assert goreleaser, "goreleaser job missing"
-    assert "needs.go-test.result == 'success'" in goreleaser.get('if', ''), "failed test gate must prevent publish"
-    assert "needs.go-test.result == 'skipped'" not in goreleaser.get('if', ''), "skipped test gate must prevent publish"
-    assert "needs.prepare-release-tag.result == 'skipped'" in goreleaser.get('if', ''), "must allow skipped prepare-release-tag"
+    g_if = goreleaser.get('if', '')
 
-    # 3. Check RC/Alpha are publish, test is snapshot
+    # Check 1: manual workflow_dispatch release-* enters goreleaser only with go-test == success
+    # Check 6: failed/skipped test gates cannot publish
+    assert "needs.go-test.result == 'success'" in g_if, "failed test gate must prevent publish"
+    assert "needs.go-test.result == 'skipped'" not in g_if, "skipped test gate must prevent publish"
+
+    # Check 2: externally pushed refs/tags/v* enters goreleaser with prepare-release-tag skipped
+    assert "needs.prepare-release-tag.result == 'skipped'" in g_if, "must allow skipped prepare-release-tag for external tag push"
+    assert "startsWith(github.ref, 'refs/tags/v')" in g_if, "must support standard v* tag pushes"
+
+    # Check 3: externally pushed refs/tags/test-* enters goreleaser in snapshot mode
+    assert "startsWith(github.ref, 'refs/tags/test-')" in g_if, "must support test-* tag pushes"
+
     steps = goreleaser.get('steps', [])
     run_goreleaser_step = next(s for s in steps if "Run GoReleaser" in s.get('name', ''))
     args = run_goreleaser_step.get('with', {}).get('args', '')
 
-    assert "release-test" in args and "snapshot" in args, "release-test must snapshot"
-    assert "test-" in args and "snapshot" in args, "test- tags must snapshot"
-    assert "release-rc" not in args, "release-rc must not trigger snapshot"
-    assert "release-alpha" not in args, "release-alpha must not trigger snapshot"
+    assert "contains(github.ref, 'test-')" in args or "startsWith(github.ref, 'refs/tags/test-')" in args, "test- tags must trigger snapshot mode"
+    assert "snapshot" in args, "snapshot argument must be conditionally present"
 
-    # 4. Check manual tagging idempotency and correct SHA handling
+    # Check 4: manual release-test is snapshot-only and does not run the permanent tag-push step
+    assert "inputs.mode == 'release-test'" in args and "snapshot" in args, "manual release-test must trigger snapshot"
+
     tag_step = next((s for s in steps if "Tag commit locally and push" in s.get('name', '')), None)
     assert tag_step, "tag step missing"
-
-    # Needs to not run on release-test
     assert "inputs.mode != 'release-test'" in tag_step.get('if', ''), "manual test mode must not push a permanent tag"
 
+    # Check 5: manual release-rc / release-alpha are non-snapshot publishing paths
+    assert "release-rc" not in args, "release-rc must not trigger snapshot mode"
+    assert "release-alpha" not in args, "release-alpha must not trigger snapshot mode"
+
+    # Check 8: manual permanent tag creation remains retry-safe and SHA-checked
     run_script = tag_step.get('run', '')
     assert "git fetch --tags" in run_script, "must fetch tags"
     assert "TAG_SHA=$(git rev-list -n 1 \"$TAG\")" in run_script, "must check tag SHA"
     assert "exit 1" in run_script, "must fail heavily on mismatched SHA"
     assert "git push origin \"$TAG\"" in run_script, "must push tag if correct"
-
-    # 5. Check no duplicate publishing paths
-    assert "publish-draft" not in jobs, "competing draft publish job remains"
-    assert "promote-release" not in jobs, "competing promote job remains"
 
     print("✅ All static release graph checks passed!")
 


### PR DESCRIPTION
## Release architecture fix

### Previous release-owner graph

`workflow_dispatch release-*` / tag push → `goreleaser` → `publish-draft` → `promote-release`

This allowed more than one component to own GitHub Release creation. GoReleaser could create the release while `softprops/action-gh-release` attempted to create a competing draft for the same tag, leaving duplicate/orphan release state.

### New release-owner graph

GoReleaser is the sole GitHub Release publisher. `publish-draft`, `promote-release`, and the incomplete `prepare-next-version-pr` job are removed.

- **Manual stable / RC / alpha release:** `prepare-release-tag` calculates and validates the intended semantic tag only → required Go lint/test gate must succeed → `goreleaser` creates/pushes that exact tag idempotently and verifies an existing tag points to `github.sha` → GoReleaser publishes the release in the same workflow run. The tag push uses `GITHUB_TOKEN`, so it does not create a duplicate workflow run.
- **Manual `release-test`:** calculates the test version → required Go test gate must succeed → GoReleaser runs with `--snapshot`. No permanent tag is pushed and no GitHub Release is published.
- **Externally pushed `v*` tag:** `prepare-release-tag` is intentionally skipped → required Go test gate must succeed → GoReleaser publishes the tagged commit.
- **Externally pushed `test-*` tag:** required Go test gate must succeed → GoReleaser runs in snapshot mode and does not publish a GitHub Release.

### Safety properties

- A failed or skipped `go-test` cannot enter the release job.
- Manual permanent tags are created only after the test gate succeeds.
- Manual tag creation is retry-safe: an existing tag is reused only when it resolves to the exact current `github.sha`; a conflicting tag fails loudly.
- RC and alpha modes are normal prerelease publication paths, not snapshots.
- Test modes remain non-publishing snapshots.
- There is one GitHub Release owner: GoReleaser.

### Files changed

- `.github/workflows/ci.yml`
- `.github/workflows/validate_release_graph.py`

### Validation

- Workflow/YAML validation and the Go test suite passed during development.
- PR CI exercises a dedicated `Validate Release Graph Policy` job which statically verifies the manual `workflow_dispatch release-*` path, external `v*` and `test-*` tag paths, snapshot versus publishing semantics, failed/skipped test gating, single publisher ownership, and retry-safe SHA-checked manual tagging.
- At head `4f1af02`, `Validate Release Graph Policy` passed in CI run 2110. The latest commit only tightens validation assertions for the manual release entry paths.

### Follow-up outside this PR

Historical untagged or duplicate draft releases created by the previous competing publisher paths should be reviewed and cleaned up manually.