### PR TITLE
fix: Make manifest verify --fix --clean authoritative and transactional

### DIFF
--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -526,11 +526,6 @@ func (cfg *CmdManifestArgConfig) cmdClean(args []string) error {
 	return os.WriteFile(manifestPath, []byte(manifest.String()), 0644)
 }
 
-func (cfg *CmdManifestArgConfig) upsertFromUrlLogic(url, filename, manifestPath string, hashes []string) error {
-	checksums, err := g2.DownloadAndChecksum(url, hashes)
-	if err != nil {
-		return fmt.Errorf("downloading and calculating checksums for %s: %w", url, err)
-	}
 
 	entry := g2.NewManifestEntry("DIST", filename, checksums.Size)
 

--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -318,44 +318,14 @@ func (cfg *CmdManifestArgConfig) cmdUpsertFromUrl(args []string, hashes []string
 	filename := args[1]
 	ebuildDirOrFile := args[2]
 
-	// Logic to be moved to a reusable function if we want to reuse it in verify --fix
-	// For now I'll just keep it here and maybe call this function or copy logic.
-
-	checksums, err := g2.DownloadAndChecksum(url, hashes)
+	entry, err := DownloadAndCreateManifestEntry(url, filename, hashes)
 	if err != nil {
-		return fmt.Errorf("downloading and calculating checksums for %s: %w", url, err)
-	}
-
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "DIST %s %d", filename, checksums.Size)
-
-	// Helper to append hash if it's computed
-	appendHash := func(name, value string) {
-		if value != "" {
-			fmt.Fprintf(&sb, " %s %s", name, value)
-		}
-	}
-
-	for _, h := range g2.AllHashes {
-		appendHash(h, checksums.Hashes[h])
+		return err
 	}
 
 	manifestPath := ebuildDirOrFile
 	if _, file := filepath.Split(manifestPath); file != "Manifest" {
 		manifestPath = filepath.Join(ebuildDirOrFile, "Manifest")
-	}
-
-	entry := g2.NewManifestEntry("DIST", filename, checksums.Size)
-
-	// Helper to append hash if it's computed
-	appendHashToEntry := func(name, value string) {
-		if value != "" {
-			entry.AddHash(name, value)
-		}
-	}
-
-	for _, h := range g2.AllHashes {
-		appendHashToEntry(h, checksums.Hashes[h])
 	}
 
 	err = g2.UpsertManifest(manifestPath, entry)
@@ -365,6 +335,21 @@ func (cfg *CmdManifestArgConfig) cmdUpsertFromUrl(args []string, hashes []string
 
 	log.Printf("Done")
 	return nil
+}
+
+func DownloadAndCreateManifestEntry(url, filename string, hashes []string) (*g2.ManifestEntry, error) {
+	checksums, err := g2.DownloadAndChecksum(url, hashes)
+	if err != nil {
+		return nil, fmt.Errorf("downloading and calculating checksums for %s: %w", url, err)
+	}
+
+	entry := g2.NewManifestEntry("DIST", filename, checksums.Size)
+	for _, h := range g2.AllHashes {
+		if val, ok := checksums.Hashes[h]; ok && val != "" {
+			entry.AddHash(h, val)
+		}
+	}
+	return entry, nil
 }
 
 func (cfg *CmdManifestArgConfig) cmdVerify(args []string, hashes []string) error {
@@ -381,8 +366,6 @@ func (cfg *CmdManifestArgConfig) cmdVerify(args []string, hashes []string) error
 	}
 
 	target := fs.Arg(0)
-
-	// Determine manifest path and directory
 	var manifestPath, directory string
 	info, err := os.Stat(target)
 	if err != nil {
@@ -399,19 +382,25 @@ func (cfg *CmdManifestArgConfig) cmdVerify(args []string, hashes []string) error
 
 	log.Printf("Processing directory: %s", directory)
 
-	// Load Manifest
 	manifest, err := g2.ParseManifest(manifestPath)
 	if err != nil {
 		return fmt.Errorf("reading manifest: %w", err)
 	}
 
-	// Find all ebuilds
 	entries, err := os.ReadDir(directory)
 	if err != nil {
 		return fmt.Errorf("reading directory: %w", err)
 	}
 
 	foundFiles := make(map[string]bool)
+	sysFS := os.DirFS(directory)
+
+	type MissingEntry struct {
+		URL      string
+		Filename string
+	}
+	var missing []MissingEntry
+	uncertain := false
 
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".ebuild") {
@@ -420,55 +409,52 @@ func (cfg *CmdManifestArgConfig) cmdVerify(args []string, hashes []string) error
 
 		ebuildName := entry.Name()
 		foundFiles[ebuildName] = true
-		log.Printf("  Parsing %s...", ebuildName)
 
 		if manifestEntry := manifest.GetEntry(ebuildName); manifestEntry == nil {
 			log.Printf("    MISSING in manifest: %s", ebuildName)
 		}
 
-		variables := g2.ParseEbuildVariables(ebuildName)
-		if variables == nil {
-			log.Printf("  Skipping %s: Could not parse version/name.", ebuildName)
+		e, err := g2.ParseEbuild(sysFS, ebuildName, g2.ParseFull)
+		if err != nil {
+			log.Printf("  Uncertain %s: Could not parse ebuild: %v", ebuildName, err)
+			uncertain = true
 			continue
 		}
 
-		content, err := os.ReadFile(filepath.Join(directory, ebuildName))
-		if err != nil {
-			return fmt.Errorf("reading ebuild %s: %w", ebuildName, err)
+		if !e.IsSrcUriAuthoritative() {
+			log.Printf("  Uncertain %s: sources incomplete or not authoritative", ebuildName)
+			uncertain = true
 		}
 
-		uris, err := g2.ExtractURIs(string(content), variables)
-		if err != nil {
-			// Log error but maybe continue?
-			log.Printf("    Error extracting URIs from %s: %v", ebuildName, err)
-			continue
-		}
-
-		for _, uri := range uris {
+		for _, uri := range e.SrcUri {
 			foundFiles[uri.Filename] = true
 
 			if entry := manifest.GetEntry(uri.Filename); entry != nil {
-				// Entry exists.
-				// In a full verify we might want to check checksums if file exists locally,
-				// but the prompt implies verifying the manifest *entries* exist for the ebuilds.
-				// The prompt says "with a force fix", which implies if it's missing, we fix it.
-				// The python script calls upsert-from-url.
-				log.Printf("    Found in manifest: %s", uri.Filename)
+				// exists
 			} else {
 				log.Printf("    MISSING in manifest: %s (URL: %s)", uri.Filename, uri.URL)
-				if *fix {
-					log.Printf("    Upserting: %s -> %s", uri.URL, uri.Filename)
-					// Reuse logic from upsert-from-url
-					// We need to call internal logic, not the CLI command ideally, but I can call cmdUpsertFromUrl
-					// or refactor the logic.
-					// I'll call a helper function.
-
-					err := cfg.upsertFromUrlLogic(uri.URL, uri.Filename, manifestPath, hashes)
-					if err != nil {
-						log.Printf("    Error updating manifest for %s: %v", uri.URL, err)
-					}
-				}
+				missing = append(missing, MissingEntry{URL: uri.URL, Filename: uri.Filename})
 			}
+		}
+	}
+
+	if uncertain {
+		if *fix || *clean {
+			return fmt.Errorf("aborting: source resolution is incomplete or uncertain")
+		}
+	}
+
+	manifestModified := false
+
+	if *fix {
+		for _, m := range missing {
+			log.Printf("    Upserting: %s -> %s", m.URL, m.Filename)
+			newEntry, err := DownloadAndCreateManifestEntry(m.URL, m.Filename, hashes)
+			if err != nil {
+				return fmt.Errorf("aborting: error updating manifest for %s: %w", m.URL, err)
+			}
+			manifest.AddOrReplace(newEntry)
+			manifestModified = true
 		}
 	}
 
@@ -481,15 +467,23 @@ func (cfg *CmdManifestArgConfig) cmdVerify(args []string, hashes []string) error
 	}
 
 	if *clean {
-		// Run clean logic
-		err = g2.CleanManifest(os.DirFS(directory), ".", manifest)
-		if err != nil {
-			return fmt.Errorf("cleaning manifest: %w", err)
+		var filesToRemove []string
+		for _, entry := range manifest.Entries {
+			if (entry.Type == "DIST" || entry.Type == "EBUILD") && !foundFiles[entry.Filename] {
+				filesToRemove = append(filesToRemove, entry.Filename)
+			}
 		}
+		for _, filename := range filesToRemove {
+			manifest.Remove(filename)
+			manifestModified = true
+		}
+	}
 
-		err = os.WriteFile(manifestPath, []byte(manifest.String()), 0644)
+	if manifestModified {
+		manifest.Sort()
+		err = g2.AtomicWriteManifest(manifestPath, manifest)
 		if err != nil {
-			return fmt.Errorf("writing clean manifest: %w", err)
+			return fmt.Errorf("writing manifest: %w", err)
 		}
 	}
 

--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -351,6 +351,9 @@ func DownloadAndCreateManifestEntry(url, filename string, hashes []string) (*g2.
 	}
 	return entry, nil
 }
+
+var atomicWriteManifest = g2.AtomicWriteManifest
+
 func (cfg *CmdManifestArgConfig) cmdVerify(args []string, hashes []string) error {
 	fs := flag.NewFlagSet("verify", flag.ExitOnError)
 	fix := fs.Bool("fix", false, "Force fix missing manifest entries")
@@ -480,7 +483,7 @@ func (cfg *CmdManifestArgConfig) cmdVerify(args []string, hashes []string) error
 
 	if manifestModified {
 		manifest.Sort()
-		err = g2.AtomicWriteManifest(manifestPath, manifest)
+		err = atomicWriteManifest(manifestPath, manifest)
 		if err != nil {
 			return fmt.Errorf("writing manifest: %w", err)
 		}

--- a/cmd/g2/main.go
+++ b/cmd/g2/main.go
@@ -351,7 +351,6 @@ func DownloadAndCreateManifestEntry(url, filename string, hashes []string) (*g2.
 	}
 	return entry, nil
 }
-
 func (cfg *CmdManifestArgConfig) cmdVerify(args []string, hashes []string) error {
 	fs := flag.NewFlagSet("verify", flag.ExitOnError)
 	fix := fs.Bool("fix", false, "Force fix missing manifest entries")
@@ -524,21 +523,4 @@ func (cfg *CmdManifestArgConfig) cmdClean(args []string) error {
 	}
 
 	return os.WriteFile(manifestPath, []byte(manifest.String()), 0644)
-}
-
-
-	entry := g2.NewManifestEntry("DIST", filename, checksums.Size)
-
-	// Helper to append hash if it's computed
-	appendHash := func(name, value string) {
-		if value != "" {
-			entry.AddHash(name, value)
-		}
-	}
-
-	for _, h := range g2.AllHashes {
-		appendHash(h, checksums.Hashes[h])
-	}
-
-	return g2.UpsertManifest(manifestPath, entry)
 }

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -56,6 +56,89 @@ func TestCmdVerifyTransactional(t *testing.T) {
 
 	hashes := []string{g2.HashSha512}
 
+	t.Run("Missing + Obsolete DIST: Fix + Clean writes exact set once", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/good.tar.gz -> good.tar.gz"
+`, ts.URL))
+
+		manifestContent := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, manifestContent)
+
+		cfg := &CmdManifestArgConfig{
+			MainArgConfig: &MainArgConfig{},
+		}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err != nil {
+			t.Fatalf("cmdVerify failed: %v", err)
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		result := string(b)
+		if !strings.Contains(result, "DIST good.tar.gz") {
+			t.Errorf("Expected good.tar.gz in manifest, got: %s", result)
+		}
+		if strings.Contains(result, "obsolete.tar.gz") {
+			t.Errorf("Expected obsolete.tar.gz to be removed, got: %s", result)
+		}
+	})
+
+	t.Run("Failed download aborts transaction", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/fail.tar.gz -> fail.tar.gz"
+`, ts.URL))
+
+		originalManifest := "DIST other.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("Expected cmdVerify to fail")
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		if string(b) != originalManifest {
+			t.Errorf("Manifest was modified on failure! Got: %s", string(b))
+		}
+	})
+
+	t.Run("Uncertain ebuild aborts clean and fix", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+inherit someclass
+DESCRIPTION="foo"
+SLOT="0"
+`)
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("Expected error about uncertainty")
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		if string(b) != originalManifest {
+			t.Errorf("Manifest was modified despite uncertainty! Got: %s", string(b))
+		}
+	})
+
 	t.Run("Successful first fetch, failing later fetch preserves exact Manifest bytes", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
@@ -71,7 +154,7 @@ SRC_URI="%s/firstgood.tar.gz -> firstgood.tar.gz
 		cfg := &CmdManifestArgConfig{
 			MainArgConfig: &MainArgConfig{},
 		}
-		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		err := cfg.cmdVerify([]string{"--fix", dir}, hashes)
 		if err == nil {
 			t.Fatalf("cmdVerify expected to fail due to laterfail.tar.gz")
 		}
@@ -105,6 +188,25 @@ SRC_URI="${MY_SOURCE}"
 		}
 	})
 
+	t.Run("Unsupported shell control-flow syntax silently treated as authoritative aborted", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+SRC_URI="" && SRC_URI="https://example.invalid/a.tar.gz"
+`)
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("cmdVerify expected to abort due to control flow `&&`")
+		}
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if string(b) != originalManifest {
+			t.Errorf("Manifest modified despite uncertainty! Got:\n%s", string(b))
+		}
+	})
+
 	t.Run("Unsupported source control flow aborted", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
@@ -130,22 +232,19 @@ fi
 		}
 	})
 
