### PR TITLE
Fix #530, Fix #529: Correct fail-severity behavior and package-scoped parsing

### DIFF
--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -126,8 +126,7 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 		}
 	}
 
-	failLvl := severityLevel(*failSeverity)
-	if failLvl == -1 {
+	if severityLevel(*failSeverity) == -1 {
 		return fmt.Errorf("invalid fail-severity: %s", *failSeverity)
 	}
 
@@ -146,8 +145,6 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 	if err != nil {
 		return fmt.Errorf("parsing repo: %w", err)
 	}
-
-	hasErrors := false
 
 	var allResults []lints.LintResult
 
@@ -236,12 +233,6 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 			}
 
 			if len(filteredWarnings) > 0 {
-				failLvl := severityLevel(*failSeverity)
-				for i := range filteredWarnings {
-					if severityLevel(string(filteredWarnings[i].RuleMetadata.Severity)) >= failLvl {
-						hasErrors = true
-					}
-				}
 				if *format == "text" {
 					packageGroups := make(map[string][]lints.LintResult)
 					for _, w := range filteredWarnings {
@@ -278,7 +269,7 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 		printGithubActions(allResults)
 	}
 
-	if hasErrors {
+	if hasFailingLintResults(allResults, *failSeverity) {
 		return fmt.Errorf("linting found errors")
 	}
 
@@ -356,6 +347,19 @@ func severityLevel(s string) int {
 	}
 }
 
+func hasFailingLintResults(results []lints.LintResult, failSeverity string) bool {
+	failLvl := severityLevel(failSeverity)
+	if failLvl == -1 {
+		return false
+	}
+	for _, res := range results {
+		if severityLevel(string(res.RuleMetadata.Severity)) >= failLvl {
+			return true
+		}
+	}
+	return false
+}
+
 type LintQuery struct {
 	RepoPath  string
 	Category  string
@@ -366,8 +370,7 @@ type LintQuery struct {
 }
 
 func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool, query *LintQuery, format, severityFilter, failSeverity, sourceFilter, tagFilter, disableRule, ignoreTag string) error {
-	failLvl := severityLevel(failSeverity)
-	if failLvl == -1 {
+	if severityLevel(failSeverity) == -1 {
 		return fmt.Errorf("invalid fail-severity: %s", failSeverity)
 	}
 
@@ -380,7 +383,6 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 		return fmt.Errorf("parsing repo: %w", err)
 	}
 
-	hasErrors := false
 	var allResults []lints.LintResult
 
 	// Run repository-level lints
@@ -436,9 +438,6 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 			}
 			if w.Package == "" {
 				w.Package = "repo"
-			}
-			if severityLevel(string(w.RuleMetadata.Severity)) >= failLvl {
-				hasErrors = true
 			}
 			filteredRepoWarnings = append(filteredRepoWarnings, w)
 		}
@@ -521,9 +520,6 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 		for i := range filteredEclassWarnings {
 			if filteredEclassWarnings[i].Package == "" {
 				filteredEclassWarnings[i].Package = filepath.Base(eclass.Path)
-			}
-			if severityLevel(string(filteredEclassWarnings[i].RuleMetadata.Severity)) >= failLvl {
-				hasErrors = true
 			}
 		}
 
@@ -684,9 +680,6 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 				if filteredWarnings[i].Package == "" {
 					filteredWarnings[i].Package = pkg.Category + "/" + pkg.Name
 				}
-				if severityLevel(string(filteredWarnings[i].RuleMetadata.Severity)) >= failLvl {
-					hasErrors = true
-				}
 			}
 
 			if len(filteredWarnings) > 0 {
@@ -718,7 +711,7 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 		printGithubActions(allResults)
 	}
 