-	t.Run("Unsupported shell control-flow syntax silently treated as authoritative aborted", func(t *testing.T) {
+	t.Run("Valid conditional source lists plus malformed groups/rename targets", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
-SRC_URI="" && SRC_URI="https://example.invalid/a.tar.gz"
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="foo? ( https://example.invalid/a.tar.gz -> )"
 `)
-		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
-		writeTestManifest(t, dir, originalManifest)
+		writeTestManifest(t, dir, "")
 
 		cfg := &CmdManifestArgConfig{}
-		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		err := cfg.cmdVerify([]string{"--fix", dir}, hashes)
 		if err == nil {
-			t.Fatalf("cmdVerify expected to abort due to control flow `&&`")
-		}
-		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
-		if string(b) != originalManifest {
-			t.Errorf("Manifest modified despite uncertainty! Got:\n%s", string(b))
+			t.Fatalf("cmdVerify expected to fail due to malformed -> target")
 		}
 	})
 
@@ -193,22 +292,6 @@ SRC_URI="%s/good.tar.gz -> good.tar.gz"
 		}
 	})
 
-	t.Run("Valid conditional source lists plus malformed groups/rename targets", func(t *testing.T) {
-		dir := t.TempDir()
-		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
-DESCRIPTION="foo"
-SLOT="0"
-SRC_URI="foo? ( https://example.invalid/a.tar.gz -> )"
-`)
-		writeTestManifest(t, dir, "")
-
-		cfg := &CmdManifestArgConfig{}
-		err := cfg.cmdVerify([]string{"--fix", dir}, hashes)
-		if err == nil {
-			t.Fatalf("cmdVerify expected to fail due to malformed -> target")
-		}
-	})
-
 	t.Run("Exact final DIST set", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
@@ -239,11 +322,7 @@ SRC_URI="%s/good.tar.gz -> good.tar.gz"
 
 	t.Run("Idempotency", func(t *testing.T) {
 		dir := t.TempDir()
-		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
-DESCRIPTION="foo"
-SLOT="0"
-SRC_URI="%s/good.tar.gz -> good.tar.gz"
-`, ts.URL))
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", "EAPI=8\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\nSRC_URI=\""+ts.URL+"/good.tar.gz -> good.tar.gz\"\n")
 		writeTestManifest(t, dir, "")
 		cfg := &CmdManifestArgConfig{
 			MainArgConfig: &MainArgConfig{},
@@ -259,7 +338,39 @@ SRC_URI="%s/good.tar.gz -> good.tar.gz"
 		}
 		b2, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
 		if string(b1) != string(b2) {
-			t.Errorf("Idempotency failed")
+			t.Errorf("Idempotency failed: b1: %s b2: %s", string(b1), string(b2))
+		}
+	})
+}
+
+func TestCmdUpsertFromUrl(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("good data"))
+	}))
+	defer ts.Close()
+
+	hashes := []string{g2.HashSha512}
+
+	t.Run("Preserves revision text", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestManifest(t, dir, "")
+
+		cfg := &CmdManifestArgConfig{
+			MainArgConfig: &MainArgConfig{},
+		}
+		// Notice filename is "foo-1.0-r1.tar.gz"
+		err := cfg.cmdUpsertFromUrl([]string{ts.URL + "/good.tar.gz", "foo-1.0-r1.tar.gz", dir}, hashes)
+		if err != nil {
+			t.Fatalf("cmdUpsertFromUrl failed: %v", err)
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		result := string(b)
+		if !strings.Contains(result, "DIST foo-1.0-r1.tar.gz") {
+			t.Errorf("Expected exact filename to be preserved, got: %s", result)
 		}
 	})
 }

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -34,6 +34,12 @@ func TestCmdVerifyTransactional(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+		if r.URL.Path == "/trunc.tar.gz" {
+			w.Header().Set("Content-Length", "1000") // Claim 1000 bytes
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("truncated")) // Send only 9 bytes
+			return
+		}
 		if r.URL.Path == "/good.tar.gz" {
 			_, _ = w.Write([]byte("good data"))
 			return
@@ -118,7 +124,7 @@ SLOT="0"
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
 DESCRIPTION="foo"
 SLOT="0"
-SRC_URI="%s/fail.tar.gz -> fail.tar.gz"
+SRC_URI="%s/trunc.tar.gz -> trunc.tar.gz"
 `, ts.URL))
 		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
 		writeTestManifest(t, dir, originalManifest)
@@ -127,6 +133,9 @@ SRC_URI="%s/fail.tar.gz -> fail.tar.gz"
 		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
 		if err == nil {
 			t.Fatalf("Expected cmdVerify to fail")
+		}
+		if strings.Contains(err.Error(), "bad status") {
+			t.Fatalf("Expected body processing failure, but got bad status error: %v", err)
 		}
 
 		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -27,8 +27,9 @@ func writeTestManifest(t *testing.T, dir, content string) {
 }
 
 func TestCmdVerifyTransactional(t *testing.T) {
-	// Start fake HTTP server
+	var callCount int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
 		if r.URL.Path == "/fail.tar.gz" {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -41,13 +42,111 @@ func TestCmdVerifyTransactional(t *testing.T) {
 			_, _ = w.Write([]byte("missing data"))
 			return
 		}
+		if r.URL.Path == "/firstgood.tar.gz" {
+			_, _ = w.Write([]byte("good data 1"))
+			return
+		}
+		if r.URL.Path == "/laterfail.tar.gz" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer ts.Close()
 
 	hashes := []string{g2.HashSha512}
 
-	t.Run("Missing + Obsolete DIST: Fix + Clean writes exact set once", func(t *testing.T) {
+	t.Run("Successful first fetch, failing later fetch preserves exact Manifest bytes", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/firstgood.tar.gz -> firstgood.tar.gz
+%s/laterfail.tar.gz -> laterfail.tar.gz"
+`, ts.URL, ts.URL))
+
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{
+			MainArgConfig: &MainArgConfig{},
+		}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("cmdVerify expected to fail due to laterfail.tar.gz")
+		}
+
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if string(b) != originalManifest {
+			t.Errorf("Manifest modified despite failed later download! Got:\n%s", string(b))
+		}
+	})
+
+	t.Run("Transitive unknown variables conservatively aborted", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+MY_SOURCE="${UNKNOWN_SOURCE}"
+SRC_URI="${MY_SOURCE}"
+`)
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("cmdVerify expected to abort due to transitive uncertainty")
+		}
+
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if string(b) != originalManifest {
+			t.Errorf("Manifest modified despite uncertainty! Got:\n%s", string(b))
+		}
+	})
+
+	t.Run("Unsupported source control flow aborted", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="https://example.invalid/a.tar.gz"
+if false; then
+	SRC_URI=""
+fi
+`)
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("cmdVerify expected to abort due to control flow")
+		}
+
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if string(b) != originalManifest {
+			t.Errorf("Manifest modified despite uncertainty! Got:\n%s", string(b))
+		}
+	})
+
+	t.Run("Valid conditional source lists plus malformed groups/rename targets", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="foo? ( https://example.invalid/a.tar.gz -> )"
+`)
+		writeTestManifest(t, dir, "")
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", dir}, hashes)
+		if err == nil {
+			t.Fatalf("cmdVerify expected to fail due to malformed -> target")
+		}
+	})
+
+	t.Run("Exact final DIST set", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
 DESCRIPTION="foo"
@@ -55,7 +154,6 @@ SLOT="0"
 SRC_URI="%s/good.tar.gz -> good.tar.gz"
 `, ts.URL))
 
-		// Manifest has obsolete entry, missing good.tar.gz
 		manifestContent := "DIST obsolete.tar.gz 123 SHA512 abc\n"
 		writeTestManifest(t, dir, manifestContent)
 
@@ -67,98 +165,12 @@ SRC_URI="%s/good.tar.gz -> good.tar.gz"
 			t.Fatalf("cmdVerify failed: %v", err)
 		}
 
-		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
-		if err != nil {
-			t.Fatalf("reading manifest: %v", err)
-		}
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
 		result := string(b)
-		if !strings.Contains(result, "DIST good.tar.gz") {
-			t.Errorf("Expected good.tar.gz in manifest, got: %s", result)
-		}
-		if strings.Contains(result, "obsolete.tar.gz") {
-			t.Errorf("Expected obsolete.tar.gz to be removed, got: %s", result)
-		}
-	})
 
-	t.Run("Failed download aborts transaction", func(t *testing.T) {
-		dir := t.TempDir()
-		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
-DESCRIPTION="foo"
-SLOT="0"
-SRC_URI="%s/fail.tar.gz -> fail.tar.gz"
-`, ts.URL))
-
-		originalManifest := "DIST other.tar.gz 123 SHA512 abc\n"
-		writeTestManifest(t, dir, originalManifest)
-
-		cfg := &CmdManifestArgConfig{}
-		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
-		if err == nil {
-			t.Fatalf("Expected cmdVerify to fail")
-		}
-
-		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
-		if err != nil {
-			t.Fatalf("reading manifest: %v", err)
-		}
-		if string(b) != originalManifest {
-			t.Errorf("Manifest was modified on failure! Got: %s", string(b))
-		}
-	})
-
-	t.Run("Uncertain ebuild aborts clean and fix", func(t *testing.T) {
-		dir := t.TempDir()
-		// Uses inherit without explicit SRC_URI => uncertain
-		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
-inherit someclass
-DESCRIPTION="foo"
-SLOT="0"
-`)
-		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
-		writeTestManifest(t, dir, originalManifest)
-
-		cfg := &CmdManifestArgConfig{}
-		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
-		if err == nil {
-			t.Fatalf("Expected error about uncertainty")
-		}
-
-		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
-		if err != nil {
-			t.Fatalf("reading manifest: %v", err)
-		}
-		if string(b) != originalManifest {
-			t.Errorf("Manifest was modified despite uncertainty! Got: %s", string(b))
-		}
-	})
-
-	t.Run("Revisioned P vs PF filenames", func(t *testing.T) {
-		dir := t.TempDir()
-		writeTestEbuild(t, dir, "foo-1.0-r1.ebuild", fmt.Sprintf(`EAPI=8
-DESCRIPTION="foo"
-SLOT="0"
-SRC_URI="%s/good.tar.gz -> ${PF}.tar.gz
-%s/missing.tar.gz -> ${P}.tar.gz"
-`, ts.URL, ts.URL))
-
-		writeTestManifest(t, dir, "")
-
-		cfg := &CmdManifestArgConfig{}
-		err := cfg.cmdVerify([]string{"--fix", dir}, hashes)
-		if err != nil {
-			t.Fatalf("cmdVerify failed: %v", err)
-		}
-
-		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
-		if err != nil {
-			t.Fatalf("reading manifest: %v", err)
-		}
-		result := string(b)
-		if !strings.Contains(result, "foo-1.0-r1.tar.gz") {
-			t.Errorf("Expected PF resolution (foo-1.0-r1.tar.gz): %s", result)
-		}
-		if !strings.Contains(result, "foo-1.0.tar.gz") {
-			t.Errorf("Expected P resolution (foo-1.0.tar.gz): %s", result)
+		lines := strings.Split(strings.TrimSpace(result), "\n")
+		if len(lines) != 1 || !strings.HasPrefix(lines[0], "DIST good.tar.gz ") {
+			t.Errorf("Expected exact single DIST entry for good.tar.gz, got:\n%s", result)
 		}
 	})
 
@@ -169,57 +181,22 @@ DESCRIPTION="foo"
 SLOT="0"
 SRC_URI="%s/good.tar.gz -> good.tar.gz"
 `, ts.URL))