-	if hasErrors {
+	if hasFailingLintResults(allResults, failSeverity) {
 		return fmt.Errorf("linting found errors")
 	}
 

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -84,6 +84,7 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 	}
 	format := fs.String("format", "text", "Output format: text, json, or github-actions")
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
+	failSeverity := fs.String("fail-severity", "warning", "Fail on this severity and worse (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
 	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
@@ -228,7 +229,12 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 			}
 
 			if len(filteredWarnings) > 0 {
-				hasErrors = true
+				failLvl := severityLevel(*failSeverity)
+				for i := range filteredWarnings {
+					if severityLevel(string(filteredWarnings[i].RuleMetadata.Severity)) >= failLvl {
+						hasErrors = true
+					}
+				}
 				if *format == "text" {
 					packageGroups := make(map[string][]lints.LintResult)
 					for _, w := range filteredWarnings {
@@ -328,6 +334,21 @@ func escapeGithubProperty(s string) string {
 	return s
 }
 
+func severityLevel(s string) int {
+	switch strings.ToLower(s) {
+	case "error":
+		return 3
+	case "warning":
+		return 2
+	case "notice":
+		return 1
+	case "info":
+		return 0
+	default:
+		return -1
+	}
+}
+
 type LintQuery struct {
 	RepoPath  string
 	Category  string
@@ -337,8 +358,17 @@ type LintQuery struct {
 	VWildcard string // e.g. "3." for "v3"
 }
 
-func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool, query *LintQuery, format, severityFilter, sourceFilter, tagFilter, disableRule, ignoreTag string) error {
-	siteData, err := parseRepo(os.DirFS(location), ".", "Linting", true, nil)
+func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool, query *LintQuery, format, severityFilter, failSeverity, sourceFilter, tagFilter, disableRule, ignoreTag string) error {
+	failLvl := severityLevel(failSeverity)
+	if failLvl == -1 {
+		return fmt.Errorf("invalid fail-severity: %s", failSeverity)
+	}
+
+	var opts []any
+	if len(targetMap) > 0 {
+		opts = append(opts, TargetPackages(targetMap))
+	}
+	siteData, err := parseRepo(os.DirFS(location), ".", "Linting", true, nil, opts...)
 	if err != nil {
 		return fmt.Errorf("parsing repo: %w", err)
 	}
@@ -400,10 +430,12 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 			if w.Package == "" {
 				w.Package = "repo"
 			}
+			if severityLevel(string(w.RuleMetadata.Severity)) >= failLvl {
+				hasErrors = true
+			}
 			filteredRepoWarnings = append(filteredRepoWarnings, w)
 		}
 		if len(filteredRepoWarnings) > 0 {
-			hasErrors = true
 			if format == "text" {
 				fmt.Printf("[Repository]\n")
 				for _, w := range filteredRepoWarnings {
@@ -483,10 +515,12 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 			if filteredEclassWarnings[i].Package == "" {
 				filteredEclassWarnings[i].Package = filepath.Base(eclass.Path)
 			}
+			if severityLevel(string(filteredEclassWarnings[i].RuleMetadata.Severity)) >= failLvl {
+				hasErrors = true
+			}
 		}
 
 		if len(filteredEclassWarnings) > 0 {
-			hasErrors = true
 			if format == "text" {
 				packageGroups := make(map[string][]lints.LintResult)
 				for _, w := range filteredEclassWarnings {
@@ -643,10 +677,12 @@ func (cfg *MainArgConfig) runLintCore(location string, targetMap map[string]bool
 				if filteredWarnings[i].Package == "" {
 					filteredWarnings[i].Package = pkg.Category + "/" + pkg.Name
 				}
+				if severityLevel(string(filteredWarnings[i].RuleMetadata.Severity)) >= failLvl {
+					hasErrors = true
+				}
 			}
 
 			if len(filteredWarnings) > 0 {
-				hasErrors = true
 				if format == "text" {
 					packageGroups := make(map[string][]lints.LintResult)
 					for _, w := range filteredWarnings {
@@ -695,6 +731,7 @@ func (cfg *MainArgConfig) cmdLintRepo(args []string) error {
 	}
 	format := fs.String("format", "text", "Output format: text, json, or github-actions")
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
+	failSeverity := fs.String("fail-severity", "warning", "Fail on this severity and worse (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
 	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
@@ -719,7 +756,7 @@ func (cfg *MainArgConfig) cmdLintRepo(args []string) error {
 		location = fs.Arg(0)
 	}
 
-	return cfg.runLintCore(location, nil, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
+	return cfg.runLintCore(location, nil, nil, *format, *severityFilter, *failSeverity, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
 }
 
 func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
@@ -733,6 +770,7 @@ func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
 	}
 	format := fs.String("format", "text", "Output format: text, json, or github-actions")
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
+	failSeverity := fs.String("fail-severity", "warning", "Fail on this severity and worse (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
 	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
@@ -784,7 +822,7 @@ func (cfg *MainArgConfig) cmdLintPackage(args []string) error {
 		targetMap[cleanP] = true
 	}
 
-	return cfg.runLintCore(location, targetMap, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
+	return cfg.runLintCore(location, targetMap, nil, *format, *severityFilter, *failSeverity, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
 }
 
 func parseLintQuery(queryStr string, defaultLocation string) (*LintQuery, error) {
@@ -900,6 +938,7 @@ func (cfg *MainArgConfig) cmdLintQuery(args []string) error {
 	}
 	format := fs.String("format", "text", "Output format: text, json, or github-actions")
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
+	failSeverity := fs.String("fail-severity", "warning", "Fail on this severity and worse (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
 	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
@@ -926,5 +965,5 @@ func (cfg *MainArgConfig) cmdLintQuery(args []string) error {
 		return fmt.Errorf("parsing query: %w", err)
 	}
 
-	return cfg.runLintCore(query.RepoPath, nil, query, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
+	return cfg.runLintCore(query.RepoPath, nil, query, *format, *severityFilter, *failSeverity, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
 }

--- a/cmd/g2/lint.go
+++ b/cmd/g2/lint.go
@@ -126,18 +126,25 @@ func (cfg *MainArgConfig) runOldLint(args []string) error {
 		}
 	}
 
-	siteData, err := parseRepo(os.DirFS(location), ".", "Linting", true, nil)
-	if err != nil {
-		return fmt.Errorf("parsing repo: %w", err)
+	failLvl := severityLevel(*failSeverity)
+	if failLvl == -1 {
+		return fmt.Errorf("invalid fail-severity: %s", *failSeverity)
 	}
 
 	var targetMap map[string]bool
+	var opts []any
 	if len(targetPkgs) > 0 {
 		targetMap = make(map[string]bool)
 		for _, p := range targetPkgs {
 			cleanP := filepath.ToSlash(filepath.Clean(p))
 			targetMap[cleanP] = true
 		}
+		opts = append(opts, TargetPackages(targetMap))
+	}
+
+	siteData, err := parseRepo(os.DirFS(location), ".", "Linting", true, nil, opts...)
+	if err != nil {
+		return fmt.Errorf("parsing repo: %w", err)
 	}
 
 	hasErrors := false

--- a/cmd/g2/lint_changed.go
+++ b/cmd/g2/lint_changed.go
@@ -26,6 +26,7 @@ func (cfg *MainArgConfig) cmdLintChanged(args []string) error {
 	}
 	format := fs.String("format", "text", "Output format: text, json, or github-actions")
 	severityFilter := fs.String("severity", "", "Only show warnings of this severity (error, warning, notice, info)")
+	failSeverity := fs.String("fail-severity", "warning", "Fail on this severity and worse (error, warning, notice, info)")
 	sourceFilter := fs.String("only-source", "", "Only show warnings from this source (g2, pkgcheck)")
 	tagFilter := fs.String("only-tag", "", "Only show warnings with this tag")
 	disableRule := fs.String("disable-rule", "", "Comma-separated list of rule IDs to ignore (case-insensitive)")
@@ -58,7 +59,7 @@ func (cfg *MainArgConfig) cmdLintChanged(args []string) error {
 		targetMap[p] = true
 	}
 
-	return cfg.runLintCore(location, targetMap, nil, *format, *severityFilter, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
+	return cfg.runLintCore(location, targetMap, nil, *format, *severityFilter, *failSeverity, *sourceFilter, *tagFilter, *disableRule, *ignoreTag)
 }
 
 func getGitModifiedPackagesChanged(repoDir string, explicitBase string) ([]string, error) {

--- a/cmd/g2/lint_changed_test.go
+++ b/cmd/g2/lint_changed_test.go
@@ -32,6 +32,7 @@ func TestGetGitModifiedPackagesChanged(t *testing.T) {
 	runCmd("git", "init")
 	runCmd("git", "config", "user.name", "g2 test")
 	runCmd("git", "config", "user.email", "g2-test@example.invalid")
+	runCmd("git", "config", "commit.gpgsign", "false")
 
 	// 2. Initial state
 	err = os.MkdirAll(filepath.Join(tmpDir, "app-misc", "foo"), 0755)

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -191,13 +191,13 @@ func TestSeverityLevel(t *testing.T) {
 		t.Errorf("expected 0")
 	}
 
-	if !(severityLevel("error") > severityLevel("warning")) {
+	if severityLevel("error") <= severityLevel("warning") {
 		t.Errorf("error should be > warning")
 	}
-	if !(severityLevel("warning") > severityLevel("notice")) {
+	if severityLevel("warning") <= severityLevel("notice") {
 		t.Errorf("warning should be > notice")
 	}
-	if !(severityLevel("notice") > severityLevel("info")) {
+	if severityLevel("notice") <= severityLevel("info") {
 		t.Errorf("notice should be > info")
 	}
 }
@@ -216,7 +216,7 @@ func TestCmdLintFailSeverity(t *testing.T) {
 	if err := os.MkdirAll(overlayPath+"/profiles", 0755); err != nil {
 		t.Fatalf("failed to create profiles dir: %v", err)
 	}
-	os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
+	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
 
 	warningEbuild := []byte(`
 # Copyright 2026 Gentoo Authors
@@ -229,8 +229,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64"
 `)
-	os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
-	os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
 
 	noticeEbuild := []byte(`
 # Copyright 2026 Gentoo Authors
@@ -243,8 +243,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 `)
-	os.WriteFile(overlayPath+"/app-misc/notice-pkg/notice-pkg-1.0.ebuild", noticeEbuild, 0644)
-	os.WriteFile(overlayPath+"/app-misc/notice-pkg/Manifest", []byte(""), 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/notice-pkg-1.0.ebuild", noticeEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/Manifest", []byte(""), 0644)
 
 	metadataContent := []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
@@ -253,8 +253,8 @@ KEYWORDS="~amd64"
 		<email>test@example.com</email>
 	</maintainer>
 </pkgmetadata>`)
-	os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
-	os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
 
 	// Pre-test validations
 	outWarning, _ := captureStdout(t, func() error {
@@ -315,7 +315,7 @@ func TestCmdLintFailSeverityOutputFormats(t *testing.T) {
 	if err := os.MkdirAll(overlayPath+"/profiles", 0755); err != nil {
 		t.Fatalf("failed to create profiles dir: %v", err)
 	}
-	os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
+	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
 
 	noticeEbuild := []byte(`
 # Copyright 2026 Gentoo Authors
@@ -328,8 +328,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 `)
-	os.WriteFile(overlayPath+"/app-misc/notice-pkg/notice-pkg-1.0.ebuild", noticeEbuild, 0644)
-	os.WriteFile(overlayPath+"/app-misc/notice-pkg/Manifest", []byte(""), 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/notice-pkg-1.0.ebuild", noticeEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/Manifest", []byte(""), 0644)
 
 	metadataContent := []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
@@ -338,7 +338,7 @@ KEYWORDS="~amd64"
 		<email>test@example.com</email>
 	</maintainer>
 </pkgmetadata>`)
-	os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
 
 	// Test github-actions format returns 0 with default failSeverity, but still outputs a notice
 	outNotice, err := captureStdout(t, func() error {

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -492,3 +492,126 @@ func (t *trackingFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	t.Accessed[name] = true
 	return fs.ReadDir(t.FS, name)
 }
+
+func TestCmdLintTargetedSyntaxes(t *testing.T) {
+	cfg := &MainArgConfig{}
+	overlayPath := "../../testdata/test_overlay"
+
+	// 1. New package syntax
+	outNew, errNew := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/foo"})
+	})
+	if errNew == nil {
+		t.Errorf("expected new syntax to fail due to foo errors, but it passed")
+	}
+
+	// 2. Legacy package syntax
+	outLegacy, errLegacy := captureStdout(t, func() error {
+		return cfg.runOldLint([]string{"--format", "json", overlayPath, "app-misc/foo"})
+	})
+	if errLegacy == nil {
+		t.Errorf("expected legacy syntax to fail due to foo errors, but it passed")
+	}
+
+	// 3. Exact Category Target syntax
+	outCategory, errCat := captureStdout(t, func() error {
+		return cfg.runOldLint([]string{"--format", "json", overlayPath, "app-misc"})
+	})
+	if errCat == nil {
+		t.Errorf("expected category syntax to fail due to foo errors, but it passed")
+	}
+
+	// Check that none of these reached bad_category
+	for _, out := range []string{outNew, outLegacy, outCategory} {
+		if strings.Contains(out, "bad_category") {
+			t.Errorf("targeted lint incorrectly leaked into unrelated 'bad_category'. Output snippet: %s", out[:min(len(out), 200)])
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func TestCmdLintEffectiveSeverityOverride(t *testing.T) {
+	cfg := &MainArgConfig{}
+	overlayPath := t.TempDir()
+
+	_ = os.MkdirAll(overlayPath+"/app-misc/warning-pkg", 0755)
+	_ = os.MkdirAll(overlayPath+"/profiles", 0755)
+	_ = os.MkdirAll(overlayPath+"/metadata", 0755)
+	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
+
+	// Provide a qa-policy.conf overriding PG0002 from Warning to Notice
+	qaPolicy := []byte(`
+[policy]
+PG0002 = notice
+`)
+	_ = os.WriteFile(overlayPath+"/metadata/qa-policy.conf", qaPolicy, 0644)
+
+	// Trigger PG0002: =-dependency with no revision
+	warningEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A proper description"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+DEPEND="=app-misc/some-dep-1.0"
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
+	metadataContent := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>test@example.com</email>
+	</maintainer>
+</pkgmetadata>`)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
+
+	// Since we overrode PG0002 to Notice, it should NOT fail default (Warning) threshold
+	out, err := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/warning-pkg"})
+	})
+
+	if err != nil {
+		t.Errorf("expected to PASS because effective severity of PG0002 is Notice. err: %v\nOut: %s", err, out)
+	}
+	if !strings.Contains(out, `"severity": "Notice"`) {
+		t.Errorf("expected JSON to contain Notice for PG0002, got: %s", out)
+	}
+
+	// But it should fail if fail-severity is Notice
+	out, err = captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "text", "--fail-severity", "notice", overlayPath, "app-misc/warning-pkg"})
+	})
+	if err == nil {
+		t.Errorf("expected to FAIL when fail-severity is Notice. Out: %s", out)
+	}
+}
+
+func TestCmdLintInvalidFailSeverity(t *testing.T) {
+	cfg := &MainArgConfig{}
+
+	// Newer path
+	_, err := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--fail-severity", "invalid_sev", ".", "app-misc/foo"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid fail-severity") {
+		t.Errorf("expected invalid fail-severity error from package cmd, got: %v", err)
+	}
+
+	// Legacy path
+	_, err = captureStdout(t, func() error {
+		return cfg.runOldLint([]string{"--fail-severity", "invalid_sev", ".", "app-misc/foo"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid fail-severity") {
+		t.Errorf("expected invalid fail-severity error from legacy cmd, got: %v", err)
+	}
+}

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -218,8 +218,7 @@ func TestCmdLintFailSeverity(t *testing.T) {
 	}
 	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
 
-	warningEbuild := []byte(`
-# Copyright 2026 Gentoo Authors
+	warningEbuild := []byte(`# Copyright 1999-2026 Test Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -232,8 +231,7 @@ KEYWORDS="amd64"
 	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
 	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
 
-	noticeEbuild := []byte(`
-# Copyright 2026 Gentoo Authors
+	noticeEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -255,6 +253,62 @@ KEYWORDS="~amd64"
 </pkgmetadata>`)
 	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
 	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
+	if err := os.MkdirAll(overlayPath+"/app-misc/info-pkg", 0755); err != nil {
+		t.Fatalf("failed to create info pkg dir: %v", err)
+	}
+	infoEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+
+pkg_postinst() {
+	if [ -e /usr ]; then
+		einfo "Wait"
+	fi
+}
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/info-pkg-1.0.ebuild", infoEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/Manifest", []byte(""), 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/metadata.xml", metadataContent, 0644)
+
+	// Error only package (no maintainer)
+	if err := os.MkdirAll(overlayPath+"/app-misc/error-pkg", 0755); err != nil {
+		t.Fatalf("failed to create error pkg dir: %v", err)
+	}
+	errorEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/error-pkg/error-pkg-1.0.ebuild", errorEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/error-pkg/Manifest", []byte(""), 0644)
+
+	// Mixed Notice + Error
+	if err := os.MkdirAll(overlayPath+"/app-misc/mixed-pkg", 0755); err != nil {
+		t.Fatalf("failed to create mixed pkg dir: %v", err)
+	}
+	mixedEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/mixed-pkg/mixed-pkg-1.0.ebuild", mixedEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/mixed-pkg/Manifest", []byte(""), 0644)
 
 	// Pre-test validations
 	outWarning, _ := captureStdout(t, func() error {
@@ -282,17 +336,23 @@ KEYWORDS="~amd64"
 		pkgTarget    string
 		failSeverity string
 		expectFail   bool
+		extraArgs    []string
 	}{
-		{"warning pkg, default warning", "app-misc/warning-pkg", "warning", true},
-		{"warning pkg, --fail-severity=error", "app-misc/warning-pkg", "error", false},
-		{"notice pkg, default warning", "app-misc/notice-pkg", "warning", false},
-		{"notice pkg, --fail-severity=notice", "app-misc/notice-pkg", "notice", true},
+		{"warning pkg, default warning", "app-misc/warning-pkg", "warning", true, nil},
+		{"warning pkg, --fail-severity=error", "app-misc/warning-pkg", "error", false, nil},
+		{"notice pkg, default warning", "app-misc/notice-pkg", "warning", false, nil},
+		{"notice pkg, --fail-severity=notice", "app-misc/notice-pkg", "notice", true, nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out, err := captureStdout(t, func() error {
-				args := []string{"--format", "text", "--fail-severity", tt.failSeverity, overlayPath, tt.pkgTarget}
+				args := []string{"--format", "text"}
+				if tt.extraArgs != nil {
+					args = args[:0]
+					args = append(args, tt.extraArgs...)
+				}
+				args = append(args, "--fail-severity", tt.failSeverity, overlayPath, tt.pkgTarget)
 				return cfg.cmdLintPackage(args)
 			})
 
@@ -317,8 +377,7 @@ func TestCmdLintFailSeverityOutputFormats(t *testing.T) {
 	}
 	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
 
-	noticeEbuild := []byte(`
-# Copyright 2026 Gentoo Authors
+	noticeEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -339,6 +398,62 @@ KEYWORDS="~amd64"
 	</maintainer>
 </pkgmetadata>`)
 	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
+	if err := os.MkdirAll(overlayPath+"/app-misc/info-pkg", 0755); err != nil {
+		t.Fatalf("failed to create info pkg dir: %v", err)
+	}
+	infoEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+
+pkg_postinst() {
+	if [ -e /usr ]; then
+		einfo "Wait"
+	fi
+}
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/info-pkg-1.0.ebuild", infoEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/Manifest", []byte(""), 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/metadata.xml", metadataContent, 0644)
+
+	// Error only package (no maintainer)
+	if err := os.MkdirAll(overlayPath+"/app-misc/error-pkg", 0755); err != nil {
+		t.Fatalf("failed to create error pkg dir: %v", err)
+	}
+	errorEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/error-pkg/error-pkg-1.0.ebuild", errorEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/error-pkg/Manifest", []byte(""), 0644)
+
+	// Mixed Notice + Error
+	if err := os.MkdirAll(overlayPath+"/app-misc/mixed-pkg", 0755); err != nil {
+		t.Fatalf("failed to create mixed pkg dir: %v", err)
+	}
+	mixedEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/mixed-pkg/mixed-pkg-1.0.ebuild", mixedEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/mixed-pkg/Manifest", []byte(""), 0644)
 
 	// Test github-actions format returns 0 with default failSeverity, but still outputs a notice
 	outNotice, err := captureStdout(t, func() error {
@@ -439,4 +554,81 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func TestCmdLintEffectiveSeverityOverride(t *testing.T) {
+	cfg := &MainArgConfig{}
+	overlayPath := t.TempDir()
+
+	_ = os.MkdirAll(overlayPath+"/app-misc/warning-pkg", 0755)
+	_ = os.MkdirAll(overlayPath+"/profiles", 0755)
+	_ = os.MkdirAll(overlayPath+"/metadata", 0755)
+	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
+
+	// Provide a qa-policy.conf overriding PG0002 from Warning to Notice
+	qaPolicy := []byte(`
+[policy]
+PG0002 = notice
+`)
+	_ = os.WriteFile(overlayPath+"/metadata/qa-policy.conf", qaPolicy, 0644)
+
+	// Trigger PG0002: =-dependency with no revision
+	warningEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A proper description"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+DEPEND="=app-misc/some-dep-1.0"
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
+	metadataContent := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>test@example.com</email>
+	</maintainer>
+</pkgmetadata>`)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
+
+	// Since we overrode PG0002 to Notice, it should NOT fail default (Warning) threshold
+	out, err := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "text", overlayPath, "app-misc/warning-pkg"})
+	})
+
+	if err != nil {
+		t.Errorf("expected to PASS because effective severity of PG0002 is Notice. err: %v\nOut: %s", err, out)
+	}
+
+	// But it should fail if fail-severity is Notice
+	out, err = captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "text", "--fail-severity", "notice", overlayPath, "app-misc/warning-pkg"})
+	})
+	if err == nil {
+		t.Errorf("expected to FAIL when fail-severity is Notice. Out: %s", out)
+	}
+}
+
+func TestCmdLintInvalidFailSeverity(t *testing.T) {
+	cfg := &MainArgConfig{}
+
+	// Newer path
+	_, err := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--fail-severity", "invalid_sev", ".", "app-misc/foo"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid fail-severity") {
+		t.Errorf("expected invalid fail-severity error from package cmd, got: %v", err)
+	}
+
+	// Legacy path
+	_, err = captureStdout(t, func() error {
+		return cfg.runOldLint([]string{"--fail-severity", "invalid_sev", ".", "app-misc/foo"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid fail-severity") {
+		t.Errorf("expected invalid fail-severity error from legacy cmd, got: %v", err)
+	}
 }

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -377,7 +377,8 @@ func TestCmdLintFailSeverityOutputFormats(t *testing.T) {
 	}
 	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
 
-	noticeEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+	noticeEbuild := []byte(`
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -398,62 +399,6 @@ KEYWORDS="~amd64"
 	</maintainer>
 </pkgmetadata>`)
 	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
-	if err := os.MkdirAll(overlayPath+"/app-misc/info-pkg", 0755); err != nil {
-		t.Fatalf("failed to create info pkg dir: %v", err)
-	}
-	infoEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
-# Distributed under the terms of the GNU General Public License v2
-
-EAPI=8
-DESCRIPTION="A sufficiently descriptive test package"
-HOMEPAGE="https://example.com"
-LICENSE="MIT"
-SLOT="0"
-KEYWORDS="amd64"
-
-pkg_postinst() {
-	if [ -e /usr ]; then
-		einfo "Wait"
-	fi
-}
-`)
-	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/info-pkg-1.0.ebuild", infoEbuild, 0644)
-	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/Manifest", []byte(""), 0644)
-	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/metadata.xml", metadataContent, 0644)
-
-	// Error only package (no maintainer)
-	if err := os.MkdirAll(overlayPath+"/app-misc/error-pkg", 0755); err != nil {
-		t.Fatalf("failed to create error pkg dir: %v", err)
-	}
-	errorEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
-# Distributed under the terms of the GNU General Public License v2
-
-EAPI=8
-DESCRIPTION="A sufficiently descriptive test package"
-HOMEPAGE="https://example.com"
-LICENSE="MIT"
-SLOT="0"
-KEYWORDS="amd64"
-`)
-	_ = os.WriteFile(overlayPath+"/app-misc/error-pkg/error-pkg-1.0.ebuild", errorEbuild, 0644)
-	_ = os.WriteFile(overlayPath+"/app-misc/error-pkg/Manifest", []byte(""), 0644)
-
-	// Mixed Notice + Error
-	if err := os.MkdirAll(overlayPath+"/app-misc/mixed-pkg", 0755); err != nil {
-		t.Fatalf("failed to create mixed pkg dir: %v", err)
-	}
-	mixedEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
-# Distributed under the terms of the GNU General Public License v2
-
-EAPI=8
-DESCRIPTION="A sufficiently descriptive test package"
-HOMEPAGE="https://example.com"
-LICENSE="MIT"
-SLOT="0"
-KEYWORDS="~amd64"
-`)
-	_ = os.WriteFile(overlayPath+"/app-misc/mixed-pkg/mixed-pkg-1.0.ebuild", mixedEbuild, 0644)
-	_ = os.WriteFile(overlayPath+"/app-misc/mixed-pkg/Manifest", []byte(""), 0644)
 
 	// Test github-actions format returns 0 with default failSeverity, but still outputs a notice
 	outNotice, err := captureStdout(t, func() error {
@@ -465,6 +410,17 @@ KEYWORDS="~amd64"
 	}
 	if !strings.Contains(outNotice, "::notice ") {
 		t.Errorf("expected github-actions format to still output a notice, got: %s", outNotice)
+	}
+
+	// Test json format returns 0 with default failSeverity, but still outputs a notice
+	outJson, errJson := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/notice-pkg"})
+	})
+	if errJson != nil {
+		t.Fatalf("expected json format to exit 0 with notice, got err: %v", errJson)
+	}
+	if !strings.Contains(outJson, `"severity": "Notice"`) {
+		t.Errorf("expected json format to still output a notice, got: %s", outJson)
 	}
 }
 

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"io/fs"
 	"os"
 	"reflect"
 	"strings"
@@ -174,4 +175,225 @@ func TestCmdLintList(t *testing.T) {
 	if !foundLabelledRef {
 		t.Error("expected at least one rule with a labelled reference in JSON output")
 	}
+}
+
+func TestSeverityLevel(t *testing.T) {
+	if severityLevel("error") != 3 {
+		t.Errorf("expected 3")
+	}
+	if severityLevel("warning") != 2 {
+		t.Errorf("expected 2")
+	}
+	if severityLevel("notice") != 1 {
+		t.Errorf("expected 1")
+	}
+	if severityLevel("info") != 0 {
+		t.Errorf("expected 0")
+	}
+
+	if !(severityLevel("error") > severityLevel("warning")) {
+		t.Errorf("error should be > warning")
+	}
+	if !(severityLevel("warning") > severityLevel("notice")) {
+		t.Errorf("warning should be > notice")
+	}
+	if !(severityLevel("notice") > severityLevel("info")) {
+		t.Errorf("notice should be > info")
+	}
+}
+
+func TestCmdLintFailSeverity(t *testing.T) {
+	cfg := &MainArgConfig{}
+
+	overlayPath := t.TempDir()
+
+	if err := os.MkdirAll(overlayPath+"/app-misc/warning-pkg", 0755); err != nil {
+		t.Fatalf("failed to create warning pkg dir: %v", err)
+	}
+	if err := os.MkdirAll(overlayPath+"/app-misc/notice-pkg", 0755); err != nil {
+		t.Fatalf("failed to create notice pkg dir: %v", err)
+	}
+	if err := os.MkdirAll(overlayPath+"/profiles", 0755); err != nil {
+		t.Fatalf("failed to create profiles dir: %v", err)
+	}
+	os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
+
+	warningEbuild := []byte(`
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="short"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+`)
+	os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
+	os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
+
+	noticeEbuild := []byte(`
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+`)
+	os.WriteFile(overlayPath+"/app-misc/notice-pkg/notice-pkg-1.0.ebuild", noticeEbuild, 0644)
+	os.WriteFile(overlayPath+"/app-misc/notice-pkg/Manifest", []byte(""), 0644)
+
+	metadataContent := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>test@example.com</email>
+	</maintainer>
+</pkgmetadata>`)
+	os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
+	os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
+
+	// Pre-test validations
+	outWarning, _ := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/warning-pkg"})
+	})
+	if strings.Contains(outWarning, `"severity": "Error"`) {
+		t.Fatalf("Fixture setup failed: warning-pkg contains Errors!\nOutput: %s", outWarning)
+	}
+	if !strings.Contains(outWarning, `"severity": "Warning"`) {
+		t.Fatalf("Fixture setup failed: warning-pkg does not contain a Warning!\nOutput: %s", outWarning)
+	}
+
+	outNotice, _ := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/notice-pkg"})
+	})
+	if strings.Contains(outNotice, `"severity": "Error"`) || strings.Contains(outNotice, `"severity": "Warning"`) {
+		t.Fatalf("Fixture setup failed: notice-pkg contains Errors/Warnings!\nOutput: %s", outNotice)
+	}
+	if !strings.Contains(outNotice, `"severity": "Notice"`) {
+		t.Fatalf("Fixture setup failed: notice-pkg does not contain a Notice!\nOutput: %s", outNotice)
+	}
+
+	tests := []struct {
+		name         string
+		pkgTarget    string
+		failSeverity string
+		expectFail   bool
+	}{
+		{"warning pkg, default warning", "app-misc/warning-pkg", "warning", true},
+		{"warning pkg, --fail-severity=error", "app-misc/warning-pkg", "error", false},
+		{"notice pkg, default warning", "app-misc/notice-pkg", "warning", false},
+		{"notice pkg, --fail-severity=notice", "app-misc/notice-pkg", "notice", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := captureStdout(t, func() error {
+				args := []string{"--format", "text", "--fail-severity", tt.failSeverity, overlayPath, tt.pkgTarget}
+				return cfg.cmdLintPackage(args)
+			})
+
+			hasErr := err != nil
+			if hasErr != tt.expectFail {
+				t.Errorf("expected fail: %v, got: %v (err: %v)", tt.expectFail, hasErr, err)
+				t.Logf("Output: %s", out)
+			}
+		})
+	}
+}
+func TestCmdLintFailSeverityOutputFormats(t *testing.T) {
+	cfg := &MainArgConfig{}
+
+	overlayPath := t.TempDir()
+
+	if err := os.MkdirAll(overlayPath+"/app-misc/notice-pkg", 0755); err != nil {
+		t.Fatalf("failed to create notice pkg dir: %v", err)
+	}
+	if err := os.MkdirAll(overlayPath+"/profiles", 0755); err != nil {
+		t.Fatalf("failed to create profiles dir: %v", err)
+	}
+	os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
+
+	noticeEbuild := []byte(`
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+`)
+	os.WriteFile(overlayPath+"/app-misc/notice-pkg/notice-pkg-1.0.ebuild", noticeEbuild, 0644)
+	os.WriteFile(overlayPath+"/app-misc/notice-pkg/Manifest", []byte(""), 0644)
+
+	metadataContent := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>test@example.com</email>
+	</maintainer>
+</pkgmetadata>`)
+	os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
+
+	// Test github-actions format returns 0 with default failSeverity, but still outputs a notice
+	outNotice, err := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "github-actions", overlayPath, "app-misc/notice-pkg"})
+	})
+
+	if err != nil {
+		t.Fatalf("expected github-actions format to exit 0 with notice, got err: %v", err)
+	}
+	if !strings.Contains(outNotice, "::notice ") {
+		t.Errorf("expected github-actions format to still output a notice, got: %s", outNotice)
+	}
+}
+
+func TestCmdLintTargetedAccessLimit(t *testing.T) {
+	// A package with a noticeable problem (no maintainer -> Error, missing vars -> Warning, etc)
+	overlayPath := "../../testdata/test_overlay"
+
+	// Create tracking fs
+	tfs := &trackingFS{
+		FS:       os.DirFS(overlayPath),
+		Accessed: make(map[string]bool),
+	}
+
+	targetMap := make(map[string]bool)
+	targetMap["app-misc/foo"] = true
+
+	_, err := parseRepo(tfs, ".", "Test Overlay", false, nil, TargetPackages(targetMap))
+	if err != nil {
+		t.Fatalf("parseRepo failed: %v", err)
+	}
+
+	for k := range tfs.Accessed {
+		if strings.Contains(k, "bad_category") {
+			t.Errorf("targeted lint incorrectly accessed unrelated path: %s", k)
+		}
+	}
+
+	if !tfs.Accessed["app-misc/foo"] {
+		t.Errorf("targeted lint failed to access target package 'app-misc/foo'")
+	}
+}
+
+// trackingFS wraps an fs.FS to track directory and file accesses.
+type trackingFS struct {
+	fs.FS
+	Accessed map[string]bool
+}
+
+func (t *trackingFS) Open(name string) (fs.File, error) {
+	t.Accessed[name] = true
+	return t.FS.Open(name)
+}
+
+func (t *trackingFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	t.Accessed[name] = true
+	return fs.ReadDir(t.FS, name)
 }

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -397,3 +397,46 @@ func (t *trackingFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	t.Accessed[name] = true
 	return fs.ReadDir(t.FS, name)
 }
+
+func TestCmdLintTargetedSyntaxes(t *testing.T) {
+	cfg := &MainArgConfig{}
+	overlayPath := "../../testdata/test_overlay"
+
+	// 1. New package syntax
+	outNew, errNew := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/foo"})
+	})
+	if errNew == nil {
+		t.Errorf("expected new syntax to fail due to foo errors, but it passed")
+	}
+
+	// 2. Legacy package syntax
+	outLegacy, errLegacy := captureStdout(t, func() error {
+		return cfg.runOldLint([]string{"--format", "json", overlayPath, "app-misc/foo"})
+	})
+	if errLegacy == nil {
+		t.Errorf("expected legacy syntax to fail due to foo errors, but it passed")
+	}
+
+	// 3. Exact Category Target syntax
+	outCategory, errCat := captureStdout(t, func() error {
+		return cfg.runOldLint([]string{"--format", "json", overlayPath, "app-misc"})
+	})
+	if errCat == nil {
+		t.Errorf("expected category syntax to fail due to foo errors, but it passed")
+	}
+
+	// Check that none of these reached bad_category
+	for _, out := range []string{outNew, outLegacy, outCategory} {
+		if strings.Contains(out, "bad_category") {
+			t.Errorf("targeted lint incorrectly leaked into unrelated 'bad_category'. Output snippet: %s", out[:min(len(out), 200)])
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -177,6 +177,46 @@ func TestCmdLintList(t *testing.T) {
 	}
 }
 
+func TestSeverityThresholdLogic(t *testing.T) {
+	// Synthetically verify the core loop logic using the identical evaluation helper
+	// used in runLintCore: severityLevel(result) >= failLvl -> hasErrors = true
+
+	testCases := []struct {
+		desc        string
+		resultSev   string
+		failSev     string
+		expectError bool
+	}{
+		{"info-only + default warning -> pass", "Info", "warning", false},
+		{"info-only + fail-severity=info -> fail", "Info", "info", true},
+		{"error-only + default warning -> fail", "Error", "warning", true},
+		{"error-only + fail-severity=error -> fail", "Error", "error", true},
+		{"mixed notice + error -> fail at warning", "Notice", "warning", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			failLvl := severityLevel(tc.failSev)
+			resultLvl := severityLevel(tc.resultSev)
+			hasErrors := resultLvl >= failLvl
+			if hasErrors != tc.expectError {
+				t.Errorf("expected error %v, got %v for result %s against threshold %s", tc.expectError, hasErrors, tc.resultSev, tc.failSev)
+			}
+		})
+	}
+
+	// Mixed Notice + Error
+	failLvl := severityLevel("warning")
+	hasErrors := false
+	for _, res := range []string{"Notice", "Error"} {
+		if severityLevel(res) >= failLvl {
+			hasErrors = true
+		}
+	}
+	if !hasErrors {
+		t.Errorf("expected mixed Notice+Error to fail at default warning")
+	}
+}
 func TestSeverityLevel(t *testing.T) {
 	if severityLevel("error") != 3 {
 		t.Errorf("expected 3")

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -422,6 +422,33 @@ KEYWORDS="~amd64"
 	if !strings.Contains(outJson, `"severity": "Notice"`) {
 		t.Errorf("expected json format to still output a notice, got: %s", outJson)
 	}
+
+	// Error JSON assertion
+	if err := os.MkdirAll(overlayPath+"/app-misc/error-pkg", 0755); err != nil {
+		t.Fatalf("failed to create error pkg dir: %v", err)
+	}
+	errorEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="A sufficiently descriptive test package"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/error-pkg/error-pkg-1.0.ebuild", errorEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/error-pkg/Manifest", []byte(""), 0644)
+
+	outJsonErr, errJsonErr := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/error-pkg"})
+	})
+	if errJsonErr == nil {
+		t.Fatalf("expected json format to exit non-0 with error")
+	}
+	if !strings.Contains(outJsonErr, `"severity": "Error"`) {
+		t.Errorf("expected json format to still output an error, got: %s", outJsonErr)
+	}
 }
 
 func TestCmdLintTargetedAccessLimit(t *testing.T) {

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -218,7 +218,8 @@ func TestCmdLintFailSeverity(t *testing.T) {
 	}
 	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
 
-	warningEbuild := []byte(`# Copyright 1999-2026 Test Authors
+	warningEbuild := []byte(`
+# Copyright 2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -231,7 +232,8 @@ KEYWORDS="amd64"
 	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
 	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
 
-	noticeEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
+	noticeEbuild := []byte(`
+# Copyright 2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -253,6 +255,7 @@ KEYWORDS="~amd64"
 </pkgmetadata>`)
 	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
 	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
+
 	if err := os.MkdirAll(overlayPath+"/app-misc/info-pkg", 0755); err != nil {
 		t.Fatalf("failed to create info pkg dir: %v", err)
 	}
@@ -267,7 +270,7 @@ SLOT="0"
 KEYWORDS="amd64"
 
 pkg_postinst() {
-	if [ -e /usr ]; then
+	if [[ -e /usr ]]; then
 		einfo "Wait"
 	fi
 }
@@ -336,23 +339,17 @@ KEYWORDS="~amd64"
 		pkgTarget    string
 		failSeverity string
 		expectFail   bool
-		extraArgs    []string
 	}{
-		{"warning pkg, default warning", "app-misc/warning-pkg", "warning", true, nil},
-		{"warning pkg, --fail-severity=error", "app-misc/warning-pkg", "error", false, nil},
-		{"notice pkg, default warning", "app-misc/notice-pkg", "warning", false, nil},
-		{"notice pkg, --fail-severity=notice", "app-misc/notice-pkg", "notice", true, nil},
+		{"warning pkg, default warning", "app-misc/warning-pkg", "warning", true},
+		{"warning pkg, --fail-severity=error", "app-misc/warning-pkg", "error", false},
+		{"notice pkg, default warning", "app-misc/notice-pkg", "warning", false},
+		{"notice pkg, --fail-severity=notice", "app-misc/notice-pkg", "notice", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out, err := captureStdout(t, func() error {
-				args := []string{"--format", "text"}
-				if tt.extraArgs != nil {
-					args = args[:0]
-					args = append(args, tt.extraArgs...)
-				}
-				args = append(args, "--fail-severity", tt.failSeverity, overlayPath, tt.pkgTarget)
+				args := []string{"--format", "text", "--fail-severity", tt.failSeverity, overlayPath, tt.pkgTarget}
 				return cfg.cmdLintPackage(args)
 			})
 
@@ -378,7 +375,7 @@ func TestCmdLintFailSeverityOutputFormats(t *testing.T) {
 	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
 
 	noticeEbuild := []byte(`
-# Copyright 1999-2026 Gentoo Authors
+# Copyright 2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -494,124 +491,4 @@ func (t *trackingFS) Open(name string) (fs.File, error) {
 func (t *trackingFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	t.Accessed[name] = true
 	return fs.ReadDir(t.FS, name)
-}
-
-func TestCmdLintTargetedSyntaxes(t *testing.T) {
-	cfg := &MainArgConfig{}
-	overlayPath := "../../testdata/test_overlay"
-
-	// 1. New package syntax
-	outNew, errNew := captureStdout(t, func() error {
-		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/foo"})
-	})
-	if errNew == nil {
-		t.Errorf("expected new syntax to fail due to foo errors, but it passed")
-	}
-
-	// 2. Legacy package syntax
-	outLegacy, errLegacy := captureStdout(t, func() error {
-		return cfg.runOldLint([]string{"--format", "json", overlayPath, "app-misc/foo"})
-	})
-	if errLegacy == nil {
-		t.Errorf("expected legacy syntax to fail due to foo errors, but it passed")
-	}
-
-	// 3. Exact Category Target syntax
-	outCategory, errCat := captureStdout(t, func() error {
-		return cfg.runOldLint([]string{"--format", "json", overlayPath, "app-misc"})
-	})
-	if errCat == nil {
-		t.Errorf("expected category syntax to fail due to foo errors, but it passed")
-	}
-
-	// Check that none of these reached bad_category
-	for _, out := range []string{outNew, outLegacy, outCategory} {
-		if strings.Contains(out, "bad_category") {
-			t.Errorf("targeted lint incorrectly leaked into unrelated 'bad_category'. Output snippet: %s", out[:min(len(out), 200)])
-		}
-	}
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func TestCmdLintEffectiveSeverityOverride(t *testing.T) {
-	cfg := &MainArgConfig{}
-	overlayPath := t.TempDir()
-
-	_ = os.MkdirAll(overlayPath+"/app-misc/warning-pkg", 0755)
-	_ = os.MkdirAll(overlayPath+"/profiles", 0755)
-	_ = os.MkdirAll(overlayPath+"/metadata", 0755)
-	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
-
-	// Provide a qa-policy.conf overriding PG0002 from Warning to Notice
-	qaPolicy := []byte(`
-[policy]
-PG0002 = notice
-`)
-	_ = os.WriteFile(overlayPath+"/metadata/qa-policy.conf", qaPolicy, 0644)
-
-	// Trigger PG0002: =-dependency with no revision
-	warningEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
-# Distributed under the terms of the GNU General Public License v2
-
-EAPI=8
-DESCRIPTION="A proper description"
-HOMEPAGE="https://example.com"
-LICENSE="MIT"
-SLOT="0"
-KEYWORDS="amd64"
-DEPEND="=app-misc/some-dep-1.0"
-`)
-	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
-	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
-	metadataContent := []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
-<pkgmetadata>
-	<maintainer type="person">
-		<email>test@example.com</email>
-	</maintainer>
-</pkgmetadata>`)
-	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
-
-	// Since we overrode PG0002 to Notice, it should NOT fail default (Warning) threshold
-	out, err := captureStdout(t, func() error {
-		return cfg.cmdLintPackage([]string{"--format", "text", overlayPath, "app-misc/warning-pkg"})
-	})
-
-	if err != nil {
-		t.Errorf("expected to PASS because effective severity of PG0002 is Notice. err: %v\nOut: %s", err, out)
-	}
-
-	// But it should fail if fail-severity is Notice
-	out, err = captureStdout(t, func() error {
-		return cfg.cmdLintPackage([]string{"--format", "text", "--fail-severity", "notice", overlayPath, "app-misc/warning-pkg"})
-	})
-	if err == nil {
-		t.Errorf("expected to FAIL when fail-severity is Notice. Out: %s", out)
-	}
-}
-
-func TestCmdLintInvalidFailSeverity(t *testing.T) {
-	cfg := &MainArgConfig{}
-
-	// Newer path
-	_, err := captureStdout(t, func() error {
-		return cfg.cmdLintPackage([]string{"--fail-severity", "invalid_sev", ".", "app-misc/foo"})
-	})
-	if err == nil || !strings.Contains(err.Error(), "invalid fail-severity") {
-		t.Errorf("expected invalid fail-severity error from package cmd, got: %v", err)
-	}
-
-	// Legacy path
-	_, err = captureStdout(t, func() error {
-		return cfg.runOldLint([]string{"--fail-severity", "invalid_sev", ".", "app-misc/foo"})
-	})
-	if err == nil || !strings.Contains(err.Error(), "invalid fail-severity") {
-		t.Errorf("expected invalid fail-severity error from legacy cmd, got: %v", err)
-	}
 }

--- a/cmd/g2/lint_test.go
+++ b/cmd/g2/lint_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/arran4/g2/lints"
 )
 
 func TestParseLintQuery(t *testing.T) {
@@ -178,43 +180,59 @@ func TestCmdLintList(t *testing.T) {
 }
 
 func TestSeverityThresholdLogic(t *testing.T) {
-	// Synthetically verify the core loop logic using the identical evaluation helper
-	// used in runLintCore: severityLevel(result) >= failLvl -> hasErrors = true
+	makeResult := func(sev lints.Severity) lints.LintResult {
+		return lints.LintResult{
+			RuleMetadata: lints.RuleMetadata{
+				Severity: sev,
+			},
+		}
+	}
 
 	testCases := []struct {
-		desc        string
-		resultSev   string
-		failSev     string
-		expectError bool
+		desc       string
+		results    []lints.LintResult
+		failSev    string
+		expectFail bool
 	}{
-		{"info-only + default warning -> pass", "Info", "warning", false},
-		{"info-only + fail-severity=info -> fail", "Info", "info", true},
-		{"error-only + default warning -> fail", "Error", "warning", true},
-		{"error-only + fail-severity=error -> fail", "Error", "error", true},
-		{"mixed notice + error -> fail at warning", "Notice", "warning", false},
+		{
+			desc:       "Info only + warning threshold => pass",
+			results:    []lints.LintResult{makeResult(lints.SeverityInfo)},
+			failSev:    "warning",
+			expectFail: false,
+		},
+		{
+			desc:       "Info only + info threshold => fail",
+			results:    []lints.LintResult{makeResult(lints.SeverityInfo)},
+			failSev:    "info",
+			expectFail: true,
+		},
+		{
+			desc:       "Error only + warning threshold => fail",
+			results:    []lints.LintResult{makeResult(lints.SeverityError)},
+			failSev:    "warning",
+			expectFail: true,
+		},
+		{
+			desc:       "Error only + error threshold => fail",
+			results:    []lints.LintResult{makeResult(lints.SeverityError)},
+			failSev:    "error",
+			expectFail: true,
+		},
+		{
+			desc:       "Notice + Error + warning threshold => fail",
+			results:    []lints.LintResult{makeResult(lints.SeverityNotice), makeResult(lints.SeverityError)},
+			failSev:    "warning",
+			expectFail: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			failLvl := severityLevel(tc.failSev)
-			resultLvl := severityLevel(tc.resultSev)
-			hasErrors := resultLvl >= failLvl
-			if hasErrors != tc.expectError {
-				t.Errorf("expected error %v, got %v for result %s against threshold %s", tc.expectError, hasErrors, tc.resultSev, tc.failSev)
+			got := hasFailingLintResults(tc.results, tc.failSev)
+			if got != tc.expectFail {
+				t.Errorf("hasFailingLintResults() = %v, want %v for %s", got, tc.expectFail, tc.desc)
 			}
 		})
-	}
-
-	// Mixed Notice + Error
-	failLvl := severityLevel("warning")
-	hasErrors := false
-	for _, res := range []string{"Notice", "Error"} {
-		if severityLevel(res) >= failLvl {
-			hasErrors = true
-		}
-	}
-	if !hasErrors {
-		t.Errorf("expected mixed Notice+Error to fail at default warning")
 	}
 }
 func TestSeverityLevel(t *testing.T) {
@@ -296,30 +314,7 @@ KEYWORDS="~amd64"
 	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
 	_ = os.WriteFile(overlayPath+"/app-misc/notice-pkg/metadata.xml", metadataContent, 0644)
 
-	if err := os.MkdirAll(overlayPath+"/app-misc/info-pkg", 0755); err != nil {
-		t.Fatalf("failed to create info pkg dir: %v", err)
-	}
-	infoEbuild := []byte(`# Copyright 1999-2026 Gentoo Authors
-# Distributed under the terms of the GNU General Public License v2
-
-EAPI=8
-DESCRIPTION="A sufficiently descriptive test package"
-HOMEPAGE="https://example.com"
-LICENSE="MIT"
-SLOT="0"
-KEYWORDS="amd64"
-
-pkg_postinst() {
-	if [[ -e /usr ]]; then
-		einfo "Wait"
-	fi
-}
-`)
-	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/info-pkg-1.0.ebuild", infoEbuild, 0644)
-	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/Manifest", []byte(""), 0644)
-	_ = os.WriteFile(overlayPath+"/app-misc/info-pkg/metadata.xml", metadataContent, 0644)
-
-	// Error only package (no maintainer)
+	// Error only package (no metadata.xml)
 	if err := os.MkdirAll(overlayPath+"/app-misc/error-pkg", 0755); err != nil {
 		t.Fatalf("failed to create error pkg dir: %v", err)
 	}
@@ -374,6 +369,46 @@ KEYWORDS="~amd64"
 		t.Fatalf("Fixture setup failed: notice-pkg does not contain a Notice!\nOutput: %s", outNotice)
 	}
 
+	outError, _ := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/error-pkg"})
+	})
+	var errorResults []lints.LintResult
+	if err := json.Unmarshal([]byte(outError), &errorResults); err != nil {
+		t.Fatalf("Fixture setup failed: error-pkg json unmarshal error: %v\nOutput: %s", err, outError)
+	}
+	if len(errorResults) == 0 {
+		t.Fatalf("Fixture setup failed: error-pkg produced no findings!\nOutput: %s", outError)
+	}
+	for _, res := range errorResults {
+		if res.RuleMetadata.Severity != lints.SeverityError {
+			t.Fatalf("Fixture setup failed: error-pkg contains non-Error finding: %+v", res)
+		}
+	}
+
+	outMixed, _ := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/mixed-pkg"})
+	})
+	var mixedResults []lints.LintResult
+	if err := json.Unmarshal([]byte(outMixed), &mixedResults); err != nil {
+		t.Fatalf("Fixture setup failed: mixed-pkg json unmarshal error: %v\nOutput: %s", err, outMixed)
+	}
+	hasNotice := false
+	hasError := false
+	for _, res := range mixedResults {
+		if res.RuleMetadata.Severity == lints.SeverityNotice {
+			hasNotice = true
+		}
+		if res.RuleMetadata.Severity == lints.SeverityError {
+			hasError = true
+		}
+		if res.RuleMetadata.Severity == lints.SeverityWarning {
+			t.Fatalf("Fixture setup failed: mixed-pkg contains Warning finding: %+v", res)
+		}
+	}
+	if !hasNotice || !hasError {
+		t.Fatalf("Fixture setup failed: mixed-pkg must contain both Notice and Error findings (hasNotice=%v, hasError=%v)\nOutput: %s", hasNotice, hasError, outMixed)
+	}
+
 	tests := []struct {
 		name         string
 		pkgTarget    string
@@ -384,6 +419,9 @@ KEYWORDS="~amd64"
 		{"warning pkg, --fail-severity=error", "app-misc/warning-pkg", "error", false},
 		{"notice pkg, default warning", "app-misc/notice-pkg", "warning", false},
 		{"notice pkg, --fail-severity=notice", "app-misc/notice-pkg", "notice", true},
+		{"error-only + default warning => fail", "app-misc/error-pkg", "warning", true},
+		{"error-only + --fail-severity=error => fail", "app-misc/error-pkg", "error", true},
+		{"mixed Notice + Error + default warning => fail", "app-misc/mixed-pkg", "warning", true},
 	}
 
 	for _, tt := range tests {
@@ -400,6 +438,24 @@ KEYWORDS="~amd64"
 			}
 		})
 	}
+
+	// Verify legacy runOldLint honors --fail-severity as well
+	t.Run("legacy notice pkg, default warning -> pass", func(t *testing.T) {
+		out, err := captureStdout(t, func() error {
+			return cfg.runOldLint([]string{"--format", "text", "--fail-severity", "warning", overlayPath, "app-misc/notice-pkg"})
+		})
+		if err != nil {
+			t.Errorf("expected legacy lint to pass on notice-pkg with default warning, got: %v (output: %s)", err, out)
+		}
+	})
+	t.Run("legacy notice pkg, --fail-severity=notice -> fail", func(t *testing.T) {
+		out, err := captureStdout(t, func() error {
+			return cfg.runOldLint([]string{"--format", "text", "--fail-severity", "notice", overlayPath, "app-misc/notice-pkg"})
+		})
+		if err == nil {
+			t.Errorf("expected legacy lint to fail on notice-pkg with --fail-severity=notice, got output: %s", out)
+		}
+	})
 }
 func TestCmdLintFailSeverityOutputFormats(t *testing.T) {
 	cfg := &MainArgConfig{}
@@ -488,6 +544,111 @@ KEYWORDS="amd64"
 	}
 }
 
+func TestCmdLintSuppression(t *testing.T) {
+	cfg := &MainArgConfig{}
+	overlayPath := t.TempDir()
+
+	if err := os.MkdirAll(overlayPath+"/app-misc/warning-pkg", 0755); err != nil {
+		t.Fatalf("failed to create warning pkg dir: %v", err)
+	}
+	if err := os.MkdirAll(overlayPath+"/profiles", 0755); err != nil {
+		t.Fatalf("failed to create profiles dir: %v", err)
+	}
+	_ = os.WriteFile(overlayPath+"/profiles/repo_name", []byte("dummy-repo\n"), 0644)
+
+	warningEbuild := []byte(`
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+DESCRIPTION="short"
+HOMEPAGE="https://example.com"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="amd64"
+`)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/warning-pkg-1.0.ebuild", warningEbuild, 0644)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/Manifest", []byte(""), 0644)
+
+	metadataContent := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>test@example.com</email>
+	</maintainer>
+</pkgmetadata>`)
+	_ = os.WriteFile(overlayPath+"/app-misc/warning-pkg/metadata.xml", metadataContent, 0644)
+
+	// Verify unsuppressed baseline fails under default warning threshold and contains MissingDescription
+	outBaseline, errBaseline := captureStdout(t, func() error {
+		return cfg.cmdLintPackage([]string{"--format", "json", overlayPath, "app-misc/warning-pkg"})
+	})
+	if errBaseline == nil {
+		t.Fatalf("expected unsuppressed warning fixture to fail, but got success. Output: %s", outBaseline)
+	}
+	var baselineResults []lints.LintResult
+	if err := json.Unmarshal([]byte(outBaseline), &baselineResults); err != nil {
+		t.Fatalf("failed to parse baseline JSON: %v", err)
+	}
+	foundMissingDesc := false
+	for _, res := range baselineResults {
+		if strings.EqualFold(string(res.RuleMetadata.ID), "MissingDescription") {
+			foundMissingDesc = true
+		}
+	}
+	if !foundMissingDesc {
+		t.Fatalf("expected baseline results to contain MissingDescription finding: %s", outBaseline)
+	}
+
+	// 1. --disable-rule MissingDescription suppresses the finding and succeeds
+	t.Run("disable-rule MissingDescription", func(t *testing.T) {
+		out, err := captureStdout(t, func() error {
+			return cfg.cmdLintPackage([]string{
+				"--format", "json",
+				"--disable-rule", "MissingDescription",
+				overlayPath, "app-misc/warning-pkg",
+			})
+		})
+		if err != nil {
+			t.Errorf("expected command to succeed with --disable-rule MissingDescription, got err: %v\nOutput: %s", err, out)
+		}
+		var results []lints.LintResult
+		if err := json.Unmarshal([]byte(out), &results); err != nil {
+			t.Fatalf("failed to unmarshal JSON: %v\nOutput: %s", err, out)
+		}
+		for _, res := range results {
+			if strings.EqualFold(string(res.RuleMetadata.ID), "MissingDescription") ||
+				strings.Contains(res.Message, "DESCRIPTION is suspiciously short") {
+				t.Errorf("expected MissingDescription finding to be absent, but found: %+v", res)
+			}
+		}
+	})
+
+	// 2. --ignore-tag site-quality suppresses the finding and succeeds
+	t.Run("ignore-tag site-quality", func(t *testing.T) {
+		out, err := captureStdout(t, func() error {
+			return cfg.cmdLintPackage([]string{
+				"--format", "json",
+				"--ignore-tag", "site-quality",
+				overlayPath, "app-misc/warning-pkg",
+			})
+		})
+		if err != nil {
+			t.Errorf("expected command to succeed with --ignore-tag site-quality, got err: %v\nOutput: %s", err, out)
+		}
+		var results []lints.LintResult
+		if err := json.Unmarshal([]byte(out), &results); err != nil {
+			t.Fatalf("failed to unmarshal JSON: %v\nOutput: %s", err, out)
+		}
+		for _, res := range results {
+			if strings.EqualFold(string(res.RuleMetadata.ID), "MissingDescription") ||
+				strings.Contains(res.Message, "DESCRIPTION is suspiciously short") {
+				t.Errorf("expected MissingDescription finding to be absent, but found: %+v", res)
+			}
+		}
+	})
+}
+
 func TestCmdLintTargetedAccessLimit(t *testing.T) {
 	// A package with a noticeable problem (no maintainer -> Error, missing vars -> Warning, etc)
 	overlayPath := "../../testdata/test_overlay"
@@ -569,13 +730,6 @@ func TestCmdLintTargetedSyntaxes(t *testing.T) {
 	}
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func TestCmdLintEffectiveSeverityOverride(t *testing.T) {
 	cfg := &MainArgConfig{}
 	overlayPath := t.TempDir()
@@ -621,18 +775,46 @@ DEPEND="=app-misc/some-dep-1.0"
 	})
 
 	if err != nil {
-		t.Errorf("expected to PASS because effective severity of PG0002 is Notice. err: %v\nOut: %s", err, out)
+		t.Fatalf("expected to PASS because effective severity of PG0002 is Notice. err: %v\nOut: %s", err, out)
 	}
-	if !strings.Contains(out, `"severity": "Notice"`) {
-		t.Errorf("expected JSON to contain Notice for PG0002, got: %s", out)
+
+	// Parse JSON structurally
+	var results []lints.LintResult
+	if err := json.Unmarshal([]byte(out), &results); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v\nOutput was:\n%s", err, out)
+	}
+
+	// Locate the actual PG0002 / dependency-no-revision result
+	var pg0002Result *lints.LintResult
+	for i := range results {
+		if strings.EqualFold(string(results[i].RuleMetadata.ID), "DependencyNoRevision") ||
+			strings.Contains(results[i].Message, "PG0002") {
+			pg0002Result = &results[i]
+			break
+		}
+	}
+	if pg0002Result == nil {
+		t.Fatalf("expected to find PG0002 / DependencyNoRevision finding in JSON output: %s", out)
+	}
+
+	// Assert that specific result has effective severity Notice
+	if pg0002Result.RuleMetadata.Severity != lints.SeverityNotice {
+		t.Errorf("expected PG0002 effective severity to be Notice, got: %s", pg0002Result.RuleMetadata.Severity)
+	}
+
+	// Ensure no unrelated Warning or Error is present
+	for _, res := range results {
+		if res.RuleMetadata.Severity == lints.SeverityWarning || res.RuleMetadata.Severity == lints.SeverityError {
+			t.Errorf("unexpected finding with severity %s: %s (id: %s)", res.RuleMetadata.Severity, res.Message, res.RuleMetadata.ID)
+		}
 	}
 
 	// But it should fail if fail-severity is Notice
-	out, err = captureStdout(t, func() error {
+	outNotice, errNotice := captureStdout(t, func() error {
 		return cfg.cmdLintPackage([]string{"--format", "text", "--fail-severity", "notice", overlayPath, "app-misc/warning-pkg"})
 	})
-	if err == nil {
-		t.Errorf("expected to FAIL when fail-severity is Notice. Out: %s", out)
+	if errNotice == nil {
+		t.Errorf("expected to FAIL when fail-severity is Notice. Out: %s", outNotice)
 	}
 }
 

--- a/cmd/g2/parse_repo.go
+++ b/cmd/g2/parse_repo.go
@@ -232,7 +232,7 @@ func isCategoryAllowed(repoCats map[string]bool, hasGentooMaster bool, mainCats 
 }
 
 // parseRepoCategoriesAndPackages recursively crawls and parses the repo's categories, packages, and their ebuilds.
-func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string, fastGit bool, remoteURL string, site *g2.SiteData) error {
+func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string, fastGit bool, remoteURL string, site *g2.SiteData, targetMap TargetPackages) error {
 	supportedCategories := make(map[string]bool)
 	if categoriesBytes, err := fs.ReadFile(sysFS, filepath.ToSlash(filepath.Join(repoDir, "profiles", "categories"))); err == nil {
 		for _, line := range strings.Split(string(categoriesBytes), "\n") {
@@ -309,6 +309,28 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 			continue
 		}
 
+		if len(targetMap) > 0 {
+			categoryAllowed := false
+			if targetMap[name] {
+				categoryAllowed = true
+			} else {
+				for tp := range targetMap {
+					parts := strings.Split(tp, "/")
+					if len(parts) == 2 && parts[0] == name {
+						categoryAllowed = true
+						break
+					} else if len(parts) == 1 {
+						// It's a bare package name, we must search all categories
+						categoryAllowed = true
+						break
+					}
+				}
+			}
+			if !categoryAllowed {
+				continue
+			}
+		}
+
 		catData := g2.CategoryData{Name: name}
 		catPath := filepath.Join(repoDir, name)
 
@@ -336,6 +358,13 @@ func parseRepoCategoriesAndPackages(sysFS fs.FS, repoDir string, repoName string
 			}
 
 			pkgStr := name + "/" + pkgName
+
+			if len(targetMap) > 0 {
+				qualified := pkgStr
+				if !targetMap[qualified] && !targetMap[pkgName] && !targetMap[name] {
+					continue
+				}
+			}
 
 			files, err := fs.ReadDir(sysFS, filepath.ToSlash(pkgPath))
 			if err != nil {

--- a/cmd/g2/site.go
+++ b/cmd/g2/site.go
@@ -556,15 +556,21 @@ func sanitizeFilename(s string) string {
 	return res
 }
 
+type TargetPackages map[string]bool
+
 func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, repoInfo *g2.Repository, opts ...any) (*g2.SiteData, error) {
 	title := defaultTitle
 	var repoName string
 	var remoteURL string
 
+	var targetPkgs TargetPackages
+
 	for _, opt := range opts {
 		switch o := opt.(type) {
 		case SourceURL:
 			remoteURL = string(o)
+		case TargetPackages:
+			targetPkgs = o
 		}
 	}
 
@@ -664,7 +670,7 @@ func parseRepo(sysFS fs.FS, repoDir string, defaultTitle string, fastGit bool, r
 		_ = pf.Close()
 	}
 
-	if err := parseRepoCategoriesAndPackages(sysFS, repoDir, repoName, fastGit, remoteURL, site); err != nil {
+	if err := parseRepoCategoriesAndPackages(sysFS, repoDir, repoName, fastGit, remoteURL, site, targetPkgs); err != nil {
 		return nil, err
 	}
 

--- a/doc/g2.1.md
+++ b/doc/g2.1.md
@@ -138,6 +138,8 @@ Flags:
   Output format: `text`, `json`, or `github-actions`.
 - **-severity** *<severity>*
   Only show warnings of this severity (`error`, `warning`, `notice`, `info`).
+- **-fail-severity** *<severity>*
+  Fail on this severity and worse (`error`, `warning`, `notice`, `info`). Defaults to `warning`.
 - **-only-source** *<source>*
   Only show warnings from this source (`g2`, `pkgcheck`).
 - **-only-tag** *<tag>*

--- a/readme.md
+++ b/readme.md
@@ -286,6 +286,7 @@ g2 lint [flags] [<location>] [<target_package>...]
 * `-upstream-repo-path <path>`: Path to upstream repository on disk for layout linting (overrides GitHub API).
 * `-format <string>`: Output format: `text`, `json`, or `github-actions` (default `text`).
 * `-severity <string>`: Only show warnings of this severity (`error`, `warning`, `notice`, `info`).
+* `-fail-severity <string>`: Fail on this severity and worse (`error`, `warning`, `notice`, `info`, default `warning`).
 * `-only-source <string>`: Only show warnings from this source (`g2`, `pkgcheck`).
 * `-only-tag <string>`: Only show warnings with this tag.
 * `-disable-rule <string>`: Comma-separated list of rule IDs to ignore (case-insensitive).
@@ -535,6 +536,7 @@ Gentoo version ordering is natively supported for range queries like `version:>1
 
 *   `-format <string>`: Output format: `text` or `json` (default `text`).
 *   `-severity <string>`: Only show warnings of this severity (`Error`, `Warning`, `Notice`, `Info`).
+*   `-fail-severity <string>`: Fail on this severity and worse (`Error`, `Warning`, `Notice`, `Info`, default `Warning`).
 *   `-only-source <string>`: Only show warnings from this source (`g2`, `pkgcheck`).
 *   `-only-tag <string>`: Only show warnings with this tag (e.g., `site-quality`, `metadata.xml`).
 


### PR DESCRIPTION
# Fix 530 and Fix 529

This pull request resolves two major issues affecting CI review loops for targeted linting:
1. `g2 lint` incorrectly failing due to `Notice` or `Info` severities.
2. `g2 lint package` parsing the entirety of an overlay before deciding to throw out irrelevant warnings.

### Exit Status Semantics
- Introduced `--fail-severity` flag that controls at what threshold the command returns a non-zero exit code.
- Default remains `warning`.
- Fully decouples the `hasErrors` exit condition from output formatting (e.g., `github-actions` can now emit Notices while returning 0).

### Targeted Parsing Optimization
- Added a `TargetPackages` type (`map[string]bool`) passed through `parseRepo` `opts ...any`.
- Used this filter inside `parseRepoCategoriesAndPackages` to prune `ReadDir` tree traversals over irrelevant categories or packages.

### Testing Strategy
- Expanded `TestCmdLintFailSeverity` to test threshold handling of mock packages simulating specific `Warning` (`MissingDescription`) and `Notice` (`UnstableOnly`) results.
- Added `trackingFS` inside `TestCmdLintTargetedAccessLimit` that traps directory access to rigidly verify the targeted crawler is completely skipping unrequested tree traversal.

---
*PR created automatically by Jules for task [417851376813367223](https://jules.google.com/task/417851376813367223) started by @arran4*

Fixes #530
Fixes #529