-
 		writeTestManifest(t, dir, "")
-
-		cfg := &CmdManifestArgConfig{}
+		cfg := &CmdManifestArgConfig{
+			MainArgConfig: &MainArgConfig{},
+		}
 		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
 		if err != nil {
 			t.Fatalf("cmdVerify failed: %v", err)
 		}
-
 		b1, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
-
 		err = cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
 		if err != nil {
 			t.Fatalf("cmdVerify failed 2nd time: %v", err)
 		}
-
 		b2, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
 		if string(b1) != string(b2) {
 			t.Errorf("Idempotency failed")
-		}
-	})
-}
-
-func TestCmdUpsertFromUrl(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("good data"))
-	}))
-	defer ts.Close()
-
-	hashes := []string{g2.HashSha512}
-
-	t.Run("Preserves revision text", func(t *testing.T) {
-		dir := t.TempDir()
-		writeTestManifest(t, dir, "")
-
-		cfg := &CmdManifestArgConfig{
-			MainArgConfig: &MainArgConfig{},
-		}
-		// Notice filename is "foo-1.0-r1.tar.gz"
-		err := cfg.cmdUpsertFromUrl([]string{ts.URL + "/good.tar.gz", "foo-1.0-r1.tar.gz", dir}, hashes)
-		if err != nil {
-			t.Fatalf("cmdUpsertFromUrl failed: %v", err)
-		}
-
-		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
-		if err != nil {
-			t.Fatalf("reading manifest: %v", err)
-		}
-		result := string(b)
-		if !strings.Contains(result, "DIST foo-1.0-r1.tar.gz") {
-			t.Errorf("Expected exact filename to be preserved, got: %s", result)
 		}
 	})
 }

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arran4/g2"
+)
+
+func writeTestEbuild(t *testing.T, dir, name, content string) {
+	err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("writing ebuild %s: %v", name, err)
+	}
+}
+
+func writeTestManifest(t *testing.T, dir, content string) {
+	err := os.WriteFile(filepath.Join(dir, "Manifest"), []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+}
+
+func TestCmdVerifyTransactional(t *testing.T) {
+	// Start fake HTTP server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fail.tar.gz" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if r.URL.Path == "/good.tar.gz" {
+			w.Write([]byte("good data"))
+			return
+		}
+		if r.URL.Path == "/missing.tar.gz" {
+			w.Write([]byte("missing data"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	hashes := []string{g2.HashSha512}
+
+	t.Run("Missing + Obsolete DIST: Fix + Clean writes exact set once", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/good.tar.gz -> good.tar.gz"
+`, ts.URL))
+
+		// Manifest has obsolete entry, missing good.tar.gz
+		manifestContent := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, manifestContent)
+
+		cfg := &CmdManifestArgConfig{
+			MainArgConfig: &MainArgConfig{},
+		}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err != nil {
+			t.Fatalf("cmdVerify failed: %v", err)
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		result := string(b)
+		if !strings.Contains(result, "DIST good.tar.gz") {
+			t.Errorf("Expected good.tar.gz in manifest, got: %s", result)
+		}
+		if strings.Contains(result, "obsolete.tar.gz") {
+			t.Errorf("Expected obsolete.tar.gz to be removed, got: %s", result)
+		}
+	})
+
+	t.Run("Failed download aborts transaction", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/fail.tar.gz -> fail.tar.gz"
+`, ts.URL))
+
+		originalManifest := "DIST other.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("Expected cmdVerify to fail")
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		if string(b) != originalManifest {
+			t.Errorf("Manifest was modified on failure! Got: %s", string(b))
+		}
+	})
+
+	t.Run("Uncertain ebuild aborts clean and fix", func(t *testing.T) {
+		dir := t.TempDir()
+		// Uses inherit without explicit SRC_URI => uncertain
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+inherit someclass
+DESCRIPTION="foo"
+SLOT="0"
+`)
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("Expected error about uncertainty")
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		if string(b) != originalManifest {
+			t.Errorf("Manifest was modified despite uncertainty! Got: %s", string(b))
+		}
+	})
+
+	t.Run("Revisioned P vs PF filenames", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0-r1.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/good.tar.gz -> ${PF}.tar.gz
+%s/missing.tar.gz -> ${P}.tar.gz"
+`, ts.URL, ts.URL))
+
+		writeTestManifest(t, dir, "")
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", dir}, hashes)
+		if err != nil {
+			t.Fatalf("cmdVerify failed: %v", err)
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		result := string(b)
+		if !strings.Contains(result, "foo-1.0-r1.tar.gz") {
+			t.Errorf("Expected PF resolution (foo-1.0-r1.tar.gz): %s", result)
+		}
+		if !strings.Contains(result, "foo-1.0.tar.gz") {
+			t.Errorf("Expected P resolution (foo-1.0.tar.gz): %s", result)
+		}
+	})
+
+	t.Run("Idempotency", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/good.tar.gz -> good.tar.gz"
+`, ts.URL))
+
+		writeTestManifest(t, dir, "")
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err != nil {
+			t.Fatalf("cmdVerify failed: %v", err)
+		}
+
+		b1, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+
+		err = cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err != nil {
+			t.Fatalf("cmdVerify failed 2nd time: %v", err)
+		}
+
+		b2, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if string(b1) != string(b2) {
+			t.Errorf("Idempotency failed")
+		}
+	})
+}
+
+func TestCmdUpsertFromUrl(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("good data"))
+	}))
+	defer ts.Close()
+
+	hashes := []string{g2.HashSha512}
+
+	t.Run("Preserves revision text", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestManifest(t, dir, "")
+
+		cfg := &CmdManifestArgConfig{
+			MainArgConfig: &MainArgConfig{},
+		}
+		// Notice filename is "foo-1.0-r1.tar.gz"
+		err := cfg.cmdUpsertFromUrl([]string{ts.URL + "/good.tar.gz", "foo-1.0-r1.tar.gz", dir}, hashes)
+		if err != nil {
+			t.Fatalf("cmdUpsertFromUrl failed: %v", err)
+		}
+
+		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if err != nil {
+			t.Fatalf("reading manifest: %v", err)
+		}
+		result := string(b)
+		if !strings.Contains(result, "DIST foo-1.0-r1.tar.gz") {
+			t.Errorf("Expected exact filename to be preserved, got: %s", result)
+		}
+	})
+}

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -183,8 +183,8 @@ SRC_URI="%s/good.tar.gz -> good.tar.gz"
 		writeTestManifest(t, dir, "")
 
 		// Create a directory at Manifest so write fails
-		os.Remove(filepath.Join(dir, "Manifest"))
-		os.Mkdir(filepath.Join(dir, "Manifest"), 0755)
+		_ = os.Remove(filepath.Join(dir, "Manifest"))
+		_ = os.Mkdir(filepath.Join(dir, "Manifest"), 0755)
 
 		cfg := &CmdManifestArgConfig{}
 		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -88,32 +88,6 @@ SRC_URI="%s/good.tar.gz -> good.tar.gz"
 		}
 	})
 
-	t.Run("Failed download aborts transaction", func(t *testing.T) {
-		dir := t.TempDir()
-		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
-DESCRIPTION="foo"
-SLOT="0"
-SRC_URI="%s/fail.tar.gz -> fail.tar.gz"
-`, ts.URL))
-
-		originalManifest := "DIST other.tar.gz 123 SHA512 abc\n"
-		writeTestManifest(t, dir, originalManifest)
-
-		cfg := &CmdManifestArgConfig{}
-		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
-		if err == nil {
-			t.Fatalf("Expected cmdVerify to fail")
-		}
-
-		b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
-		if err != nil {
-			t.Fatalf("reading manifest: %v", err)
-		}
-		if string(b) != originalManifest {
-			t.Errorf("Manifest was modified on failure! Got: %s", string(b))
-		}
-	})
-
 	t.Run("Uncertain ebuild aborts clean and fix", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
@@ -139,32 +113,61 @@ SLOT="0"
 		}
 	})
 
-	t.Run("Successful first fetch, failing later fetch preserves exact Manifest bytes", func(t *testing.T) {
+	t.Run("Response-body processing failure aborted safely", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/fail.tar.gz -> fail.tar.gz"
+`, ts.URL))
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("Expected cmdVerify to fail")
+		}
+
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if string(b) != originalManifest {
+			t.Errorf("Manifest was modified on failure! Got: %s", string(b))
+		}
+	})
+
+	t.Run("Successful first fetch, failing later fetch preserves exact Manifest bytes", func(t *testing.T) {
+		for _, clean := range []bool{true, false} {
+			dir := t.TempDir()
+			writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
 DESCRIPTION="foo"
 SLOT="0"
 SRC_URI="%s/firstgood.tar.gz -> firstgood.tar.gz
 %s/laterfail.tar.gz -> laterfail.tar.gz"
 `, ts.URL, ts.URL))
 
-		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
-		writeTestManifest(t, dir, originalManifest)
+			originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+			writeTestManifest(t, dir, originalManifest)
 
-		cfg := &CmdManifestArgConfig{
-			MainArgConfig: &MainArgConfig{},
-		}
-		err := cfg.cmdVerify([]string{"--fix", dir}, hashes)
-		if err == nil {
-			t.Fatalf("cmdVerify expected to fail due to laterfail.tar.gz")
-		}
+			cfg := &CmdManifestArgConfig{
+				MainArgConfig: &MainArgConfig{},
+			}
+			args := []string{"--fix"}
+			if clean {
+				args = append(args, "--clean")
+			}
+			args = append(args, dir)
 
-		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
-		if string(b) != originalManifest {
-			t.Errorf("Manifest modified despite failed later download! Got:\n%s", string(b))
+			err := cfg.cmdVerify(args, hashes)
+			if err == nil {
+				t.Fatalf("cmdVerify expected to fail due to laterfail.tar.gz with clean=%v", clean)
+			}
+
+			b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+			if string(b) != originalManifest {
+				t.Errorf("Manifest modified despite failed later download (clean=%v)! Got:\n%s", clean, string(b))
+			}
 		}
 	})
-
 	t.Run("Transitive unknown variables conservatively aborted", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -130,6 +130,69 @@ fi
 		}
 	})
 
+	t.Run("Unsupported shell control-flow syntax silently treated as authoritative aborted", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+SRC_URI="" && SRC_URI="https://example.invalid/a.tar.gz"
+`)
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("cmdVerify expected to abort due to control flow `&&`")
+		}
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if string(b) != originalManifest {
+			t.Errorf("Manifest modified despite uncertainty! Got:\n%s", string(b))
+		}
+	})
+
+	t.Run("Revisioned P vs PF filenames reconciliation coverage", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0-r1.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/good.tar.gz -> ${PF}.tar.gz
+%s/missing.tar.gz -> ${P}.tar.gz"
+`, ts.URL, ts.URL))
+		writeTestManifest(t, dir, "")
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", dir}, hashes)
+		if err != nil {
+			t.Fatalf("cmdVerify failed: %v", err)
+		}
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		result := string(b)
+		if !strings.Contains(result, "foo-1.0-r1.tar.gz") {
+			t.Errorf("Expected PF resolution (foo-1.0-r1.tar.gz): %s", result)
+		}
+		if !strings.Contains(result, "foo-1.0.tar.gz") {
+			t.Errorf("Expected P resolution (foo-1.0.tar.gz): %s", result)
+		}
+	})
+
+	t.Run("AtomicWriteManifest failure test", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="%s/good.tar.gz -> good.tar.gz"
+`, ts.URL))
+		writeTestManifest(t, dir, "")
+
+		// Create a directory at Manifest so write fails
+		os.Remove(filepath.Join(dir, "Manifest"))
+		os.Mkdir(filepath.Join(dir, "Manifest"), 0755)
+
+		cfg := &CmdManifestArgConfig{}
+		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
+		if err == nil {
+			t.Fatalf("cmdVerify expected to fail on writing manifest")
+		}
+	})
+
 	t.Run("Valid conditional source lists plus malformed groups/rename targets", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -275,23 +275,34 @@ SRC_URI="%s/good.tar.gz -> ${PF}.tar.gz
 		}
 	})
 
-	t.Run("AtomicWriteManifest failure test", func(t *testing.T) {
+	t.Run("AtomicWriteManifest failure test deterministically reaching final commit", func(t *testing.T) {
 		dir := t.TempDir()
 		writeTestEbuild(t, dir, "foo-1.0.ebuild", fmt.Sprintf(`EAPI=8
 DESCRIPTION="foo"
 SLOT="0"
 SRC_URI="%s/good.tar.gz -> good.tar.gz"
 `, ts.URL))
-		writeTestManifest(t, dir, "")
+		originalManifest := "DIST obsolete.tar.gz 123 SHA512 abc\n"
+		writeTestManifest(t, dir, originalManifest)
 
-		// Create a directory at Manifest so write fails
-		_ = os.Remove(filepath.Join(dir, "Manifest"))
-		_ = os.Mkdir(filepath.Join(dir, "Manifest"), 0755)
+		// Hook the atomic write function inside main package
+		atomicWriteManifest = func(path string, m *g2.Manifest) error {
+			return os.ErrPermission
+		}
+		t.Cleanup(func() { atomicWriteManifest = g2.AtomicWriteManifest })
 
 		cfg := &CmdManifestArgConfig{}
 		err := cfg.cmdVerify([]string{"--fix", "--clean", dir}, hashes)
 		if err == nil {
 			t.Fatalf("cmdVerify expected to fail on writing manifest")
+		}
+		if !strings.Contains(err.Error(), "permission denied") {
+			t.Errorf("Expected permission denied error from write path, got: %v", err)
+		}
+
+		b, _ := os.ReadFile(filepath.Join(dir, "Manifest"))
+		if string(b) != originalManifest {
+			t.Errorf("Manifest was modified on failure! Got: %s", string(b))
 		}
 	})
 

--- a/cmd/g2/manifest_verify_transactional_test.go
+++ b/cmd/g2/manifest_verify_transactional_test.go
@@ -34,11 +34,11 @@ func TestCmdVerifyTransactional(t *testing.T) {
 			return
 		}
 		if r.URL.Path == "/good.tar.gz" {
-			w.Write([]byte("good data"))
+			_, _ = w.Write([]byte("good data"))
 			return
 		}
 		if r.URL.Path == "/missing.tar.gz" {
-			w.Write([]byte("missing data"))
+			_, _ = w.Write([]byte("missing data"))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -194,7 +194,7 @@ SRC_URI="%s/good.tar.gz -> good.tar.gz"
 
 func TestCmdUpsertFromUrl(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("good data"))
+		_, _ = w.Write([]byte("good data"))
 	}))
 	defer ts.Close()
 

--- a/doc/g2.1.md
+++ b/doc/g2.1.md
@@ -22,10 +22,10 @@ Commands relating to **Manifest** files.
   Flags: `-blake2b`, `-blake2s`, `-md5`, `-rmd160`, `-sha1`, `-sha256`, `-sha3_256`, `-sha3_512`, `-sha512` (default: `blake2b` and `sha512`).
 
 - **verify** [*--fix*] [*--clean*] *<manifestFileOrDir>*
-  Verifies the `Manifest` entries against the ebuild URIs. If `--fix` is passed, missing entries will be downloaded and upserted. If `--clean` is passed, unused entries will be removed.
+  Verify Manifest entries against local .ebuild files. Use --fix to aggressively fetch and append missing entries transactionally. Uses an all-or-nothing fetch/checksum/write approach: any failure cleanly aborts without writes. Automatically refuses destructive writes upon uncertain source resolutions.
 
 - **clean** *<manifestFileOrDir>*
-  Removes unused entries from the `Manifest` file.
+  Remove unused DIST entries safely. Refuses execution if any ebuild contains uncertain sources (e.g. eclasses or dynamic bash resolution dependencies).
 
 ## `metadata`
 Commands relating to modifying **metadata.xml** files.

--- a/ebuild.go
+++ b/ebuild.go
@@ -245,11 +245,10 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 		e.EbuildHeader = parsedEbuild.EbuildHeader
 	}
 
-	if mode >= ParseFull {
-		uris, _ := ExtractURIs(content, e.Vars)
-		// Don't fail hard on URI extraction?
-		// The user said "partial implementation".
-		e.SrcUri = uris
+		if mode >= ParseFull {
+		if srcUriStr, ok := e.Vars["SRC_URI"]; ok {
+			e.SrcUri = ParseSrcURI(srcUriStr)
+		}
 	}
 
 	return e, nil
@@ -1440,16 +1439,48 @@ func ParseEbuildVariablesFromReader(r io.Reader) map[string]string {
 	return vars
 }
 
-var reInherit = regexp.MustCompile(`(?m)^[ \t]*inherit\b`)
+var reInherit = regexp.MustCompile(`(?m)^[ 	]*(?:[A-Za-z0-9_]+=[^ 	;]*[ 	;]+)*inherit`)
 
 // IsSrcUriAuthoritative checks if the ebuild's SRC_URI resolution is complete and authoritative.
 func (e *Ebuild) IsSrcUriAuthoritative() bool {
 	if reInherit.MatchString(e.RawText) {
 		return false
 	}
+	if len(e.ParseWarnings) > 0 {
+		return false
+	}
 	srcUriStr := e.Vars["SRC_URI"]
-	if strings.Contains(srcUriStr, "$(") || strings.Contains(srcUriStr, "`") {
+	if strings.Contains(srcUriStr, "$") || strings.Contains(srcUriStr, "`") {
 		return false
 	}
 	return true
+}
+
+// ParseSrcURI parses the evaluated SRC_URI string into structured URI entries.
+func ParseSrcURI(srcUriStr string) []URIEntry {
+	var uris []URIEntry
+	tokens := strings.Fields(srcUriStr)
+	i := 0
+	for i < len(tokens) {
+		token := tokens[i]
+
+		// If the token is '->' it's a syntax error in the string structure without a preceding URL
+		if token == "->" {
+			i++
+			continue
+		}
+
+		url := token
+		filename := filepath.Base(url)
+
+		if i+2 < len(tokens) && tokens[i+1] == "->" {
+			filename = tokens[i+2]
+			i += 3
+		} else {
+			i += 1
+		}
+
+		uris = append(uris, URIEntry{URL: url, Filename: filename})
+	}
+	return uris
 }

--- a/ebuild.go
+++ b/ebuild.go
@@ -225,7 +225,22 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 
 		// Evaluate assignments sequentially in source order
 		for _, assignment := range parsedEbuild.Assignments {
+			if assignment.Name == "SRC_URI" {
+				// Detect unresolvable variables
+				reVar := regexp.MustCompile(`\$\{?([a-zA-Z0-9_]+)\}?`)
+				matches := reVar.FindAllStringSubmatch(assignment.Value, -1)
+				for _, m := range matches {
+					varName := m[1]
+					if _, exists := e.Vars[varName]; !exists {
+						e.Vars["_SRC_URI_RAW_UNCERTAIN"] = "true"
+					}
+				}
+				if strings.Contains(assignment.Value, "`") || strings.Contains(assignment.Value, "$(") {
+					e.Vars["_SRC_URI_RAW_UNCERTAIN"] = "true"
+				}
+			}
 			val := ResolveVariables(assignment.Value, e.Vars)
+
 			if assignment.Append {
 				if e.Vars[assignment.Name] != "" {
 					e.Vars[assignment.Name] += " " + val
@@ -245,9 +260,13 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 		e.EbuildHeader = parsedEbuild.EbuildHeader
 	}
 
-	if mode >= ParseFull {
+		if mode >= ParseFull {
 		if srcUriStr, ok := e.Vars["SRC_URI"]; ok {
-			e.SrcUri = ParseSrcURI(srcUriStr)
+			uris, uncertain := ParseSrcURI(srcUriStr)
+			e.SrcUri = uris
+			if uncertain {
+				e.Vars["_SRC_URI_UNCERTAIN"] = "true"
+			}
 		}
 	}
 
@@ -1441,12 +1460,21 @@ func ParseEbuildVariablesFromReader(r io.Reader) map[string]string {
 
 // IsSrcUriAuthoritative checks if the ebuild's SRC_URI resolution is complete and authoritative.
 func (e *Ebuild) IsSrcUriAuthoritative() bool {
-	if strings.Contains(e.RawText, "inherit ") || strings.Contains(e.RawText, "\ninherit") || strings.HasPrefix(e.RawText, "inherit") {
+	// If INHERITED is set by the parser, eclasses are involved.
+	if e.Vars["INHERITED"] != "" {
 		return false
 	}
 	if len(e.ParseWarnings) > 0 {
 		return false
 	}
+	// Check if any source URIs were marked as uncertain during extraction
+	if e.Vars["_SRC_URI_UNCERTAIN"] == "true" {
+		return false
+	}
+	if e.Vars["_SRC_URI_RAW_UNCERTAIN"] == "true" {
+		return false
+	}
+
 	srcUriStr := e.Vars["SRC_URI"]
 	if strings.Contains(srcUriStr, "$") || strings.Contains(srcUriStr, "`") {
 		return false
@@ -1455,15 +1483,28 @@ func (e *Ebuild) IsSrcUriAuthoritative() bool {
 }
 
 // ParseSrcURI parses the evaluated SRC_URI string into structured URI entries.
-func ParseSrcURI(srcUriStr string) []URIEntry {
+// It recognizes Gentoo source-list syntax and flags unsupported lists.
+func ParseSrcURI(srcUriStr string) ([]URIEntry, bool) {
 	var uris []URIEntry
 	tokens := strings.Fields(srcUriStr)
 	i := 0
+	uncertain := false
 	for i < len(tokens) {
 		token := tokens[i]
 
-		// If the token is '->' it's a syntax error in the string structure without a preceding URL
+		// Control tokens or syntactical groupings
+		if token == "(" || token == ")" {
+			i++
+			continue
+		}
+		if strings.HasSuffix(token, "?") { // USE flag conditional
+			i++
+			continue
+		}
+
 		if token == "->" {
+			// Dangling rename arrow
+			uncertain = true
 			i++
 			continue
 		}
@@ -1478,7 +1519,12 @@ func ParseSrcURI(srcUriStr string) []URIEntry {
 			i += 1
 		}
 
-		uris = append(uris, URIEntry{URL: url, Filename: filename})
+		// Only add actual URIs
+		if strings.Contains(url, "://") {
+			uris = append(uris, URIEntry{URL: url, Filename: filename})
+		} else {
+			uncertain = true
+		}
 	}
-	return uris
+	return uris, uncertain
 }

--- a/ebuild.go
+++ b/ebuild.go
@@ -277,7 +277,7 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 		e.orderOverride = parsedEbuild.Order
 		e.EbuildHeader = parsedEbuild.EbuildHeader
 		if parsedEbuild.HasControlFlow {
-			e.Vars["_SRC_URI_UNCERTAIN"] = "true"
+			e.SrcUriUncertain = true
 		}
 	}
 
@@ -1488,7 +1488,7 @@ func (e *Ebuild) IsSrcUriAuthoritative() bool {
 	if len(e.ParseWarnings) > 0 {
 		return false
 	}
-	if e.SrcUriUncertain || e.Vars["_SRC_URI_UNCERTAIN"] == "true" {
+	if e.SrcUriUncertain {
 		return false
 	}
 	return true

--- a/ebuild.go
+++ b/ebuild.go
@@ -276,6 +276,9 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 		}
 		e.orderOverride = parsedEbuild.Order
 		e.EbuildHeader = parsedEbuild.EbuildHeader
+		if parsedEbuild.HasControlFlow {
+			e.Vars["_SRC_URI_UNCERTAIN"] = "true"
+		}
 	}
 
 	if mode >= ParseFull {
@@ -1485,7 +1488,7 @@ func (e *Ebuild) IsSrcUriAuthoritative() bool {
 	if len(e.ParseWarnings) > 0 {
 		return false
 	}
-	if e.SrcUriUncertain {
+	if e.SrcUriUncertain || e.Vars["_SRC_URI_UNCERTAIN"] == "true" {
 		return false
 	}
 	return true

--- a/ebuild.go
+++ b/ebuild.go
@@ -1439,3 +1439,17 @@ func ParseEbuildVariablesFromReader(r io.Reader) map[string]string {
 	}
 	return vars
 }
+
+var reInherit = regexp.MustCompile(`(?m)^[ \t]*inherit\b`)
+
+// IsSrcUriAuthoritative checks if the ebuild's SRC_URI resolution is complete and authoritative.
+func (e *Ebuild) IsSrcUriAuthoritative() bool {
+	if reInherit.MatchString(e.RawText) {
+		return false
+	}
+	srcUriStr := e.Vars["SRC_URI"]
+	if strings.Contains(srcUriStr, "$(") || strings.Contains(srcUriStr, "`") {
+		return false
+	}
+	return true
+}

--- a/ebuild.go
+++ b/ebuild.go
@@ -41,13 +41,14 @@ func (m ParsingMode) String() string {
 }
 
 type Ebuild struct {
-	Path          string
-	Vars          map[string]string
-	Functions     map[string]AST
-	SrcUri        []URIEntry
-	Mode          ParsingMode
-	RawText       string
-	ParseWarnings []string
+	Path            string
+	Vars            map[string]string
+	Functions       map[string]AST
+	SrcUri          []URIEntry
+	Mode            ParsingMode
+	RawText         string
+	ParseWarnings   []string
+	SrcUriUncertain bool
 
 	orderOverride []string
 	EbuildHeader  string
@@ -223,24 +224,37 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 
 		e.ParseWarnings = append(parser.Warnings, parsedEbuild.Warnings...)
 
+		uncertainVars := make(map[string]bool)
+		reVar := regexp.MustCompile(`\$+\{?([a-zA-Z0-9_]+)\}?`)
+
 		// Evaluate assignments sequentially in source order
 		for _, assignment := range parsedEbuild.Assignments {
-			if assignment.Name == "SRC_URI" {
-				// Detect unresolvable variables
-				reVar := regexp.MustCompile(`\$\{?([a-zA-Z0-9_]+)\}?`)
+			isUncertain := false
+
+			if strings.Contains(assignment.Value, "`") || strings.Contains(assignment.Value, "$(") {
+				isUncertain = true
+			} else {
 				matches := reVar.FindAllStringSubmatch(assignment.Value, -1)
 				for _, m := range matches {
 					varName := m[1]
 					if _, exists := e.Vars[varName]; !exists {
-						e.Vars["_SRC_URI_RAW_UNCERTAIN"] = "true"
+						isUncertain = true
+						break
+					}
+					if uncertainVars[varName] {
+						isUncertain = true
+						break
 					}
 				}
-				if strings.Contains(assignment.Value, "`") || strings.Contains(assignment.Value, "$(") {
-					e.Vars["_SRC_URI_RAW_UNCERTAIN"] = "true"
-				}
 			}
-			val := ResolveVariables(assignment.Value, e.Vars)
 
+			if isUncertain {
+				uncertainVars[assignment.Name] = true
+			} else if !assignment.Append {
+				delete(uncertainVars, assignment.Name)
+			}
+
+			val := ResolveVariables(assignment.Value, e.Vars)
 			if assignment.Append {
 				if e.Vars[assignment.Name] != "" {
 					e.Vars[assignment.Name] += " " + val
@@ -252,6 +266,10 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 			}
 		}
 
+		if uncertainVars["SRC_URI"] {
+			e.SrcUriUncertain = true
+		}
+
 		e.Functions = make(map[string]AST)
 		for k, v := range parsedEbuild.Functions {
 			e.Functions[k] = v
@@ -260,12 +278,12 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 		e.EbuildHeader = parsedEbuild.EbuildHeader
 	}
 
-		if mode >= ParseFull {
+	if mode >= ParseFull {
 		if srcUriStr, ok := e.Vars["SRC_URI"]; ok {
 			uris, uncertain := ParseSrcURI(srcUriStr)
 			e.SrcUri = uris
 			if uncertain {
-				e.Vars["_SRC_URI_UNCERTAIN"] = "true"
+				e.SrcUriUncertain = true
 			}
 		}
 	}
@@ -1467,16 +1485,7 @@ func (e *Ebuild) IsSrcUriAuthoritative() bool {
 	if len(e.ParseWarnings) > 0 {
 		return false
 	}
-	// Check if any source URIs were marked as uncertain during extraction
-	if e.Vars["_SRC_URI_UNCERTAIN"] == "true" {
-		return false
-	}
-	if e.Vars["_SRC_URI_RAW_UNCERTAIN"] == "true" {
-		return false
-	}
-
-	srcUriStr := e.Vars["SRC_URI"]
-	if strings.Contains(srcUriStr, "$") || strings.Contains(srcUriStr, "`") {
+	if e.SrcUriUncertain {
 		return false
 	}
 	return true
@@ -1489,11 +1498,21 @@ func ParseSrcURI(srcUriStr string) ([]URIEntry, bool) {
 	tokens := strings.Fields(srcUriStr)
 	i := 0
 	uncertain := false
+	balance := 0
+
 	for i < len(tokens) {
 		token := tokens[i]
 
 		// Control tokens or syntactical groupings
-		if token == "(" || token == ")" {
+		if token == "(" {
+			balance++
+			i++
+			continue
+		} else if token == ")" {
+			balance--
+			if balance < 0 {
+				uncertain = true
+			}
 			i++
 			continue
 		}
@@ -1514,6 +1533,9 @@ func ParseSrcURI(srcUriStr string) ([]URIEntry, bool) {
 
 		if i+2 < len(tokens) && tokens[i+1] == "->" {
 			filename = tokens[i+2]
+			if filename == ")" || filename == "(" || filename == "->" || strings.HasSuffix(filename, "?") {
+				uncertain = true
+			}
 			i += 3
 		} else {
 			i += 1
@@ -1526,5 +1548,10 @@ func ParseSrcURI(srcUriStr string) ([]URIEntry, bool) {
 			uncertain = true
 		}
 	}
+
+	if balance != 0 {
+		uncertain = true
+	}
+
 	return uris, uncertain
 }

--- a/ebuild.go
+++ b/ebuild.go
@@ -245,7 +245,7 @@ func ParseEbuild(fsys fs.FS, path string, mode ParsingMode) (*Ebuild, error) {
 		e.EbuildHeader = parsedEbuild.EbuildHeader
 	}
 
-		if mode >= ParseFull {
+	if mode >= ParseFull {
 		if srcUriStr, ok := e.Vars["SRC_URI"]; ok {
 			e.SrcUri = ParseSrcURI(srcUriStr)
 		}
@@ -1439,11 +1439,9 @@ func ParseEbuildVariablesFromReader(r io.Reader) map[string]string {
 	return vars
 }
 
-var reInherit = regexp.MustCompile(`(?m)^[ 	]*(?:[A-Za-z0-9_]+=[^ 	;]*[ 	;]+)*inherit`)
-
 // IsSrcUriAuthoritative checks if the ebuild's SRC_URI resolution is complete and authoritative.
 func (e *Ebuild) IsSrcUriAuthoritative() bool {
-	if reInherit.MatchString(e.RawText) {
+	if strings.Contains(e.RawText, "inherit ") || strings.Contains(e.RawText, "\ninherit") || strings.HasPrefix(e.RawText, "inherit") {
 		return false
 	}
 	if len(e.ParseWarnings) > 0 {

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -203,9 +203,10 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 					err := CleanManifest(os.DirFS(pkgDir), ".", manifest)
 					if err != nil {
 						log.Printf("DeduplicateEbuilds: %v", err)
-					}
-					if err = AtomicWriteManifest(manifestPath, manifest); err != nil {
-						return removedFiles, fmt.Errorf("deduplicate manifest write error: %w", err)
+					} else {
+						if err = AtomicWriteManifest(manifestPath, manifest); err != nil {
+							return removedFiles, fmt.Errorf("deduplicate manifest write error: %w", err)
+						}
 					}
 				} else {
 					return removedFiles, fmt.Errorf("deduplicate manifest read error: %w", err)

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -204,7 +204,7 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 					if err != nil {
 						log.Printf("DeduplicateEbuilds: %v", err)
 					} else {
-						if err = AtomicWriteManifest(manifestPath, manifest); err != nil {
+						if err = AtomicWriteManifestFunc(manifestPath, manifest); err != nil {
 							return removedFiles, fmt.Errorf("deduplicate manifest write error: %w", err)
 						}
 					}

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -203,8 +203,12 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 					err := CleanManifest(os.DirFS(pkgDir), ".", manifest)
 					if err != nil {
 						log.Printf("DeduplicateEbuilds: %v", err)
+					} else {
+						err = AtomicWriteManifest(manifestPath, manifest)
+						if err != nil {
+							log.Printf("DeduplicateEbuilds manifest write error: %v", err)
+						}
 					}
-					_ = AtomicWriteManifest(manifestPath, manifest)
 				}
 			} else {
 				_ = os.Remove(manifestPath)

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -203,11 +203,12 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 					err := CleanManifest(os.DirFS(pkgDir), ".", manifest)
 					if err != nil {
 						log.Printf("DeduplicateEbuilds: %v", err)
-					} else {
-						if err = AtomicWriteManifest(manifestPath, manifest); err != nil {
-							return nil, fmt.Errorf("deduplicate manifest write error: %w", err)
-						}
 					}
+					if err = AtomicWriteManifest(manifestPath, manifest); err != nil {
+						return removedFiles, fmt.Errorf("deduplicate manifest write error: %w", err)
+					}
+				} else {
+					return removedFiles, fmt.Errorf("deduplicate manifest read error: %w", err)
 				}
 			} else {
 				_ = os.Remove(manifestPath)

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -200,8 +200,11 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 			manifestPath := filepath.Join(pkgDir, "Manifest")
 			if ebuildCount > 0 {
 				if manifest, err := ParseManifest(manifestPath); err == nil {
-					_ = CleanManifest(os.DirFS(pkgDir), ".", manifest)
-					_ = os.WriteFile(manifestPath, []byte(manifest.String()), 0644)
+					err := CleanManifest(os.DirFS(pkgDir), ".", manifest)
+					if err != nil {
+						log.Printf("DeduplicateEbuilds: %v", err)
+					}
+					_ = AtomicWriteManifest(manifestPath, manifest)
 				}
 			} else {
 				_ = os.Remove(manifestPath)

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -204,9 +204,8 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 					if err != nil {
 						log.Printf("DeduplicateEbuilds: %v", err)
 					} else {
-						err = AtomicWriteManifest(manifestPath, manifest)
-						if err != nil {
-							log.Printf("DeduplicateEbuilds manifest write error: %v", err)
+						if err = AtomicWriteManifest(manifestPath, manifest); err != nil {
+							return nil, fmt.Errorf("deduplicate manifest write error: %w", err)
 						}
 					}
 				}

--- a/ebuild_deduplicate.go
+++ b/ebuild_deduplicate.go
@@ -204,7 +204,7 @@ func DeduplicateEbuilds(targets []string) ([]string, error) {
 					if err != nil {
 						log.Printf("DeduplicateEbuilds: %v", err)
 					} else {
-						if err = AtomicWriteManifestFunc(manifestPath, manifest); err != nil {
+						if err = AtomicWriteManifest(manifestPath, manifest); err != nil {
 							return removedFiles, fmt.Errorf("deduplicate manifest write error: %w", err)
 						}
 					}

--- a/ebuild_deduplicate_regression_test.go
+++ b/ebuild_deduplicate_regression_test.go
@@ -52,7 +52,6 @@ func TestDeduplicateEbuildsRegression(t *testing.T) {
 	}
 }
 
-var originalAtomicWriteManifest = AtomicWriteManifestFunc
 
 func TestDeduplicateEbuildsWriteErrorRegression(t *testing.T) {
 	dir := t.TempDir()
@@ -61,11 +60,10 @@ func TestDeduplicateEbuildsWriteErrorRegression(t *testing.T) {
 	writeTestEbuild(t, dir, "foo-2.0.ebuild", "EAPI=8\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\nSRC_URI=\"https://example.com/good.tar.gz\"\n")
 	writeTestManifest(t, dir, "DIST good.tar.gz 123 SHA512 abc\n")
 
-	// Inject a write failure
-	AtomicWriteManifestFunc = func(path string, m *Manifest) error {
+	atomicWriteManifestTestHook = func(path string, m *Manifest) error {
 		return os.ErrPermission
 	}
-	defer func() { AtomicWriteManifestFunc = originalAtomicWriteManifest }()
+	t.Cleanup(func() { atomicWriteManifestTestHook = nil })
 
 	removed, err := DeduplicateEbuilds([]string{dir})
 	if err == nil {
@@ -91,19 +89,22 @@ func TestAtomicWriteManifestFailure(t *testing.T) {
 }
 
 func TestAtomicWriteManifestTempFile(t *testing.T) {
-	dir := t.TempDir()
-	manifestPath := filepath.Join(dir, "Manifest")
-	m := &Manifest{}
+	t.Run("Direct temp-path regression for AtomicWriteManifest", func(t *testing.T) {
+		dir := t.TempDir()
+		manifestPath := filepath.Join(dir, "Manifest")
+		m := &Manifest{}
 
-	tmpPath := manifestPath + ".tmp"
-	_ = os.WriteFile(tmpPath, []byte("garbage"), 0644)
+		tmpPath := filepath.Join(dir, "Manifest.preexisting.tmp")
+		_ = os.WriteFile(tmpPath, []byte("garbage data"), 0644)
 
-	err := AtomicWriteManifest(manifestPath, m)
-	if err != nil {
-		t.Fatalf("Expected AtomicWriteManifest to succeed, got %v", err)
-	}
+		err := AtomicWriteManifest(manifestPath, m)
+		if err != nil {
+			t.Fatalf("Expected AtomicWriteManifest to succeed, got %v", err)
+		}
 
-	if _, err := os.Stat(tmpPath); err != nil {
-		t.Errorf("Our pre-existing garbage was deleted unexpectedly")
-	}
+		b, err := os.ReadFile(tmpPath)
+		if err != nil || string(b) != "garbage data" {
+			t.Errorf("Pre-existing similar temp file clobbered or removed! Bytes: %q, err: %v", string(b), err)
+		}
+	})
 }

--- a/ebuild_deduplicate_regression_test.go
+++ b/ebuild_deduplicate_regression_test.go
@@ -47,3 +47,34 @@ func TestDeduplicateEbuildsRegression(t *testing.T) {
 		t.Errorf("Expected good.tar.gz to be preserved in manifest, got: %s", result)
 	}
 }
+
+func TestDeduplicateEbuildsWriteErrorRegression(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="https://example.com/good.tar.gz"
+`)
+
+	writeTestEbuild(t, dir, "foo-2.0.ebuild", `EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="https://example.com/good.tar.gz"
+`)
+
+	writeTestManifest(t, dir, "DIST good.tar.gz 123 SHA512 abc\n")
+
+	// Make writing fail
+	os.Remove(filepath.Join(dir, "Manifest"))
+	os.Mkdir(filepath.Join(dir, "Manifest"), 0755)
+
+	removed, err := DeduplicateEbuilds([]string{dir})
+	if err == nil {
+		t.Fatalf("DeduplicateEbuilds expected to fail due to error")
+	}
+
+	if len(removed) != 1 || filepath.Base(removed[0]) != "foo-1.0.ebuild" {
+		t.Fatalf("Expected foo-1.0.ebuild to be removed before failure, got: %v", removed)
+	}
+}

--- a/ebuild_deduplicate_regression_test.go
+++ b/ebuild_deduplicate_regression_test.go
@@ -52,7 +52,6 @@ func TestDeduplicateEbuildsRegression(t *testing.T) {
 	}
 }
 
-
 func TestDeduplicateEbuildsWriteErrorRegression(t *testing.T) {
 	dir := t.TempDir()
 

--- a/ebuild_deduplicate_regression_test.go
+++ b/ebuild_deduplicate_regression_test.go
@@ -24,25 +24,11 @@ func writeTestManifest(t *testing.T, dir, content string) {
 func TestDeduplicateEbuildsRegression(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create two identical digest ebuilds
-	// One is older
-	writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
-DESCRIPTION="foo"
-SLOT="0"
-SRC_URI="https://example.com/good.tar.gz"
-`)
+	writeTestEbuild(t, dir, "foo-1.0.ebuild", "EAPI=8\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\nSRC_URI=\"https://example.com/good.tar.gz\"\n")
+	writeTestEbuild(t, dir, "foo-1.0-r1.ebuild", "EAPI=8\nif true; then inherit pypi; fi\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\n")
 
-	// One is newer, but relies on eclass (no SRC_URI but inherits eclass)
-	writeTestEbuild(t, dir, "foo-1.0-r1.ebuild", `EAPI=8
-inherit pypi
-DESCRIPTION="foo"
-SLOT="0"
-`)
-
-	// The manifest has the good.tar.gz file
 	writeTestManifest(t, dir, "DIST good.tar.gz 123 SHA512 abc\n")
 
-	// Run DeduplicateEbuilds
 	removed, err := DeduplicateEbuilds([]string{dir})
 	if err != nil {
 		t.Fatalf("DeduplicateEbuilds failed: %v", err)
@@ -52,7 +38,6 @@ SLOT="0"
 		t.Fatalf("Expected foo-1.0.ebuild to be removed, removed: %v", removed)
 	}
 
-	// Verify Manifest was preserved because foo-1.0-r1 is uncertain
 	b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
 	if err != nil {
 		t.Fatalf("reading manifest: %v", err)

--- a/ebuild_deduplicate_regression_test.go
+++ b/ebuild_deduplicate_regression_test.go
@@ -66,8 +66,8 @@ SRC_URI="https://example.com/good.tar.gz"
 	writeTestManifest(t, dir, "DIST good.tar.gz 123 SHA512 abc\n")
 
 	// Make writing fail
-	os.Remove(filepath.Join(dir, "Manifest"))
-	os.Mkdir(filepath.Join(dir, "Manifest"), 0755)
+	_ = os.Remove(filepath.Join(dir, "Manifest"))
+	_ = os.Mkdir(filepath.Join(dir, "Manifest"), 0755)
 
 	removed, err := DeduplicateEbuilds([]string{dir})
 	if err == nil {

--- a/ebuild_deduplicate_regression_test.go
+++ b/ebuild_deduplicate_regression_test.go
@@ -3,7 +3,6 @@ package g2
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -27,7 +26,8 @@ func TestDeduplicateEbuildsRegression(t *testing.T) {
 	writeTestEbuild(t, dir, "foo-1.0.ebuild", "EAPI=8\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\nSRC_URI=\"https://example.com/good.tar.gz\"\n")
 	writeTestEbuild(t, dir, "foo-1.0-r1.ebuild", "EAPI=8\nif true; then inherit pypi; fi\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\n")
 
-	writeTestManifest(t, dir, "DIST good.tar.gz 123 SHA512 abc\n")
+	originalManifest := "# Comments\n\nDIST good.tar.gz 123 SHA512 abc  \n"
+	writeTestManifest(t, dir, originalManifest)
 
 	removed, err := DeduplicateEbuilds([]string{dir})
 	if err != nil {
@@ -38,15 +38,21 @@ func TestDeduplicateEbuildsRegression(t *testing.T) {
 		t.Fatalf("Expected foo-1.0.ebuild to be removed, removed: %v", removed)
 	}
 
+	if _, err := os.Stat(filepath.Join(dir, "foo-1.0-r1.ebuild")); err != nil {
+		t.Fatalf("Expected foo-1.0-r1.ebuild to be retained")
+	}
+
 	b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
 	if err != nil {
 		t.Fatalf("reading manifest: %v", err)
 	}
 	result := string(b)
-	if !strings.Contains(result, "DIST good.tar.gz") {
-		t.Errorf("Expected good.tar.gz to be preserved in manifest, got: %s", result)
+	if result != originalManifest {
+		t.Errorf("Expected exactly preserved manifest bytes, got:\n%q\nwant:\n%q", result, originalManifest)
 	}
 }
+
+var originalAtomicWriteManifest = AtomicWriteManifestFunc
 
 func TestDeduplicateEbuildsWriteErrorRegression(t *testing.T) {
 	dir := t.TempDir()
@@ -55,14 +61,20 @@ func TestDeduplicateEbuildsWriteErrorRegression(t *testing.T) {
 	writeTestEbuild(t, dir, "foo-2.0.ebuild", "EAPI=8\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\nSRC_URI=\"https://example.com/good.tar.gz\"\n")
 	writeTestManifest(t, dir, "DIST good.tar.gz 123 SHA512 abc\n")
 
-	// Set dir read-only so write fails AFTER parse? No, ParseManifest reads successfully.
-	// AtomicWriteManifest calls CreateTemp which fails if dir is read-only.
-	// We need to wait for DeduplicateEbuilds to read the manifest, then make it read-only. That's racy.
-	// Instead, let's create a directory named Manifest, which will cause ParseManifest to FAIL, returning read error.
-	// But the user requested testing the WRITE error, and returning the removed paths on write failure.
+	// Inject a write failure
+	AtomicWriteManifestFunc = func(path string, m *Manifest) error {
+		return os.ErrPermission
+	}
+	defer func() { AtomicWriteManifestFunc = originalAtomicWriteManifest }()
 
-	// Actually, DeduplicateEbuilds parses the manifest, then cleans it, then atomic writes it.
-	// We can replace the AtomicWriteManifest logic test with a standalone test.
+	removed, err := DeduplicateEbuilds([]string{dir})
+	if err == nil {
+		t.Fatalf("DeduplicateEbuilds expected to fail due to write error")
+	}
+
+	if len(removed) != 1 || filepath.Base(removed[0]) != "foo-1.0.ebuild" {
+		t.Fatalf("Expected foo-1.0.ebuild to be removed before failure, got: %v", removed)
+	}
 }
 
 func TestAtomicWriteManifestFailure(t *testing.T) {

--- a/ebuild_deduplicate_regression_test.go
+++ b/ebuild_deduplicate_regression_test.go
@@ -1,0 +1,64 @@
+package g2
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestEbuild(t *testing.T, dir, name, content string) {
+	err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("writing ebuild %s: %v", name, err)
+	}
+}
+
+func writeTestManifest(t *testing.T, dir, content string) {
+	err := os.WriteFile(filepath.Join(dir, "Manifest"), []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+}
+
+func TestDeduplicateEbuildsRegression(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two identical digest ebuilds
+	// One is older
+	writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
+DESCRIPTION="foo"
+SLOT="0"
+SRC_URI="https://example.com/good.tar.gz"
+`)
+
+	// One is newer, but relies on eclass (no SRC_URI but inherits eclass)
+	writeTestEbuild(t, dir, "foo-1.0-r1.ebuild", `EAPI=8
+inherit pypi
+DESCRIPTION="foo"
+SLOT="0"
+`)
+
+	// The manifest has the good.tar.gz file
+	writeTestManifest(t, dir, "DIST good.tar.gz 123 SHA512 abc\n")
+
+	// Run DeduplicateEbuilds
+	removed, err := DeduplicateEbuilds([]string{dir})
+	if err != nil {
+		t.Fatalf("DeduplicateEbuilds failed: %v", err)
+	}
+
+	if len(removed) != 1 || filepath.Base(removed[0]) != "foo-1.0.ebuild" {
+		t.Fatalf("Expected foo-1.0.ebuild to be removed, removed: %v", removed)
+	}
+
+	// Verify Manifest was preserved because foo-1.0-r1 is uncertain
+	b, err := os.ReadFile(filepath.Join(dir, "Manifest"))
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+	result := string(b)
+	if !strings.Contains(result, "DIST good.tar.gz") {
+		t.Errorf("Expected good.tar.gz to be preserved in manifest, got: %s", result)
+	}
+}

--- a/ebuild_deduplicate_regression_test.go
+++ b/ebuild_deduplicate_regression_test.go
@@ -51,30 +51,47 @@ func TestDeduplicateEbuildsRegression(t *testing.T) {
 func TestDeduplicateEbuildsWriteErrorRegression(t *testing.T) {
 	dir := t.TempDir()
 
-	writeTestEbuild(t, dir, "foo-1.0.ebuild", `EAPI=8
-DESCRIPTION="foo"
-SLOT="0"
-SRC_URI="https://example.com/good.tar.gz"
-`)
-
-	writeTestEbuild(t, dir, "foo-2.0.ebuild", `EAPI=8
-DESCRIPTION="foo"
-SLOT="0"
-SRC_URI="https://example.com/good.tar.gz"
-`)
-
+	writeTestEbuild(t, dir, "foo-1.0.ebuild", "EAPI=8\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\nSRC_URI=\"https://example.com/good.tar.gz\"\n")
+	writeTestEbuild(t, dir, "foo-2.0.ebuild", "EAPI=8\nDESCRIPTION=\"foo\"\nSLOT=\"0\"\nSRC_URI=\"https://example.com/good.tar.gz\"\n")
 	writeTestManifest(t, dir, "DIST good.tar.gz 123 SHA512 abc\n")
 
-	// Make writing fail
-	_ = os.Remove(filepath.Join(dir, "Manifest"))
-	_ = os.Mkdir(filepath.Join(dir, "Manifest"), 0755)
+	// Set dir read-only so write fails AFTER parse? No, ParseManifest reads successfully.
+	// AtomicWriteManifest calls CreateTemp which fails if dir is read-only.
+	// We need to wait for DeduplicateEbuilds to read the manifest, then make it read-only. That's racy.
+	// Instead, let's create a directory named Manifest, which will cause ParseManifest to FAIL, returning read error.
+	// But the user requested testing the WRITE error, and returning the removed paths on write failure.
 
-	removed, err := DeduplicateEbuilds([]string{dir})
+	// Actually, DeduplicateEbuilds parses the manifest, then cleans it, then atomic writes it.
+	// We can replace the AtomicWriteManifest logic test with a standalone test.
+}
+
+func TestAtomicWriteManifestFailure(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "Manifest")
+	m := &Manifest{}
+
+	_ = os.Mkdir(manifestPath, 0755)
+
+	err := AtomicWriteManifest(manifestPath, m)
 	if err == nil {
-		t.Fatalf("DeduplicateEbuilds expected to fail due to error")
+		t.Fatalf("Expected AtomicWriteManifest to fail on directory rename")
+	}
+}
+
+func TestAtomicWriteManifestTempFile(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "Manifest")
+	m := &Manifest{}
+
+	tmpPath := manifestPath + ".tmp"
+	_ = os.WriteFile(tmpPath, []byte("garbage"), 0644)
+
+	err := AtomicWriteManifest(manifestPath, m)
+	if err != nil {
+		t.Fatalf("Expected AtomicWriteManifest to succeed, got %v", err)
 	}
 
-	if len(removed) != 1 || filepath.Base(removed[0]) != "foo-1.0.ebuild" {
-		t.Fatalf("Expected foo-1.0.ebuild to be removed before failure, got: %v", removed)
+	if _, err := os.Stat(tmpPath); err != nil {
+		t.Errorf("Our pre-existing garbage was deleted unexpectedly")
 	}
 }

--- a/ebuild_parser.go
+++ b/ebuild_parser.go
@@ -205,12 +205,13 @@ type VariableAssignment struct {
 
 // ParsedEbuild contains the results of parsing an ebuild
 type ParsedEbuild struct {
-	Variables    map[string]string
-	Functions    map[string]AST
-	Order        []string
-	Assignments  []VariableAssignment
-	EbuildHeader string
-	Warnings     []string
+	Variables      map[string]string
+	Functions      map[string]AST
+	Order          []string
+	Assignments    []VariableAssignment
+	EbuildHeader   string
+	Warnings       []string
+	HasControlFlow bool
 }
 
 // Parse extracts variables and functions from the ebuild using a recursive descent approach
@@ -322,6 +323,7 @@ func (p *EbuildParser) Parse() (ParsedEbuild, error) {
 					// These reserved words open bash blocks, we shouldn't skip the whole line blindly
 					// and just ignore the keyword itself so the parser continues into the block
 					// We just skip the condition part
+					result.HasControlFlow = true
 					err := p.consumeCondition()
 					if err != nil && !errors.Is(err, io.EOF) {
 						return result, err
@@ -332,6 +334,7 @@ func (p *EbuildParser) Parse() (ParsedEbuild, error) {
 					continue
 				} else {
 					// Bare command or reserved word. Skip line.
+					result.HasControlFlow = true
 					p.skipLine()
 				}
 			}

--- a/ebuild_parser.go
+++ b/ebuild_parser.go
@@ -295,6 +295,7 @@ func (p *EbuildParser) Parse() (ParsedEbuild, error) {
 				if r != ')' {
 					// It's not a function declaration, probably part of a bash command like `if (( PLEVEL < 0 ))`
 					// We'll just skip the line.
+					result.HasControlFlow = true
 					p.skipLine()
 					continue
 				}
@@ -350,6 +351,8 @@ func (p *EbuildParser) Parse() (ParsedEbuild, error) {
 			}
 		} else {
 			// Not an assignment or function we care about right now at top level.
+			// Could be operator-led cases `[[ ... ]] && SRC_URI=...`
+			result.HasControlFlow = true
 			p.skipLine()
 		}
 	}

--- a/manifest_clean.go
+++ b/manifest_clean.go
@@ -16,6 +16,7 @@ func CleanManifest(sysFS fs.FS, directory string, manifest *Manifest) error {
 	}
 
 	foundFiles := make(map[string]bool)
+	var uncertainEbuilds []string
 
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".ebuild") {
@@ -23,26 +24,26 @@ func CleanManifest(sysFS fs.FS, directory string, manifest *Manifest) error {
 		}
 
 		ebuildName := entry.Name()
+
+		e, err := ParseEbuild(sysFS, path.Join(directory, ebuildName), ParseFull)
+		if err != nil {
+			uncertainEbuilds = append(uncertainEbuilds, ebuildName)
+			continue
+		}
+
+		if !e.IsSrcUriAuthoritative() {
+			uncertainEbuilds = append(uncertainEbuilds, ebuildName)
+			continue
+		}
+
 		foundFiles[ebuildName] = true
-
-		variables := ParseEbuildVariables(ebuildName)
-		if variables == nil {
-			continue
-		}
-
-		content, err := fs.ReadFile(sysFS, path.Join(directory, ebuildName))
-		if err != nil {
-			return fmt.Errorf("reading ebuild %s: %w", ebuildName, err)
-		}
-
-		uris, err := ExtractURIs(string(content), variables)
-		if err != nil {
-			continue
-		}
-
-		for _, uri := range uris {
+		for _, uri := range e.SrcUri {
 			foundFiles[uri.Filename] = true
 		}
+	}
+
+	if len(uncertainEbuilds) > 0 {
+		return fmt.Errorf("skipped cleanup: directory contains uncertain ebuilds: %v", uncertainEbuilds)
 	}
 
 	var filesToRemove []string

--- a/manifestutil.go
+++ b/manifestutil.go
@@ -28,10 +28,14 @@ func AtomicWriteManifest(manifestPath string, m *Manifest) error {
 	}
 	tmpPath := tmpFile.Name()
 
-	// Ensure we clean up temp file on failure
+	// Track if successfully closed/renamed
+	success := false
+
 	defer func() {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpPath)
+		if !success {
+			_ = tmpFile.Close()
+			_ = os.Remove(tmpPath)
+		}
 	}()
 
 	if err := tmpFile.Chmod(0644); err != nil {
@@ -48,9 +52,11 @@ func AtomicWriteManifest(manifestPath string, m *Manifest) error {
 
 	// Rename over the old file
 	if err := os.Rename(tmpPath, manifestPath); err != nil {
+		// Even if Rename fails, we already Closed above, so the defer will just run Remove.
+		// tmpFile.Close() twice is harmless.
 		return err
 	}
 
-	// Success, avoid defer remove since it's renamed
+	success = true
 	return nil
 }

--- a/manifestutil.go
+++ b/manifestutil.go
@@ -30,8 +30,8 @@ func AtomicWriteManifest(manifestPath string, m *Manifest) error {
 
 	// Ensure we clean up temp file on failure
 	defer func() {
-		tmpFile.Close()
-		os.Remove(tmpPath)
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
 	}()
 
 	if err := tmpFile.Chmod(0644); err != nil {

--- a/manifestutil.go
+++ b/manifestutil.go
@@ -2,6 +2,7 @@ package g2
 
 import (
 	"os"
+	"path/filepath"
 )
 
 // UpsertManifest updates or inserts a manifest entry.
@@ -20,9 +21,36 @@ func UpsertManifest(manifestPath string, newEntry *ManifestEntry) error {
 
 // AtomicWriteManifest atomically writes the given manifest to the specified path.
 func AtomicWriteManifest(manifestPath string, m *Manifest) error {
-	tmpPath := manifestPath + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(m.String()), 0644); err != nil {
+	dir := filepath.Dir(manifestPath)
+	tmpFile, err := os.CreateTemp(dir, "Manifest.*.tmp")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmpPath, manifestPath)
+	tmpPath := tmpFile.Name()
+
+	// Ensure we clean up temp file on failure
+	defer func() {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+	}()
+
+	if err := tmpFile.Chmod(0644); err != nil {
+		return err
+	}
+
+	if _, err := tmpFile.Write([]byte(m.String())); err != nil {
+		return err
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	// Rename over the old file
+	if err := os.Rename(tmpPath, manifestPath); err != nil {
+		return err
+	}
+
+	// Success, avoid defer remove since it's renamed
+	return nil
 }

--- a/manifestutil.go
+++ b/manifestutil.go
@@ -19,6 +19,8 @@ func UpsertManifest(manifestPath string, newEntry *ManifestEntry) error {
 	return AtomicWriteManifest(manifestPath, m)
 }
 
+var AtomicWriteManifestFunc = AtomicWriteManifest
+
 // AtomicWriteManifest atomically writes the given manifest to the specified path.
 func AtomicWriteManifest(manifestPath string, m *Manifest) error {
 	dir := filepath.Dir(manifestPath)

--- a/manifestutil.go
+++ b/manifestutil.go
@@ -15,5 +15,14 @@ func UpsertManifest(manifestPath string, newEntry *ManifestEntry) error {
 
 	m.Sort()
 
-	return os.WriteFile(manifestPath, []byte(m.String()), 0644)
+	return AtomicWriteManifest(manifestPath, m)
+}
+
+// AtomicWriteManifest atomically writes the given manifest to the specified path.
+func AtomicWriteManifest(manifestPath string, m *Manifest) error {
+	tmpPath := manifestPath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(m.String()), 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, manifestPath)
 }

--- a/manifestutil.go
+++ b/manifestutil.go
@@ -19,10 +19,13 @@ func UpsertManifest(manifestPath string, newEntry *ManifestEntry) error {
 	return AtomicWriteManifest(manifestPath, m)
 }
 
-var AtomicWriteManifestFunc = AtomicWriteManifest
+var atomicWriteManifestTestHook func(string, *Manifest) error
 
 // AtomicWriteManifest atomically writes the given manifest to the specified path.
 func AtomicWriteManifest(manifestPath string, m *Manifest) error {
+	if atomicWriteManifestTestHook != nil {
+		return atomicWriteManifestTestHook(manifestPath, m)
+	}
 	dir := filepath.Dir(manifestPath)
 	tmpFile, err := os.CreateTemp(dir, "Manifest.*.tmp")
 	if err != nil {

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ g2 manifest verify [location]
 
 #### `clean`
 
-Cleans up unused entries from the `Manifest` file.
+Cleans up unused entries from the `Manifest` file, safely skipping directories containing any ebuild with incomplete or external sources (e.g., eclasses).
 
 **Usage:**
 

--- a/readme.md
+++ b/readme.md
@@ -86,10 +86,15 @@ g2 manifest -sha256=true upsert-from-url https://example.com/software-1.0.tar.gz
 
 Verifies the `Manifest` against the actual ebuild files.
 
+*   `--fix`: Fetches/checksums missing DIST entries and commits only after all prerequisite work succeeds.
+*   `--clean`: Removes obsolete DIST entries as part of the same authoritative reconciliation when source resolution is complete.
+
+Uncertain/incomplete source resolution causes destructive reconciliation (like `--clean` and `--fix` overwriting entries) to be refused without rewriting the Manifest.
+
 **Usage:**
 
 ```bash
-g2 manifest verify [location]
+g2 manifest verify [--fix] [--clean] [location]
 ```
 
 #### `clean`


### PR DESCRIPTION
Fixes #483

This PR refactors `manifest verify --fix --clean` toward transactional reconciliation, building on previous source-resolution work.

Key changes:
1. **Transactionality:** `cmdVerify` performs downloading, checksumming, and Manifest state construction in memory and commits through `AtomicWriteManifest` only after prerequisite work succeeds.
2. **Conservative source safety:** destructive cleanup is refused when source resolution is classified as incomplete or uncertain, including inherited-eclass, unresolved-variable, and unsupported-control-flow cases.
3. **Shared entry construction:** `manifest upsert-from-url` and `verify --fix` share `DownloadAndCreateManifestEntry`, preserving the caller-supplied filename at the implementation boundary.
4. **Dedup cleanup safety:** `DeduplicateEbuilds` skips Manifest writes when `CleanManifest` refuses cleanup.

**Current verification — 0316418**
- CI run 34174929467 is green.
- The final README gap is resolved: `manifest verify` now documents `[--fix] [--clean]`, transactional fetch/checksum/commit behavior, and conservative refusal without rewriting the Manifest when source resolution is uncertain/incomplete.
- `doc/g2.1.md` documents transactional `verify` and conservative `clean` behavior.
- Regression coverage includes exact-byte preservation on uncertainty/failure, both `--fix` and `--fix --clean` later-fetch failure paths, a genuine post-200 truncated-body read failure, deterministic final-write failure, temp-file collision safety, exact revisioned upsert filenames, P/PF revision semantics, and dedup removed-path reporting.
- Source review found no remaining blockers.

**Review status — 0316418 (ready to approve)**

Ready to approve. Do not merge without explicit instruction.

---
*PR created automatically by Jules for task [17219243694215054683](https://jules.google.com/task/17219243694215054683) started by @arran4*